### PR TITLE
Client/Server Protocol link correction

### DIFF
--- a/server/clients-and-utilities/server-client-software/client-libraries/clientserver-protocol/README.md
+++ b/server/clients-and-utilities/server-client-software/client-libraries/clientserver-protocol/README.md
@@ -2,6 +2,6 @@
 
 Find detailed descriptions in the Reference section:
 
-{% content-ref url="./" %}
-[.](./)
+{% content-ref url="../../../reference/clientserver-protocol" %}
+[clientserver-protocol](../../../reference/clientserver-protocol)
 {% endcontent-ref %}


### PR DESCRIPTION
Client/Server Protocol can be found at 2 places : 
https://mariadb.com/docs/server/reference/clientserver-protocol (good)
and https://mariadb.com/docs/server/clients-and-utilities/server-client-software/client-libraries/clientserver-protocol

The second link is wrong, i'm not completly sure of this correction, to be tested, but at least it won't be worse than current wrong link to nothing
