### PR TITLE
Improve wording for PERCENTILE_CONT

### DIFF
--- a/server/reference/sql-functions/special-functions/window-functions/percentile_cont.md
+++ b/server/reference/sql-functions/special-functions/window-functions/percentile_cont.md
@@ -10,8 +10,8 @@ Essentially, the following process is followed to find the value to return:
 
 * Get the number of rows in the partition, denoted by N
 * RN = p\*(N-1), where p denotes the argument to the PERCENTILE\_CONT function
-* calculate the FRN(floor row number) and CRN(column row number for the group( FRN= floor(RN) and CRN = ceil(RN))
-* look up rows FRN and CRN
+* Calculate FRN as FRN=floor(RN) and CRN as CRN=ceil(RN)
+* Look up rows FRN and CRN
 * If (CRN = FRN = RN) then the result is (value of expression from row at RN)
 * Otherwise the result is
 * (CRN - RN) \* (value of expression for row at FRN) +


### PR DESCRIPTION
The current wording has grammatical issues (capitalization, mismatched parentheses), incorrectly calls CRN "column row number" when it seems clearly intended as "ceiling row number", and is generally a bit unnecessarily complex. This commit makes fairly small changes to clean up the wording. Potentially, the last three bullet points could also be combined into one or two, as splitting up an equation over multiple bullet points is a bit confusing, but I left it as-is.