### PR TITLE
Fix SQL example in query-cache.md

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache.md
+++ b/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache.md
@@ -50,7 +50,7 @@ SELECT * FROM t
 Is different from :
 
 ```sql
-SELECT * FROM t
+SELECT * from t
 ```
 
 Comments are also considered and can make the queries differ, so :


### PR DESCRIPTION
Correct SQL syntax in query cache documentation.
Partially revert 886cf7c, because lower-case was the point here.