### PR TITLE
Fix maxctrl reload tls desciption

### DIFF
--- a/maxscale/reference/maxscale-maxctrl.md
+++ b/maxscale/reference/maxscale-maxctrl.md
@@ -2794,7 +2794,7 @@ Options:
 #### reload tls
 
 ```
-Usage: reload service <service>
+Usage: reload tls <service>
 
 Global Options:
   -c, --config     MaxCtrl configuration file  [string] [default: "~/.maxctrl.cnf"]


### PR DESCRIPTION
This was filed as MXS-4930 but the documentation for it didn't seem to be udpated.