### PR TITLE
Fix formatting in about-mariadb-connector-j.md

### DIFF
--- a/connectors/mariadb-connector-j/about-mariadb-connector-j.md
+++ b/connectors/mariadb-connector-j/about-mariadb-connector-j.md
@@ -110,7 +110,7 @@ final HikariDataSource ds = new HikariDataSource();
         ds.setAutoCommit(false);
 ```
 
-Please note that the driver class provided by MariaDB Connector/J \*\*is not `com.mysql.jdbc.Driver` but \`org.mariadb.jdbc.Driver!
+Please note that the driver class provided by MariaDB Connector/J **is not `com.mysql.jdbc.Driver` but `org.mariadb.jdbc.Driver`**!
 
 The `org.mariadb.jdbc.MariaDbDataSource` class can be used when the pool datasource configuration only permits the java.sql.Datasource implementation.
 


### PR DESCRIPTION
I noticed a missing closing ` character in the docs.
As far as I can see, the formatting was lost in https://github.com/mariadb-corporation/mariadb-docs/commit/e1bb0e54944d236cfab6251926f0e48ee1f90576