### PR TITLE
Add a note about IPv6 Galera and wsrep_allowlist

### DIFF
--- a/galera-cluster/reference/galera-cluster-system-variables.md
+++ b/galera-cluster/reference/galera-cluster-system-variables.md
@@ -8,7 +8,9 @@ Also see the [Full list of MariaDB options, system and status variables](https:/
 
 #### `wsrep_allowlist`
 
-* Description: Allowed IP addresses, comma delimited.
+* Description:
+    * Allowed IP addresses, comma delimited.
+    * Note that setting `gmcast.listen_addr=tcp://[::]:4567` on a dual-stack system (eg. Linux with `net.ipv6.bindv6only = 0`), IPv4 addresses need to allowlisted using the IPv4-mapped IPv6 address (eg. `::ffff:1.2.3.4`).
 * Commandline: `--wsrep-allowlist=value1[,value2...]`
 * Scope: Global
 * Dynamic: No


### PR DESCRIPTION
The intersection of listening on IPv6 and wsrep_allowlist isn't immediately expected.

A person can confidently deploy wsrep_allowlist, then when a node next restarts it fails to reconnect as expected.

Suggestions welcome.