### PR TITLE
Update mariadb-maxscale-installation-guide.md

### DIFF
--- a/maxscale/maxscale-quickstart-guides/mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-quickstart-guides/mariadb-maxscale-installation-guide.md
@@ -102,7 +102,6 @@ GRANT
   ON *.* 
   TO `maxscale_monitor`@`%`
 GRANT SELECT ON mysql.global_priv TO 'maxscale_monitor'@'%';
-GRANT SELECT ON mysql.global_priv TO 'maxscale_monitor'@'%';
 ```
 
 #### **Define a Service (e.g., Read-Write Split):**


### PR DESCRIPTION
removing duplicate line :
GRANT SELECT ON mysql.global_priv TO 'maxscale_monitor'@'%';