### PR TITLE
Add a symlink to spider-system-variables.md

### DIFF
--- a/server/server-usage/storage-engines/spider/spider-server-system-variables.md
+++ b/server/server-usage/storage-engines/spider/spider-server-system-variables.md
@@ -1,0 +1,1 @@
+./spider-system-variables.md


### PR DESCRIPTION
This patch attempts to fix
https://mariadb.com/kb/en/spider-server-system-variables/ returning 404.

In old kb spider-server-system-variables redirected to spider-system-variables (no "-server"). To verify this, note that the following wayback machine link

http://web.archive.org/web/20240208141155/https://mariadb.com/kb/en/spider-server-system-variables/

says:

Loading...

https://mariadb.com/kb/en/spider-server-system-variables/ |
	    14:11:55 February 08, 2024

Got an HTTP 301 response at crawl time

Redirecting to...

/kb/en/spider-system-variables/