### PR TITLE
Update description of VEC_Distance_Cosine function

### DIFF
--- a/server/reference/sql-structure/vectors/vector-functions/vec_distance_cosine.md
+++ b/server/reference/sql-structure/vectors/vector-functions/vec_distance_cosine.md
@@ -12,7 +12,7 @@ VEC_DISTANCE_COSINE(v, s)
 
 ## Description
 
-`VEC_Distance_Cosine` is an SQL function that calculates a [Cosine distance](https://en.wikipedia.org/wiki/Cosine_similarity#Cosine_distance) between two vectors.
+`VEC_Distance_Cosine` is an SQL function that calculates the [Cosine distance](https://en.wikipedia.org/wiki/Cosine_similarity#Cosine_distance) between two (not necessarily normalized) vectors.
 
 Vectors must be of the same length. A distance between two vectors of different lengths is not defined, and `VEC_Distance_Cosine` will return `NULL` in such cases.
 


### PR DESCRIPTION
The reference to the Cosine distance section in the Cosine similarity Wikipedia article is misleading since this section only provides the formular for *normalized* vectors. However, VEC_Distance_Cosine computes the Cosine distance of any two vectors (see https://github.com/MariaDB/server/blob/main/sql/item_vectorfunc.cc for details). Hence, the reference should either be removed or clarified.