### PR TITLE
Auto-update: API Documentation from mariadb-corporation/mariadb-connector-python

### DIFF
--- a/connectors/mariadb-connector-python/README.md
+++ b/connectors/mariadb-connector-python/README.md
@@ -1,16 +1,23 @@
----
-icon: link
----
+# MariaDB Connector/Python
 
-# Connector/Python
+<!-- import mariadb
+conn_params= {
+   "host" : "localhost",
+   "database" : "test"
+}
+with mariadb.connect(**conn_params) as conn:
+   with conn.cursor() as cursor:
+      cursor.execute("CREATE USER IF NOT EXISTS example_user@localhost identified by 'GHbe_Su3B8'")
+      cursor.execute("grant all on test.* to example_user@localhost")
+      cursor.execute("DROP TABLE IF EXISTS book") -->
 
-## MariaDB Connector/Python
+MariaDB Connector/Python enables python programs to access MariaDB and MySQL databases, using an API
+which is compliant with the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)). It is written in C and Python and uses
+MariaDB Connector/C client library for client server communication.
 
-MariaDB Connector/Python enables python programs to access MariaDB and MySQL databases, using an API which is compliant with the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)). It is written in C and Python and uses MariaDB Connector/C client library for client server communication.
+### Contents
 
-#### Contents
-
-## Contents:
+# Contents:
 
 * [Installation](install.md)
   * [Prerequisites](install.md#prerequisites)

--- a/connectors/mariadb-connector-python/api.md
+++ b/connectors/mariadb-connector-python/api.md
@@ -1,8 +1,6 @@
 # API Reference
 
-## API Reference
-
-## Contents:
+# Contents:
 
 * [The MariaDB Connector/Python module](module.md)
   * [Constructors](module.md#constructors)
@@ -26,13 +24,11 @@
   * [CLIENT](constants.md#module-mariadb.constants.CLIENT)
   * [CURSOR](constants.md#module-mariadb.constants.CURSOR)
   * [ERR (Error)](constants.md#err-error)
-  * [FIELD\_FLAG](constants.md#module-mariadb.constants.FIELD_FLAG)
-  * [FIELD\_TYPE](constants.md#module-mariadb.constants.FIELD_TYPE)
+  * [FIELD_FLAG](constants.md#module-mariadb.constants.FIELD_FLAG)
+  * [FIELD_TYPE](constants.md#module-mariadb.constants.FIELD_TYPE)
   * [INDICATORS](constants.md#indicators)
   * [INFO](constants.md#info)
-  * [TPC\_STATE](constants.md#tpc-state)
+  * [TPC_STATE](constants.md#tpc-state)
   * [STATUS](constants.md#status)
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/bugs.md
+++ b/connectors/mariadb-connector-python/bugs.md
@@ -1,6 +1,7 @@
-# Bug Reports
+# Bug reports
 
-If you think that you have found a bug in MariaDB Software, please report it at [Jira issue tracker](https://jira.mariadb.org) and file it under Project CONPY (abbreviation for Connector/Python).
+If you think that you have found a bug in MariaDB Software, please report it at
+[Jira issue tracker](https://jira.mariadb.org) and file it under Project CONPY (abbreviation for Connector/Python).
 
 ## How to report a bug?
 
@@ -10,15 +11,20 @@ Always search the bug database first. Especially if you are using an older versi
 
 ### What?
 
-We need to know what you did, what happened and what you wanted to happen. A report stating that method xyz() hangs, will not allow us to provide you with an advice or fix, since we just don’t know what the method is doing. Beside versions, a good bug report contains a short script which reproduces the problem. Sometimes it is also necessary to provide the definition (and data) of used tables.
+We need to know what you did, what happened and what you wanted to happen. A report stating that method xyz() hangs, will not allow us to provide you with an advice or fix, since we just don’t know what the method is doing.
+Beside versions, a good bug report contains a short script which reproduces the problem. Sometimes it is also necessary to
+provide the definition (and data) of used tables.
 
 ### Versions of components
 
-MariaDB Connector/Python interacts with two other components: The database server and MariaDB Connector/C. The latter one is responsible for client/server communication. An error does not necessarily have to exist in Connector / Python; it can also be an error in the database server or in Connector/C. In this case, we will reclassify the bug (MDEV or CONC).
+MariaDB Connector/Python interacts with two other components: The database server and MariaDB Connector/C. The latter one is responsible for client/server communication.
+An error does not necessarily have to exist in Connector / Python; it can also be an error in the database server or in Connector/C.
+In this case, we will reclassify the bug (MDEV or CONC).
 
 ### Avoid screenshots!
 
-Use copy and paste instead. Screenshots create a lot more data volume and are often difficult to read on mobile devices. Typing program code from a screenshot is also an unnecessary effort.
+Use copy and paste instead. Screenshots create a lot more data volume and are often difficult to
+read on mobile devices. Typing program code from a screenshot is also an unnecessary effort.
 
 ### Keep it simple!
 
@@ -35,7 +41,5 @@ If you have encountered two or more bugs which are not related, please file an i
 If your application crashes, please also provide if possible a backtrace and output of the exception.
 
 ### Report bugs in English only!
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/connection.md
+++ b/connectors/mariadb-connector-python/connection.md
@@ -1,59 +1,74 @@
 # The connection class
 
-### _class_ Connection(\*args, \*\*kwargs)
+### *class* Connection(\*args, \*\*kwargs)
 
 MariaDB Connector/Python Connection Object
 
-Handles the connection to a MariaDB or MySQL database server. It encapsulates a database session.
+Handles the connection to a MariaDB or MySQL database server.
+It encapsulates a database session.
 
 Connections are created using the method mariadb.connect()
 
 ## Connection constructors
 
-#### Connection.xid(format\_id: int, global\_transaction\_id: str, branch\_qualifier: str)
+#### Connection.xid(format_id: int, global_transaction_id: str, branch_qualifier: str)
 
-Creates a transaction ID object suitable for passing to the .tpc\_\*() methods of this connection.
+Creates a transaction ID object suitable for passing to the .tpc_\*()
+methods of this connection.
 
 Parameters:
 
-* format\_id: Format id. Default to value 0.
-* global\_transaction\_id: Global transaction qualifier, which must be unique. The maximum length of the global transaction id is limited to 64 characters.
-* branch\_qualifier: Branch qualifier which represents a local transaction identifier. The maximum length of the branch qualifier is limited to 64 characters.
+- format_id: Format id. Default to value 0.
+- global_transaction_id: Global transaction qualifier, which must be
+  unique. The maximum length of the global transaction id is
+  limited to 64 characters.
+- branch_qualifier: Branch qualifier which represents a local
+  transaction identifier. The maximum length of the branch qualifier
+  is limited to 64 characters.
 
-_Since version 1.0.1._
+*Since version 1.0.1.*
 
 ## Connection methods
 
 #### Connection.begin()
 
-Start a new transaction which can be committed by .commit() method, or canceled by .rollback() method.
+Start a new transaction which can be committed by .commit() method,
+or canceled by .rollback() method.
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
 #### Connection.commit()
 
 Commit any pending transaction to the database.
 
-#### Connection.change\_user()
+#### Connection.change_user()
 
 Changes the user and default database of the current connection
 
-Parameters: : - user: user name
+Parameters:
+: - user: user name
+  - password: password
+  - database: name of default database
 
-* password: password
-* database: name of default database
-
-In order to successfully change users a valid username and password parameters must be provided and that user must have sufficient permissions to access the desired database. If for any reason authorization fails an exception will be raised and the current user authentication will remain.
+In order to successfully change users a valid username and password
+parameters must be provided and that user must have sufficient
+permissions to access the desired database. If for any reason
+authorization fails an exception will be raised and the current user
+authentication will remain.
 
 #### Connection.close()
 
 Close the connection now (rather than whenever ._\_del_\_() is called).
 
-The connection will be unusable from this point forward; an Error (or subclass) exception will be raised if any operation is attempted with the connection. The same applies to all cursor objects trying to use the connection.
+The connection will be unusable from this point forward; an Error
+(or subclass) exception will be raised if any operation is attempted
+with the connection. The same applies to all cursor objects trying to
+use the connection.
 
-Note that closing a connection without committing the changes first will cause an implicit rollback to be performed.
+Note that closing a connection without committing the changes first
+will cause an implicit rollback to be performed.
 
-#### Connection.cursor(cursorclass=\<class 'mariadb.cursors.Cursor'>, \*\*kwargs)
+#### Connection.cursor(cursorclass=<class 'mariadb.cursors.Cursor'>, \*\*kwargs)
 
 Returns a new cursor object for the current connection.
 
@@ -61,36 +76,41 @@ If no cursorclass was specified, a cursor with default mariadb.Cursor class will
 
 Optional keyword parameters:
 
-* **buffered** (default: `True`) - If disabled, the result will be unbuffered, which means before executing another statement with the same connection, the entire result set must be fetched. Please note that the default was False for MariaDB Connector/Python versions < 1.1.0.
-* **dictionary** (default: `False`) - Return fetch values as dictionary when enabled.
-* **named\_tuple** (default: `False`) - Return fetch values as named tuple. This feature exists for compatibility reasons and should be avoided due to possible inconsistency.
-* **cursor\_type** (default: `CURSOR.NONE`) - If cursor\_type is set to CURSOR.READ\_ONLY, a cursor is opened for the statement invoked with cursors execute() method.
-* **prepared** (default: `False`) - When enabled, the cursor will remain in prepared state after the first execute() method was called. Further calls to execute() method will ignore the SQL statement.
-* **binary** (default: `False`) - Always execute statement in MariaDB client/server binary protocol.
+- **buffered** (default: `True`) - If disabled, the result will be unbuffered, which means before executing another statement with the same connection, the entire result set must be fetched. Please note that the default was False for MariaDB Connector/Python versions < 1.1.0.
+- **dictionary** (default: `False`) - Return fetch values as dictionary when enabled.
+- **named_tuple** (default: `False`) - Return fetch values as named tuple. This feature exists for compatibility reasons and should be avoided due to possible inconsistency.
+- **cursor_type** (default: `CURSOR.NONE`) - If cursor_type is set to CURSOR.READ_ONLY, a cursor is opened for the statement invoked with cursors execute() method.
+- **prepared** (default: `False`) - When enabled, the cursor will remain in prepared state after the first execute() method was called. Further calls to execute() method will ignore the SQL statement.
+- **binary** (default: `False`) - Always execute statement in MariaDB client/server binary protocol.
 
 In versions prior to 1.1.0 results were unbuffered by default, which means before executing another statement with the same connection, the entire result set must be fetched.
 
-fetch\* methods of the cursor class by default return result set values as a tuple, unless dictionary or named\_tuple was specified. The latter one exists for compatibility reasons and should be avoided due to possible inconsistency in case two or more fields in a result set have the same name.
+fetch\* methods of the cursor class by default return result set values as a tuple, unless dictionary or named_tuple was specified. The latter one exists for compatibility reasons and should be avoided due to possible inconsistency in case two or more fields in a result set have the same name.
 
-If cursor\_type is set to CURSOR.READ\_ONLY, a cursor is opened for the statement invoked with cursors execute() method.
+If cursor_type is set to CURSOR.READ_ONLY, a cursor is opened for the statement invoked with cursors execute() method.
 
-#### Connection.dump\_debug\_info()
+#### Connection.dump_debug_info()
 
-This function is designed to be executed by an user with the SUPER privilege and is used to dump server status information into the log for the MariaDB Server relating to the connection.
+This function is designed to be executed by an user with the SUPER privilege
+and is used to dump server status information into the log for the MariaDB
+Server relating to the connection.
 
-_Since version 1.1.2._
+*Since version 1.1.2.*
 
-#### Connection.get\_server\_version()
+#### Connection.get_server_version()
 
-Returns a tuple representing the version of the connected server in the following format: (MAJOR\_VERSION, MINOR\_VERSION, PATCH\_VERSION)
+Returns a tuple representing the version of the connected server in
+the following format: (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
-#### Connection.escape\_string()
+#### Connection.escape_string()
 
-Parameters: statement: string
+Parameters:
+statement: string
 
-This function is used to create a legal SQL string that you can use in an SQL statement. The given string is encoded to an escaped SQL string.
+This function is used to create a legal SQL string that you can use in
+an SQL statement. The given string is encoded to an escaped SQL string.
 
-_Since version 1.0.5._
+*Since version 1.0.5.*
 
 ```python
 # connection parameters
@@ -113,119 +133,159 @@ This string contains the following special characters: \\,\"
 
 #### Connection.kill(id: int)
 
-This function is used to ask the server to kill a database connection specified by the processid parameter.
+This function is used to ask the server to kill a database connection
+specified by the processid parameter.
 
 The connection id can be retrieved by SHOW PROCESSLIST SQL command.
 
 #### NOTE
-
-A thread\_id from other connections can be determined by executing the SQL statement `SHOW PROCESSLIST`. The thread\_id of the current connection is stored in the `connection_id` attribute.
+A thread_id from other connections can be determined by executing the SQL statement `SHOW PROCESSLIST`.
+The thread_id of the current connection is stored in the `connection_id` attribute.
 
 #### Connection.ping()
 
 Checks if the connection to the database server is still available.
 
-If auto reconnect was set to true, an attempt will be made to reconnect to the database server in case the connection was lost
+If auto reconnect was set to true, an attempt will be made to reconnect
+to the database server in case the connection
+was lost
 
 If the connection is not available an InterfaceError will be raised.
 
 #### Connection.reconnect()
 
-tries to reconnect to a server in case the connection died due to timeout or other errors. It uses the same credentials which were specified in connect() method.
+tries to reconnect to a server in case the connection died due to timeout
+or other errors. It uses the same credentials which were specified in
+connect() method.
 
 #### Connection.reset()
 
-Resets the current connection and clears session state and pending results. Open cursors will become invalid and cannot be used anymore.
+Resets the current connection and clears session state and pending
+results. Open cursors will become invalid and cannot be used anymore.
 
 #### Connection.rollback()
 
-Causes the database to roll back to the start of any pending transaction
+Causes the database to roll back to the start of any pending
+transaction
 
-Closing a connection without committing the changes first will cause an implicit rollback to be performed. Note that rollback() will not work as expected if autocommit mode was set to True or the storage engine does not support transactions.”
+Closing a connection without committing the changes first will
+cause an implicit rollback to be performed.
+Note that rollback() will not work as expected if autocommit mode
+was set to True or the storage engine does not support transactions.”
 
-#### Connection.select\_db(new\_db: str)
+#### Connection.select_db(new_db: str)
 
 Gets the default database for the current connection.
 
-The default database can also be obtained or changed by database attribute.
+The default database can also be obtained or changed by database
+attribute.
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
-#### Connection.show\_warnings()
+#### Connection.show_warnings()
 
 Shows error, warning and note messages from last executed command.
 
-#### Connection.tpc\_begin(xid)
+#### Connection.tpc_begin(xid)
 
-Parameter: : xid: xid object which was created by .xid() method of connection : class
+Parameter:
+: xid: xid object which was created by .xid() method of connection
+  : class
 
 Begins a TPC transaction with the given transaction ID xid.
 
-This method should be called outside a transaction (i.e., nothing may have been executed since the last .commit() or .rollback()). Furthermore, it is an error to call .commit() or .rollback() within the TPC transaction. A ProgrammingError is raised if the application calls .commit() or .rollback() during an active TPC transaction.
+This method should be called outside a transaction
+(i.e., nothing may have been executed since the last .commit()
+or .rollback()).
+Furthermore, it is an error to call .commit() or .rollback() within
+the TPC transaction. A ProgrammingError is raised if the application
+calls .commit() or .rollback() during an active TPC transaction.
 
-#### Connection.tpc\_commit(xid=None)
+#### Connection.tpc_commit(xid=None)
 
 Optional parameter:
 
-* xid : xid object which was created by .xid() method of connection class.
+- xid
+  : xid object which was created by .xid() method of connection class.
 
-When called with no arguments, .tpc\_commit() commits a TPC transaction previously prepared with .tpc\_prepare().
+When called with no arguments, .tpc_commit() commits a TPC transaction
+previously prepared with .tpc_prepare().
 
-If .tpc\_commit() is called prior to .tpc\_prepare(), a single phase commit is performed. A transaction manager may choose to do this if only a single resource is participating in the global transaction. When called with a transaction ID xid, the database commits the given transaction. If an invalid transaction ID is provided, a ProgrammingError will be raised. This form should be called outside a transaction, and is intended for use in recovery.
+If .tpc_commit() is called prior to .tpc_prepare(), a single phase
+commit is performed. A transaction manager may choose to do this if
+only a single resource is participating in the global transaction.
+When called with a transaction ID xid, the database commits the given
+transaction. If an invalid transaction ID is provided,
+a ProgrammingError will be raised.
+This form should be called outside a transaction, and
+is intended for use in recovery.
 
-#### Connection.tpc\_prepare()
+#### Connection.tpc_prepare()
 
-Performs the first phase of a transaction started with .tpc\_begin(). A ProgrammingError will be raised if this method was called outside a TPC transaction.
+Performs the first phase of a transaction started with .tpc_begin().
+A ProgrammingError will be raised if this method was called outside
+a TPC transaction.
 
-After calling .tpc\_prepare(), no statements can be executed until .tpc\_commit() or .tpc\_rollback() have been called.
+After calling .tpc_prepare(), no statements can be executed until
+.tpc_commit() or .tpc_rollback() have been called.
 
-#### Connection.tpc\_recover()
+#### Connection.tpc_recover()
 
-Returns a list of pending transaction IDs suitable for use with tpc\_commit(xid) or .tpc\_rollback(xid).
+Returns a list of pending transaction IDs suitable for use with
+tpc_commit(xid) or .tpc_rollback(xid).
 
-#### Connection.tpc\_rollback(xid=None)
+#### Connection.tpc_rollback(xid=None)
 
-Parameter: : xid: xid object which was created by .xid() method of connection : class
+Parameter:
+: xid: xid object which was created by .xid() method of connection
+  : class
 
-Performs the first phase of a transaction started with .tpc\_begin(). A ProgrammingError will be raised if this method outside a TPC transaction.
+Performs the first phase of a transaction started with .tpc_begin().
+A ProgrammingError will be raised if this method outside a TPC
+transaction.
 
-After calling .tpc\_prepare(), no statements can be executed until .tpc\_commit() or .tpc\_rollback() have been called.
+After calling .tpc_prepare(), no statements can be executed until
+.tpc_commit() or .tpc_rollback() have been called.
 
 ## Connection attributes
 
-#### Connection.auto\_reconnect
+#### Connection.auto_reconnect
 
 (read/write)
 
-Enable or disable automatic reconnection to the server if the connection is found to have been lost.
+Enable or disable automatic reconnection to the server if the connection
+is found to have been lost.
 
-When enabled, client tries to reconnect to a database server in case the connection to a database server died due to timeout or other errors.
+When enabled, client tries to reconnect to a database server in case
+the connection to a database server died due to timeout or other errors.
 
 #### Connection.autocommit
 
 Toggles autocommit mode on or off for the current database connection.
 
-Autocommit mode only affects operations on transactional table types. Be aware that rollback() will not work if autocommit mode was switched on.
+Autocommit mode only affects operations on transactional table types.
+Be aware that rollback() will not work if autocommit mode was switched
+on.
 
 By default, autocommit mode is set to False.
 
-#### Connection.character\_set
+#### Connection.character_set
 
 Client character set.
 
 For MariaDB Connector/Python, it is always utf8mb4.
 
-#### Connection.client\_capabilities
+#### Connection.client_capabilities
 
 Client capability flags.
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
 #### Connection.collation
 
 Client character set collation
 
-#### Connection.connection\_id
+#### Connection.connection_id
 
 Id of current connection
 
@@ -237,78 +297,84 @@ Get the current database of the connection.
 
 Returns true if the connection is alive.
 
-A ping command will be sent to the server for this purpose, which means this function might fail if there are still non-processed pending result sets.
+A ping command will be sent to the server for this purpose,
+which means this function might fail if there are still
+non-processed pending result sets.
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
-#### Connection.server\_capabilities
+#### Connection.server_capabilities
 
 Server capability flags.
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
-#### Connection.extended\_server\_capabilities
+#### Connection.extended_server_capabilities
 
-Extended server capability flags (only for MariaDB database servers).
+Extended server capability flags (only for MariaDB
+database servers).
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
-#### Connection.server\_info
+#### Connection.server_info
 
 Server version in alphanumerical format (str)
 
-#### Connection.server\_name
+#### Connection.server_name
 
 Name or IP address of database server.
 
-#### Connection.server\_port
+#### Connection.server_port
 
-Database server TCP/IP port. This value will be 0 in case of an unix socket connection.
+Database server TCP/IP port. This value will be 0 in case of an unix
+socket connection.
 
-#### Connection.server\_status
+#### Connection.server_status
 
 Return server status flags
 
-_Since version 1.1.0._
+*Since version 1.1.0.*
 
-#### Connection.server\_version
+#### Connection.server_version
 
 Server version in numerical format.
 
-The form of the version number is VERSION\_MAJOR \* 10000 + VERSION\_MINOR \* 100 + VERSION\_PATCH
+The form of the version number is
+VERSION_MAJOR \* 10000 + VERSION_MINOR \* 100 + VERSION_PATCH
 
-#### Connection.server\_version\_info
+#### Connection.server_version_info
 
 Returns numeric version of connected database server in tuple format.
 
-#### Connection.tls\_cipher
+#### Connection.tls_cipher
 
 TLS cipher suite if a secure connection is used.
 
-_Since version 1.0.5._
+*Since version 1.0.5.*
 
-#### Connection.tls\_version
+#### Connection.tls_version
 
 TLS protocol version if a secure connection is used.
 
-#### Connection.tls\_peer\_cert\_info
+#### Connection.tls_peer_cert_info
 
 Get peer certificate information.
 
-_Since version 1.1.11._
+*Since version 1.1.11.*
 
-#### Connection.unix\_socket
+#### Connection.unix_socket
 
 Unix socket name.
 
 #### Connection.user
 
-Returns the username for the current connection or empty string if it can’t be determined, e.g., when using socket authentication.
+Returns the username for the current connection or empty
+string if it can’t be determined, e.g., when using socket
+authentication.
 
 #### Connection.warnings
 
-Returns the number of warnings from the last executed statement, or zero if there are no warnings.
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+Returns the number of warnings from the last executed statement, or zero
+if there are no warnings.
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/constants.md
+++ b/connectors/mariadb-connector-python/constants.md
@@ -3,7 +3,6 @@
 > Constants are declared in mariadb.constants module.
 
 > For using constants of various types, they have to be imported first:
-
 ```python
 from mariadb.constants import *
 ```
@@ -12,11 +11,12 @@ from mariadb.constants import *
 
 MariaDB capability flags.
 
-These flags are used to check the capabilities both of a MariaDB server or the client applicaion.
+These flags are used to check the capabilities both of a MariaDB server
+or the client applicaion.
 
-Capability flags are defined in module _mariadb.constants.CAPABILIY_
+Capability flags are defined in module *mariadb.constants.CAPABILIY*
 
-_Since version 1.1.4_
+*Since version 1.1.4*
 
 ```python
 import mariadb
@@ -35,7 +35,7 @@ with mariadb.connect(**conn_params) as connection:
         print("Server supports LOCAL INFILE")
 ```
 
-_Output_:
+*Output*:
 
 ```none
 Server supports LOCAL INFILE
@@ -45,33 +45,37 @@ Server supports LOCAL INFILE
 
 MariaDB capability flags.
 
-These flags are used to check the capabilities both of a MariaDB server or the client applicaion.
+These flags are used to check the capabilities both of a MariaDB server
+or the client applicaion.
 
-Capability flags are defined in module _mariadb.constants.CLIENT_
+Capability flags are defined in module *mariadb.constants.CLIENT*
 
-_Since version 1.1.0, deprecated in 1.1.4_
+*Since version 1.1.0, deprecated in 1.1.4*
 
 ## CURSOR
 
-Cursor constants are used for server side cursors. Currently only read only cursor is supported.
+Cursor constants are used for server side cursors.
+Currently only read only cursor is supported.
 
-Cursor constants are defined in module _mariadb.constants.CURSOR_.
+Cursor constants are defined in module *mariadb.constants.CURSOR*.
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
 #### CURSOR.NONE
 
 This is the default setting (no cursor)
 
-#### CURSOR.READ\_ONLY
+#### CURSOR.READ_ONLY
 
-Will create a server side read only cursor. The cursor is a forward cursor, which means it is not possible to scroll back.
+Will create a server side read only cursor. The cursor is a forward cursor, which
+means it is not possible to scroll back.
 
 ## ERR (Error)
 
-Using ERR constants instead of error numbers make the code more readable. Error constants are defined in constants.ERR module
+Using ERR constants instead of error numbers make the code more readable. Error constants
+are defined in constants.ERR module
 
-_Since version 1.1.2_
+*Since version 1.1.2*
 
 ```python
 import mariadb
@@ -92,199 +96,203 @@ except mariadb.OperationalError as Err:
         print("Access denied. Wrong password!")
 ```
 
-_Output_:
+*Output*:
 
 ```none
 Access denied. Wrong password!
 ```
 
-## FIELD\_FLAG
+## FIELD_FLAG
 
-MariaDB FIELD\_FLAG Constants
+MariaDB FIELD_FLAG Constants
 
-These constants represent the various field flags. As an addition to the DBAPI 2.0 standard (PEP-249) these flags are returned as eighth element of the cursor description attribute.
+These constants represent the various field flags. As an addition
+to the DBAPI 2.0 standard (PEP-249) these flags are returned as
+eighth element of the cursor description attribute.
 
-Field flags are defined in module _mariadb.constants.FIELD\_FLAG_
+Field flags are defined in module *mariadb.constants.FIELD_FLAG*
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
-#### FIELD\_FLAG.NOT\_NULL
+#### FIELD_FLAG.NOT_NULL
 
 column is defined as not NULL
 
-#### FIELD\_FLAG.PRIMARY\_KEY
+#### FIELD_FLAG.PRIMARY_KEY
 
 column is (part of) a primary key
 
-#### FIELD\_FLAG.UNIQUE\_KEY
+#### FIELD_FLAG.UNIQUE_KEY
 
 column is (part of) a unique key
 
-#### FIELD\_FLAG.MULTIPLE\_KEY
+#### FIELD_FLAG.MULTIPLE_KEY
 
 column is (part of) a key
 
-#### FIELD\_FLAG.BLOB
+#### FIELD_FLAG.BLOB
 
 column contains a binary object
 
-#### FIELD\_FLAG.UNSIGNED
+#### FIELD_FLAG.UNSIGNED
 
 numeric column is defined as unsigned
 
-#### FIELD\_FLAG.ZEROFILL
+#### FIELD_FLAG.ZEROFILL
 
 column has zerofill attribute
 
-#### FIELD\_FLAG.BINARY
+#### FIELD_FLAG.BINARY
 
 column is a binary
 
-#### FIELD\_FLAG.ENUM
+#### FIELD_FLAG.ENUM
 
 column is defined as enum
 
-#### FIELD\_FLAG.AUTO\_INCREMENT
+#### FIELD_FLAG.AUTO_INCREMENT
 
-column is an auto\_increment column
+column is an auto_increment column
 
-#### FIELD\_FLAG.TIMESTAMP
+#### FIELD_FLAG.TIMESTAMP
 
 column is defined as time stamp
 
-#### FIELD\_FLAG.SET
+#### FIELD_FLAG.SET
 
 column is defined as SET
 
-#### FIELD\_FLAG.NO\_DEFAULT
+#### FIELD_FLAG.NO_DEFAULT
 
 column hasn’t a default value
 
-#### FIELD\_FLAG.ON\_UPDATE\_NOW
+#### FIELD_FLAG.ON_UPDATE_NOW
 
 column will be set to current timestamp on UPDATE
 
-#### FIELD\_FLAG.NUMERIC
+#### FIELD_FLAG.NUMERIC
 
 column contains numeric value
 
-#### FIELD\_FLAG.PART\_OF\_KEY
+#### FIELD_FLAG.PART_OF_KEY
 
 column is part of a key
 
-## FIELD\_TYPE
+## FIELD_TYPE
 
-MariaDB FIELD\_TYPE Constants
+MariaDB FIELD_TYPE Constants
 
-These constants represent the field types supported by MariaDB. The field type is returned as second element of cursor description attribute.
+These constants represent the field types supported by MariaDB.
+The field type is returned as second element of cursor description attribute.
 
-Field types are defined in module _mariadb.constants.FIELD\_TYPE_
+Field types are defined in module *mariadb.constants.FIELD_TYPE*
 
-#### FIELD\_TYPE.TINY
+#### FIELD_TYPE.TINY
 
-column type is TINYINT (1-byte integer)
+column type is TINYINT  (1-byte integer)
 
-#### FIELD\_TYPE.SHORT
+#### FIELD_TYPE.SHORT
 
 column type is SMALLINT (2-byte integer)
 
-#### FIELD\_TYPE.LONG
+#### FIELD_TYPE.LONG
 
 column tyoe is INT (4-byte integer)
 
-#### FIELD\_TYPE.FLOAT
+#### FIELD_TYPE.FLOAT
 
 column type is FLOAT (4-byte single precision)
 
-#### FIELD\_TYPE.DOUBLE
+#### FIELD_TYPE.DOUBLE
 
 column type is DOUBLE (8-byte double precision)
 
-#### FIELD\_TYPE.NULL
+#### FIELD_TYPE.NULL
 
 column type is NULL
 
-#### FIELD\_TYPE.TIMESTAMP
+#### FIELD_TYPE.TIMESTAMP
 
 column tyoe is TIMESTAMP
 
-#### FIELD\_TYPE.LONGLONG
+#### FIELD_TYPE.LONGLONG
 
 column tyoe is BIGINT (8-byte Integer)
 
-#### FIELD\_TYPE.INT24
+#### FIELD_TYPE.INT24
 
 column type is MEDIUMINT (3-byte Integer)
 
-#### FIELD\_TYPE.DATE
+#### FIELD_TYPE.DATE
 
 column type is DATE
 
-#### FIELD\_TYPE.TIME
+#### FIELD_TYPE.TIME
 
 column type is TIME
 
-#### FIELD\_TYPE.DATETIME
+#### FIELD_TYPE.DATETIME
 
 column type is YEAR
 
-#### FIELD\_TYPE.YEAR
+#### FIELD_TYPE.YEAR
 
-#### FIELD\_TYPE.VARCHAR
+#### FIELD_TYPE.VARCHAR
 
 column type is YEAR
 
-#### FIELD\_TYPE.BIT
+#### FIELD_TYPE.BIT
 
 column type is BIT
 
-#### FIELD\_TYPE.JSON
+#### FIELD_TYPE.JSON
 
 column type is JSON
 
-#### FIELD\_TYPE.NEWDECIMAL
+#### FIELD_TYPE.NEWDECIMAL
 
 column type is DECIMAL
 
-#### FIELD\_TYPE.ENUM
+#### FIELD_TYPE.ENUM
 
 column type is ENUM
 
-#### FIELD\_TYPE.SET
+#### FIELD_TYPE.SET
 
 column type is SET
 
-#### FIELD\_TYPE.TINY\_BLOB
+#### FIELD_TYPE.TINY_BLOB
 
 column type is TINYBLOB (max. length of 255 bytes)
 
-#### FIELD\_TYPE.MEDIUM\_BLOB
+#### FIELD_TYPE.MEDIUM_BLOB
 
 column type is MEDIUMBLOB (max. length of 16,777,215 bytes)
 
-#### FIELD\_TYPE.LONG\_BLOB
+#### FIELD_TYPE.LONG_BLOB
 
 column type is LONGBLOB (max. length 4GB bytes)
 
-#### FIELD\_TYPE.BLOB
+#### FIELD_TYPE.BLOB
 
 column type is BLOB (max. length of 65.535 bytes)
 
-#### FIELD\_TYPE.VAR\_STRING
+#### FIELD_TYPE.VAR_STRING
 
 column type is VARCHAR (variable length)
 
-#### FIELD\_TYPE.STRING
+#### FIELD_TYPE.STRING
 
 column type is CHAR (fixed length)
 
-#### FIELD\_TYPE.GEOMETRY
+#### FIELD_TYPE.GEOMETRY
 
 column type is GEOMETRY
 
 ## INDICATORS
 
-Indicator values are used in executemany() method of cursor class to indicate special values when connected to a MariaDB server 10.2 or newer.
+Indicator values are used in executemany() method of cursor class to
+indicate special values when connected to a MariaDB server 10.2 or newer.
 
 #### INDICATOR.NULL
 
@@ -296,9 +304,10 @@ indicates to use default value of column
 
 #### INDICATOR.IGNORE
 
-indicates to ignore value for column for UPDATE statements. If set, the column will not be updated.
+indicates to ignore value for column for UPDATE statements.
+If set, the column will not be updated.
 
-#### INDICATOR.IGNORE\_ROW
+#### INDICATOR.IGNORE_ROW
 
 indicates not to update the entire row.
 
@@ -306,7 +315,7 @@ indicates not to update the entire row.
 
 For internal use only
 
-## TPC\_STATE
+## TPC_STATE
 
 For internal use only
 
@@ -314,20 +323,22 @@ For internal use only
 
 The STATUS constants are used to check the server status of the current connection.
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
 > Example:
 
 > ```python
 > cursor.callproc("my_storedprocedure", (1,"foo"))
+
+> if (connection.server_status & STATUS.SP_OUT_PARAMS):
+>     print("retrieving output parameters from store procedure")
+>     ...
+> else:
+>     print("retrieving data from stored procedure")
+>     ....
 > ```
 
-> if (connection.server\_status & STATUS.SP\_OUT\_PARAMS): print("retrieving output parameters from store procedure") ... else: print("retrieving data from stored procedure") ....
->
-> ```
-> ```
-
-#### STATUS.IN\_TRANS
+#### STATUS.IN_TRANS
 
 Pending transaction
 
@@ -335,50 +346,51 @@ Pending transaction
 
 Server operates in autocommit mode
 
-#### STATUS.MORE\_RESULTS\_EXIST
+#### STATUS.MORE_RESULTS_EXIST
 
-The result from last executed statement contained two or more result sets which can be retrieved by cursors nextset() method.
+The result from last executed statement contained two or more result
+sets which can be retrieved by cursors nextset() method.
 
-#### STATUS.QUERY\_NO\_GOOD\_INDEX\_USED
+#### STATUS.QUERY_NO_GOOD_INDEX_USED
 
 The last executed statement didn’t use a good index.
 
-#### STATUS.QUERY\_NO\_INDEX\_USED
+#### STATUS.QUERY_NO_INDEX_USED
 
 The last executed statement didn’t use an index.
 
-#### STATUS.CURSOR\_EXISTS
+#### STATUS.CURSOR_EXISTS
 
 The last executed statement opened a server side cursor.
 
-#### STATUS.LAST\_ROW\_SENT
+#### STATUS.LAST_ROW_SENT
 
 For server side cursors this flag indicates end of a result set.
 
-#### STATUS.DB\_DROPPED
+#### STATUS.DB_DROPPED
 
-The current database in use was dropped and there is no default database for the connection anymore.
+The current database in use was dropped and there is no default
+database for the connection anymore.
 
-#### STATUS.NO\_BACKSLASH\_ESCAPES
+#### STATUS.NO_BACKSLASH_ESCAPES
 
-Indicates that SQL mode NO\_BACKSLASH\_ESCAPE is active, which means that the backslash character ‘' becomes an ordinary character.
+Indicates that SQL mode NO_BACKSLASH_ESCAPE is active, which means
+that the backslash character ‘' becomes an ordinary character.
 
-#### STATUS.QUERY\_WAS\_SLOW
+#### STATUS.QUERY_WAS_SLOW
 
 The previously executed statement was slow (and needs to be optimized).
 
-#### STATUS.PS\_OUT\_PARAMS
+#### STATUS.PS_OUT_PARAMS
 
 The current result set contains output parameters of a stored procedure.
 
-#### STATUS.SESSION\_STATE\_CHANGED
+#### STATUS.SESSION_STATE_CHANGED
 
 The session status has been changed.
 
-#### STATUS.ANSI\_QUOTES
+#### STATUS.ANSI_QUOTES
 
-SQL mode ANSI\_QUOTES is active,
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+SQL mode ANSI_QUOTES is active,
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/cursor.md
+++ b/connectors/mariadb-connector-python/cursor.md
@@ -1,6 +1,6 @@
 # The cursor class
 
-### _class_ Cursor(connection, \*\*kwargs)
+### *class* Cursor(connection, \*\*kwargs)
 
 MariaDB Connector/Python Cursor Object
 
@@ -8,13 +8,17 @@ MariaDB Connector/Python Cursor Object
 
 #### Cursor.callproc(sp: str, data: Sequence = ())
 
-Executes a stored procedure sp. The data sequence must contain an entry for each parameter the procedure expects.
+Executes a stored procedure sp. The data sequence must contain an
+entry for each parameter the procedure expects.
 
-Input/Output or Output parameters have to be retrieved by .fetch methods, the .sp\_outparams attribute indicates if the result set contains output parameters.
+Input/Output or Output parameters have to be retrieved by .fetch
+methods, the .sp_outparams attribute indicates if the result set
+contains output parameters.
 
-Arguments: : - sp: Name of stored procedure.
-
-* data: Optional sequence containing data for placeholder : substitution.
+Arguments:
+: - sp: Name of stored procedure.
+  - data: Optional sequence containing data for placeholder
+    : substitution.
 
 Example:
 
@@ -41,19 +45,35 @@ True
 
 Prepare and execute a SQL statement.
 
-Parameters may be provided as sequence or mapping and will be bound to variables in the operation. Variables are specified as question marks (paramstyle =’qmark’), however for compatibility reasons MariaDB Connector/Python also supports the ‘format’ and ‘pyformat’ paramstyles with the restriction, that different paramstyles can’t be mixed within a statement.
+Parameters may be provided as sequence or mapping and will be bound
+to variables in the operation. Variables are specified as question
+marks (paramstyle =’qmark’), however for compatibility reasons MariaDB
+Connector/Python also supports the ‘format’ and ‘pyformat’ paramstyles
+with the restriction, that different paramstyles can’t be mixed within
+a statement.
 
-A reference to the operation will be retained by the cursor. If the cursor was created with attribute prepared =True the statement string for following execute operations will be ignored. This is most effective for algorithms where the same operation is used, but different parameters are bound to it (many times).
+A reference to the operation will be retained by the cursor.
+If the cursor was created with attribute prepared =True the statement
+string for following execute operations will be ignored.
+This is most effective for algorithms where the same operation is used,
+but different parameters are bound to it (many times).
 
-By default execute() method generates an buffered result unless the optional parameter buffered was set to False or the cursor was generated as an unbuffered cursor.
+By default execute() method generates an buffered result unless the
+optional parameter buffered was set to False or the cursor was
+generated as an unbuffered cursor.
 
 #### Cursor.executemany(statement, parameters)
 
-Prepare a database operation (INSERT,UPDATE,REPLACE or DELETE statement) and execute it against all parameter found in sequence.
+Prepare a database operation (INSERT,UPDATE,REPLACE or DELETE
+statement) and execute it against all parameter found in sequence.
 
-Exactly behaves like .execute() but accepts a list of tuples, where each tuple represents data of a row within a table. .executemany() only supports DML (insert, update, delete) statements.
+Exactly behaves like .execute() but accepts a list of tuples, where
+each tuple represents data of a row within a table.
+.executemany() only supports DML (insert, update, delete) statements.
 
-If the SQL statement contains a RETURNING clause, executemany() returns a result set containing the values for columns listed in the RETURNING clause.
+If the SQL statement contains a RETURNING clause, executemany()
+returns a result set containing the values for columns listed in the
+RETURNING clause.
 
 Example:
 
@@ -70,49 +90,65 @@ cursor.executemany("INSERT INTO colleagues VALUES (?, ?, ?)", data)
 
 To insert special values like NULL or a column default, you need to specify indicators:
 
-* INDICATOR.NULL is used for NULL values
-* INDICATOR.IGNORE is used to skip update of a column.
-* INDICATOR.DEFAULT is used for a default value (insert/update)
-* INDICATOR.ROW is used to skip update/insert of the entire row.
+- INDICATOR.NULL is used for NULL values
+- INDICATOR.IGNORE is used to skip update of a column.
+- INDICATOR.DEFAULT is used for a default value (insert/update)
+- INDICATOR.ROW is used to skip update/insert of the entire row.
 
 #### NOTE
-
-* All values for a column must have the same data type.
-* Indicators can only be used when connecting to a MariaDB Server 10.2 or newer. MySQL servers don’t support this feature.
+- All values for a column must have the same data type.
+- Indicators can only be used when connecting to a MariaDB Server 10.2 or newer. MySQL servers don’t support this feature.
 
 #### Cursor.fetchall()
 
-Fetch all remaining rows of a query result, returning them as a sequence of sequences (e.g. a list of tuples).
+Fetch all remaining rows of a query result, returning them as a
+sequence of sequences (e.g. a list of tuples).
 
-An exception will be raised if the previous call to execute() didn’t produce a result set or execute() wasn’t called before.
+An exception will be raised if the previous call to execute() didn’t
+produce a result set or execute() wasn’t called before.
 
 #### Cursor.fetchmany(size: int = 0)
 
-Fetch the next set of rows of a query result, returning a sequence of sequences (e.g. a list of tuples). An empty sequence is returned when no more rows are available.
+Fetch the next set of rows of a query result, returning a sequence
+of sequences (e.g. a list of tuples). An empty sequence is returned
+when no more rows are available.
 
-The number of rows to fetch per call is specified by the parameter. If it is not given, the cursor’s arraysize determines the number of rows to be fetched. The method should try to fetch as many rows as indicated by the size parameter. If this is not possible due to the specified number of rows not being available, fewer rows may be returned.
+The number of rows to fetch per call is specified by the parameter.
+If it is not given, the cursor’s arraysize determines the number
+of rows to be fetched. The method should try to fetch as many rows
+as indicated by the size parameter.
+If this is not possible due to the specified number of rows not being
+available, fewer rows may be returned.
 
-An exception will be raised if the previous call to execute() didn’t produce a result set or execute() wasn’t called before.
+An exception will be raised if the previous call to execute() didn’t
+produce a result set or execute() wasn’t called before.
 
 #### Cursor.fetchone()
 
-Fetch the next row of a query result set, returning a single sequence, or None if no more data is available.
+Fetch the next row of a query result set, returning a single sequence,
+or None if no more data is available.
 
-An exception will be raised if the previous call to execute() didn’t produce a result set or execute() wasn’t called before.
+An exception will be raised if the previous call to execute() didn’t
+produce a result set or execute() wasn’t called before.
 
 #### Cursor.next()
 
-Return the next row from the currently executed SQL statement using the same semantics as .fetchone().
+Return the next row from the currently executed SQL statement
+using the same semantics as .fetchone().
 
 #### Cursor.nextset()
 
-Will make the cursor skip to the next available result set, discarding any remaining rows from the current set.
+Will make the cursor skip to the next available result set,
+discarding any remaining rows from the current set.
 
 #### Cursor.scroll(value: int, mode='relative')
 
-Scroll the cursor in the result set to a new position according to mode.
+Scroll the cursor in the result set to a new position according to
+mode.
 
-If mode is “relative” (default), value is taken as offset to the current position in the result set, if set to absolute, value states an absolute target position.
+If mode is “relative” (default), value is taken as offset to the
+current position in the result set, if set to absolute, value states
+an absolute target position.
 
 #### Cursor.setinputsizes()
 
@@ -134,7 +170,9 @@ This read/write attribute specifies the number of rows to fetch at a time with .
 
 #### Cursor.buffered
 
-When True all result sets are immediately transferred and the connection between client and server is no longer blocked. Since version 1.1.0 default is True, for prior versions default was False.
+When True all result sets are immediately transferred and the connection
+between client and server is no longer blocked. Since version 1.1.0 default
+is True, for prior versions default was False.
 
 #### Cursor.closed
 
@@ -142,33 +180,38 @@ Indicates if the cursor is closed and can’t be reused
 
 #### Cursor.connection
 
-Read-Only attribute which returns the reference to the connection object on which the cursor was created.
+Read-Only attribute which returns the reference to the connection
+object on which the cursor was created.
 
 #### Cursor.description
 
-This read-only attribute is a sequence of 11-item sequences Each of these sequences contains information describing one result column:
+This read-only attribute is a sequence of 11-item sequences
+Each of these sequences contains information describing one result column:
 
-* name
-* type\_code
-* display\_size
-* internal\_size
-* precision
-* scale
-* null\_ok
-* field\_flags
-* table\_name
-* original\_column\_name
-* original\_table\_name
+- name
+- type_code
+- display_size
+- internal_size
+- precision
+- scale
+- null_ok
+- field_flags
+- table_name
+- original_column_name
+- original_table_name
 
-This attribute will be None for operations that do not return rows or if the cursor has not had an operation invoked via the .execute\*() method yet.
+This attribute will be None for operations that do not return rows or if the cursor has
+not had an operation invoked via the .execute\*() method yet.
 
 #### NOTE
+The 8th parameter ‘field_flags’ is an extension to the PEP-249 DB API standard.
+In combination with the type element field, it can be determined for example,
+whether a column is a BLOB or TEXT field:
 
-The 8th parameter ‘field\_flags’ is an extension to the PEP-249 DB API standard. In combination with the type element field, it can be determined for example, whether a column is a BLOB or TEXT field:
+*Since version 1.1.0*
 
-_Since version 1.1.0_
-
-The parameter table\_name, original\_column\_name and original\_table\_name are an extension to the PEP-249 DB API standard.
+The parameter table_name, original_column_name and original_table_name are an
+extension to the PEP-249 DB API standard.
 
 ```python
 if cursor.description[0][1] == FIELD_TYPE.BLOB:
@@ -180,9 +223,14 @@ if cursor.description[0][1] == FIELD_TYPE.BLOB:
 
 #### Cursor.lastrowid
 
-Returns the ID generated by a query on a table with a column having the AUTO\_INCREMENT attribute or the value for the last usage of LAST\_INSERT\_ID().
+Returns the ID generated by a query on a table with a column having
+the AUTO_INCREMENT attribute or the value for the last usage of
+LAST_INSERT_ID().
 
-If the last query wasn’t an INSERT or UPDATE statement or if the modified table does not have a column with the AUTO\_INCREMENT attribute and LAST\_INSERT\_ID was not used, the returned value will be None
+If the last query wasn’t an INSERT or UPDATE
+statement or if the modified table does not have a column with the
+AUTO_INCREMENT attribute and LAST_INSERT_ID was not used, the returned
+value will be None
 
 #### Cursor.metadata
 
@@ -190,25 +238,26 @@ Similar to description property, this property returns a dictionary with complet
 
 The dictionary contains the following keys:
 
-* catalog: catalog (always ‘def’)
-* schema: current schema
-* field: alias column name or if no alias was specified column name
-* org\_field: original column name
-* table: alias table name or if no alias was specified table name
-* org\_table: original table name
-* type: column type
-* charset: character set (utf8mb4 or binary)
-* length: The length of the column
-* max length: The maximum length of the column
-* decimals: The numer of decimals
-* flags: Flags (flags are defined in constants.FIELD\_FLAG)
-* ext\_type: Extended data type (types are defined in constants.EXT\_FIELD\_TYPE)
+- catalog:     catalog (always ‘def’)
+- schema:      current schema
+- field:       alias column name or if no alias was specified column name
+- org_field:   original column name
+- table:       alias table name or if no alias was specified table name
+- org_table:   original table name
+- type:        column type
+- charset:     character set (utf8mb4 or binary)
+- length:      The length of the column
+- max length:  The maximum length of the column
+- decimals:    The numer of decimals
+- flags:       Flags (flags are defined in constants.FIELD_FLAG)
+- ext_type:    Extended data type (types are defined in constants.EXT_FIELD_TYPE)
 
-_Since version 1.1.8_
+*Since version 1.1.8*
 
-#### Cursor.sp\_outparams
+#### Cursor.sp_outparams
 
-Indicates if the current result set contains in out or out parameter from a previous executed stored procedure
+Indicates if the current result set contains in out or out parameter
+from a previous executed stored procedure
 
 #### Cursor.paramcount
 
@@ -216,15 +265,19 @@ Indicates if the current result set contains in out or out parameter from a prev
 
 Returns the number of parameter markers present in the executed statement.
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
 #### Cursor.rowcount
 
-This read-only attribute specifies the number of rows that the last execute\*() produced (for DQL statements like SELECT) or affected (for DML statements like UPDATE or INSERT). The return value is -1 in case no .execute\*() has been performed on the cursor or the rowcount of the last operation cannot be determined by the interface.
+This read-only attribute specifies the number of rows that the last        execute\*() produced (for DQL statements like SELECT) or affected
+(for DML statements like UPDATE or INSERT).
+The return value is -1 in case no .execute\*() has been performed
+on the cursor or the rowcount of the last operation  cannot be
+determined by the interface.
 
 #### NOTE
-
-For unbuffered cursors (default) the exact number of rows can only be determined after all rows were fetched.
+For unbuffered cursors (default) the exact number of rows can only be
+determined after all rows were fetched.
 
 Example:
 
@@ -250,12 +303,10 @@ The last executed statement
 
 #### Cursor.warnings
 
-Returns the number of warnings from the last executed statement, or zero if there are no warnings.
+Returns the number of warnings from the last executed statement, or zero
+if there are no warnings.
 
 #### NOTE
-
-Warnings can be retrieved by the show\_warnings() method of connection class.
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+Warnings can be retrieved by the show_warnings() method of connection class.
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/faq.md
+++ b/connectors/mariadb-connector-python/faq.md
@@ -1,14 +1,18 @@
+<a id="faq"></a>
+
 # MariaDB Connector/Python FAQ
 
-## MariaDB Connector/Python FAQ
+This is a list of frequently asked questions about MariaDB Connector/Python. Feel free to suggest new
+entries!
 
-This is a list of frequently asked questions about MariaDB Connector/Python. Feel free to suggest new entries!
+<a id="installation-faq"></a>
 
-### Installation
+## Installation
 
-#### Error: “Python.h: No such file or directory”
+### Error: “Python.h: No such file or directory”
 
-The header files and libraries of the Python development package weren’t properly installed. Use your package manager to install them system-wide:
+The header files and libraries of the Python development package weren’t properly installed.
+Use your package manager to install them system-wide:
 
 **Alpine (using apk):**
 
@@ -46,11 +50,13 @@ brew install mariadb-connector-c
 sudo zypper in python3-devel
 ```
 
-Note: The python3 development packages of your distribution might not cover all minor versions of python3. If you are using python3.10 you may need to install python3.10-dev.
+Note: The python3 development packages of your distribution might not cover all minor versions
+of python3. If you are using python3.10 you may need to install python3.10-dev.
 
-#### ModuleNotFoundError: No module named ‘packaging’
+### ModuleNotFoundError: No module named ‘packaging’
 
-With deprecation of distutils (see [PEP-632](https://peps.python.org/pep-632)) version functions of distutils module were replaced in MariaDB Connector/Python 1.1.5 by packaging version functions.
+With deprecation of distutils (see [PEP-632](https://peps.python.org/pep-632)) version functions of distutils module were
+replaced in MariaDB Connector/Python 1.1.5 by packaging version functions.
 
 Before you can install MariaDB Connector/Python you have to install the packaging module:
 
@@ -58,9 +64,10 @@ Before you can install MariaDB Connector/Python you have to install the packagin
 pip3 install packaging
 ```
 
-#### MariaDB Connector/Python requires MariaDB Connector/C >= 3.3.1, found version 3.1.2
+### MariaDB Connector/Python requires MariaDB Connector/C >= 3.3.1, found version 3.1.2
 
-The previously installed version of MariaDB Connector/C is too old and cannot be used for the MariaDB Connector/Python version you are trying to install.
+The previously installed version of MariaDB Connector/C is too old and cannot be used for the MariaDB Connector/Python version
+you are trying to install.
 
 To determine the installed version of MariaDB Connector/C, execute the command:
 
@@ -68,38 +75,45 @@ To determine the installed version of MariaDB Connector/C, execute the command:
 mariadb_config --cc_version
 ```
 
-* Check if your distribution can be upgraded to a more recent version of MariaDB Connector/C, which fits the requirements.
-* If your distribution doesn’t provide a recent version of MariaDB Connector/C, check the [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/), which provides latest versions for the major distributions.
-* If none of the above will work for you, build and install MariaDB Connector/C from source.
+- Check if your distribution can be upgraded to a more recent version of MariaDB Connector/C, which fits the requirements.
+- If your distribution doesn’t provide a recent version of MariaDB Connector/C, check the [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/), which provides
+  latest versions for the major distributions.
+- If none of the above will work for you, build and install MariaDB Connector/C from source.
 
-#### OSError: mariadb\_config not found
+### OSError: mariadb_config not found
 
-The mariadb\_config program is used to retrieve configuration information (such as the location of header files and libraries, installed version, etc.) from MariaDB Connector/C.
+The mariadb_config program is used to retrieve configuration information (such as the location of
+header files and libraries, installed version, etc.) from MariaDB Connector/C.
 
-This error indicates that MariaDB Connector/C, an important dependency for client/server communication that needs to be preinstalled, either was not installed or could not be found.
+This error indicates that MariaDB Connector/C, an important dependency for client/server communication that needs
+to be preinstalled, either was not installed or could not be found.
 
-*   If MariaDB Connector/C was previously installed, the installation script cannot detect the location of mariadb\_config. Locate the directory where mariadb\_config was installed and add this directory to your PATH.
+* If MariaDB Connector/C was previously installed, the installation script cannot detect the location of mariadb_config.
+  Locate the directory where mariadb_config was installed and add this directory to your PATH.
+  ```console
+  # locate mariadb_config
+  sudo find / -name "mariadb_config"
+  ```
+* If MariaDB Connector/C was not installed and the location of mariadb_config couldn’t be detected, please install
+  MariaDB Connector/C.
 
-    ```console
-    # locate mariadb_config
-    sudo find / -name "mariadb_config"
-    ```
-* If MariaDB Connector/C was not installed and the location of mariadb\_config couldn’t be detected, please install MariaDB Connector/C.
+### Error: struct st_mariadb_methods’ has no member named ‘db_execute_generate_request’
 
-#### Error: struct st\_mariadb\_methods’ has no member named ‘db\_execute\_generate\_request’
-
-Even if the correct version of MariaDB Connector/C was installed, there are multiple mysql.h include files installed on your system, either from libmysql or an older MariaDB Connector/C installation. This can be checked by executing:
+Even if the correct version of MariaDB Connector/C was installed, there are multiple mysql.h include files installed
+on your system, either from libmysql or an older MariaDB Connector/C installation. This can be checked by executing:
 
 ```console
 export CFLAGS="-V -E"
 pip3 install mariadb > output.txt
 ```
 
-Open output.txt in your favourite editor and search for “search starts here” where you can see the include files and paths used for the build.
+Open output.txt in your favourite editor and search for “search starts here” where you can see the include
+files and paths used for the build.
 
-#### Q: My distribution doesn’t provide a recent version of MariaDB Connector/C
+### Q: My distribution doesn’t provide a recent version of MariaDB Connector/C
 
-If your distribution doesn’t provide a recent version of MariaDB Connector/C (required version is 3.3.1) you either can download a version of MariaDB Connector/C from the [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/) or build the package from source:
+If your distribution doesn’t provide a recent version of MariaDB Connector/C (required version is 3.3.1) you either
+can download a version of MariaDB Connector/C from the [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/) or build the package from source:
 
 ```console
 mkdir bld
@@ -109,11 +123,12 @@ make
 make install
 ```
 
-#### Q: Does MariaDB Connector/Python provide pre-releases or snapshot builds which contain recent bug fixes?
+### Q: Does MariaDB Connector/Python provide pre-releases or snapshot builds which contain recent bug fixes?
 
-No. If an issue was fixed, the fix will be available in the next release via Python’s package manager repository (pypi.org).
+No. If an issue was fixed, the fix will be available in the next release via Python’s package
+manager repository (pypi.org).
 
-#### Q: How can I build an actual version from github sources?
+### Q: How can I build an actual version from github sources?
 
 To build MariaDB Connector/Python from github sources, checkout latest sources from github:
 
@@ -128,46 +143,49 @@ python3 setup.py build
 python3 -m pip install .
 ```
 
-### Connecting
+## Connecting
 
-#### mariadb.OperationalError: Can’t connect to local server through socket ‘/tmp/mysql.sock’
+### mariadb.OperationalError: Can’t connect to local server through socket ‘/tmp/mysql.sock’
 
 1. Check if MariaDB server has been started.
-2.  Check if the MariaDB server was correctly configured and uses the right socket file:
+2. Check if the MariaDB server was correctly configured and uses the right socket file:
+   ```console
+   mysqld --help --verbose | grep socket
+   ```
 
-    ```console
-    mysqld --help --verbose | grep socket
-    ```
+   If the socket is different and cannot be changed, you can specify the socket in your
+   connection parameters.
+   ```python
+   connection = mariadb.connect(unix_socket="/path_socket/mysql.sock", ....)
+   ```
 
-    If the socket is different and cannot be changed, you can specify the socket in your connection parameters.
+   Another option is setting the environment variable MYSQL_UNIX_PORT.
+   ```console
+   export MYSQL_UNIX_PORT=/path_to/mysql.sock
+   ```
 
-    ```python
-    connection = mariadb.connect(unix_socket="/path_socket/mysql.sock", ....)
-    ```
+### Q: Which authentication methods are supported by MariaDB Connector/Python?
 
-    Another option is setting the environment variable MYSQL\_UNIX\_PORT.
+MariaDB Connector/Python uses MariaDB Connector/C for client-server communication. That means all authentication plugins shipped
+together with MariaDB Connector/C can be used for user authentication.
 
-    ```console
-    export MYSQL_UNIX_PORT=/path_to/mysql.sock
-    ```
+## General
 
-#### Q: Which authentication methods are supported by MariaDB Connector/Python?
-
-MariaDB Connector/Python uses MariaDB Connector/C for client-server communication. That means all authentication plugins shipped together with MariaDB Connector/C can be used for user authentication.
-
-### General
-
-#### Q: How do I execute multiple statements with cursor.execute()?
+### Q: How do I execute multiple statements with cursor.execute()?
 
 Since MariaDB Connector/Python uses binary protocol for client-server communication, this feature is not supported yet.
 
-#### Q: Does MariaDB Connector/Python work with Python 2.x?
+### Q: Does MariaDB Connector/Python work with Python 2.x?
 
-Python versions which reached their end of life are not officially supported. While MariaDB Connector/Python might still work with older Python 3.x versions, it doesn’t work with Python version 2.x.
+Python versions which reached their end of life are not officially supported. While MariaDB Connector/Python might still work
+with older Python 3.x versions, it doesn’t work with Python version 2.x.
 
-#### Q: How can I see a transformed statement? Is there a mogrify() method available?
+### Q: How can I see a transformed statement? Is there a mogrify() method available?
 
-No, MariaDB Connector/Python Python uses binary protocol for client/server communication. Before a statement will be executed it will be parsed and parameter markers which are different than question marks will be replaced by question marks. Afterwards the statement will be sent together with data to the server. The transformed statement can be obtained by cursor.statement attribute.
+No, MariaDB Connector/Python Python uses binary protocol for client/server communication. Before a statement will be executed
+it will be parsed and parameter markers which are different than question marks will be replaced by question
+marks. Afterwards the statement will be sent together with data to the server. The transformed statement can
+be obtained by cursor.statement attribute.
 
 Example:
 
@@ -183,19 +201,22 @@ print(cursor.statement)
 SELECT DATE_FORMAT(creation_time, '%h:%m:%s') as time, topic, amount FROM mytable WHERE topic=? and id > ?
 ```
 
-Please note, that there is no need to escape ‘%s’ by ‘%%s’ for the time conversion in DATE\_FORMAT() function.
+Please note, that there is no need to escape ‘%s’ by ‘%%s’ for the time conversion in DATE_FORMAT() function.
 
-#### Q: Does MariaDB Connector/Python support paramstyle “pyformat”?
+### Q: Does MariaDB Connector/Python support paramstyle “pyformat”?
 
-The default paramstyle (see [PEP-249](https://peps.python.org/pep-249)) is **qmark** (question mark) for parameter markers. For compatibility with other drivers MariaDB Connector/Python also supports (and automatically recognizes) the **format** and **pyformat** parameter styles.
+The default paramstyle (see [PEP-249](https://peps.python.org/pep-249)) is **qmark** (question mark) for parameter markers. For compatibility
+with other drivers MariaDB Connector/Python also supports (and automatically recognizes) the **format** and **pyformat** parameter
+styles.
 
 Mixing different paramstyles within the same query is not supported and will raise an exception.
 
-### Transactions
+## Transactions
 
-#### Q: Previously inserted records disappeared after my program finished
+### Q: Previously inserted records disappeared after my program finished
 
-Default for autocommit in MariaDB Connector/Python is off, which means every transaction must be committed. Uncommitted pending transactions are rolled back automatically when the connection is closed.
+Default for autocommit in MariaDB Connector/Python is off, which means every transaction must be committed.
+Uncommitted pending transactions are rolled back automatically when the connection is closed.
 
 ```python
 .. code-block:: python
@@ -211,7 +232,5 @@ Default for autocommit in MariaDB Connector/Python is off, which means every tra
            # commit pending transactions
            connection.commit()
 ```
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/install.md
+++ b/connectors/mariadb-connector-python/install.md
@@ -1,5 +1,7 @@
 # Installation
 
+<a id="id1"></a>
+
 ## Prerequisites
 
 The current MariaDB Connector/Python implementation supports
@@ -12,7 +14,8 @@ The current MariaDB Connector/Python implementation supports
 
 ### Microsoft Windows
 
-To install MariaDB Connector/Python on Microsoft Windows, you first have to install a recent version of MariaDB Connector/C. MSI installer for both 32-bit and 64-bit operating systems are available from [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/).
+To install MariaDB Connector/Python on Microsoft Windows, you first have to install a recent version of MariaDB Connector/C. MSI installer for
+both 32-bit and 64-bit operating systems are available from [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/).
 
 After installation of MariaDB Connector/C download and install MariaDB Connector/Python with the following command:
 
@@ -20,7 +23,8 @@ After installation of MariaDB Connector/C download and install MariaDB Connector
 pip3 install mariadb
 ```
 
-On success, you should see a message at the end “Successfully installed mariadb-x.y.z”, where x.y.z is the recent version of MariaDB Connector/Python.
+On success, you should see a message at the end “Successfully installed mariadb-x.y.z”, where x.y.z is
+the recent version of MariaDB Connector/Python.
 
 ```console
 Collecting mariadb
@@ -34,18 +38,23 @@ Successfully installed mariadb-1.1.5
 
 ### Build prerequisites
 
-The following build prerequisites are required to install or build MariaDB Connector/Python from source code, github or from pypi.org.
+The following build prerequisites are required to install or build MariaDB Connector/Python from source code, github or from
+pypi.org.
 
 To install MariaDB Connector/Python from sources you will need:
 
-* C compiler
-* Python development files (Usually they are installed with package **python3-dev**). The minimum supported version of Python is 3.7.
-* MariaDB Connector/C libraries and header files (Either from MariaDB server package or from MariaDB Connector/C package). Minimum required version for MariaDB Connector/Python < 1.1.0 is 3.1.5, for later versions 3.3.1. If your distribution doesn’t provide a recent version of MariaDB Connector/C you can either download binary packages from [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/) or build the package from source.
-* The mariadb\_config program from MariaDB Connector/C, which should be in your PATH directory.
-* For Posix systems: TLS libraries, e.g. GnuTLS or OpenSSL (default)
-* Since MariaDB Connector/Python 1.1.5: Python’s “packaging” module.
+- C compiler
+- Python development files (Usually they are installed with package **python3-dev**). The minimum supported version of Python is 3.7.
+- MariaDB Connector/C libraries and header files (Either from MariaDB server package or
+  from  MariaDB Connector/C package). Minimum required version for MariaDB Connector/Python < 1.1.0 is 3.1.5, for later versions 3.3.1.
+  If your distribution doesn’t provide a recent version of MariaDB Connector/C you can either download binary packages from [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/) or build
+  the package from source.
+- The mariadb_config program from MariaDB Connector/C, which should be in your PATH directory.
+- For Posix systems: TLS libraries, e.g. GnuTLS or OpenSSL (default)
+- Since MariaDB Connector/Python 1.1.5: Python’s “packaging” module.
 
-On Posix systems make sure that the path environment variable contains the directory which contains the mariadb\_config utility.
+On Posix systems make sure that the path environment variable contains the directory which
+contains the mariadb_config utility.
 
 Once everything is in place, run
 
@@ -64,7 +73,8 @@ For troubleshooting please also check the chapter [Installation](faq.md#installa
 
 ## Test suite
 
-If you have installed the sources, after successful build you can run the test suite from the source directory.
+If you have installed the sources, after successful build you can run the test suite
+from the source directory.
 
 ```console
 cd testing
@@ -73,12 +83,10 @@ python3 -m unittest discover -v
 
 You can configure the connection parameters by using the following environment variables
 
-* TEST\_DB\_USER (default root)
-* TEST\_DB\_PASSWORD
-* TEST\_DB\_DATABASE (default ‘testp’)
-* TEST\_DB\_HOST (default ‘localhost’)
-* TEST\_DB\_PORT (default 3306)
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+* TEST_DB_USER (default root)
+* TEST_DB_PASSWORD
+* TEST_DB_DATABASE (default ‘testp’)
+* TEST_DB_HOST (default ‘localhost’)
+* TEST_DB_PORT (default 3306)
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/license.md
+++ b/connectors/mariadb-connector-python/license.md
@@ -6,16 +6,14 @@
 
 ## MariaDB Connector/Python documentation
 
-> The documentation for MariaDB Connector/Python at [https://mariadb-corporation.github.io/mariadb-connector-python/](https://mariadb-corporation.github.io/mariadb-connector-python/) is covered by the [Creative Commons Attribution 3.0 license](https://creativecommons.org/licenses/by/3.0/legalcode).
+> The documentation for MariaDB Connector/Python is covered by the [Creative Commons Attribution 3.0 license](https://creativecommons.org/licenses/by/3.0/legalcode).
 
-> You are **free**, to : - Share, copy and redistribute the material in any medium or format
->
-> * Adapt, remix, transform, and build upon the material for any purpose, even commercially.
+> You are **free**, to
+> : - Share, copy and redistribute the material in any medium or format
+>   - Adapt, remix, transform, and build upon the material for any purpose, even commercially.
 
-> under the following **terms** : - Attribution – You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
->
-> * No additional restrictions —- You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+> under the following **terms**
+> : - Attribution – You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+>   - No additional restrictions —- You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/module.md
+++ b/connectors/mariadb-connector-python/module.md
@@ -1,6 +1,12 @@
 # The MariaDB Connector/Python module
 
-MariaDB Connector/Python module enables python programs to access MariaDB and MySQL databases, using an API which is compliant with the Python DB API 2.0 (PEP-249).
+<a id="module"></a>
+
+<a id="module-mariadb"></a>
+
+MariaDB Connector/Python module enables python programs to access MariaDB and
+MySQL databases, using an API which is compliant with the Python DB API 2.0
+(PEP-249).
 
 ## Constructors
 
@@ -10,42 +16,44 @@ MariaDB Connector/Python module enables python programs to access MariaDB and My
 
 Creates a MariaDB Connection object.
 
-By default, the standard connectionclass mariadb.connections.Connection will be created.
+By default, the standard connectionclass mariadb.connections.Connection
+will be created.
 
-Parameter connectionclass specifies a subclass of mariadb.Connection object. If not specified, default will be used. This optional parameter was added in version 1.1.0.
+Parameter connectionclass specifies a subclass of
+mariadb.Connection object. If not specified, default will be used.
+This optional parameter was added in version 1.1.0.
 
 Connection parameters are provided as a set of keyword arguments:
 
-* **\`host\`** - The host name or IP address of the database server. If MariaDB Connector/Python was built with MariaDB Connector/C 3.3, it is also possible to provide a comma separated list of hosts for simple fail over in case of one or more hosts are not available.
-* **\`user\`, \`username\`** - The username used to authenticate with the database server
-* **\`password\`, \`passwd\`** - The password of the given user
-* **\`database\`, \`db\`** - Database (schema) name to use when connecting with the database server
-* **\`unix\_socket\`** - The location of the unix socket file to use instead of using an IP port to connect. If socket authentication is enabled, this can also be used in place of a password.
-* **\`port\`** - Port number of the database server. If not specified, the default value of 3306 will be used.
-* **\`connect\_timeout\`** - Connect timeout in seconds
-* **\`read\_timeout\`** - Read timeout in seconds
-* **\`write\_timeout\`** - Write timeout in seconds
-* **\`local\_infile\`** - Enables or disables the use of LOAD DATA LOCAL INFILE statements.
-* **\`compress\`** (default: False) - Uses the compressed protocol for client server communication. If the server doesn’t support compressed protocol, the default protocol will be used.
-* **\`init\_command\`** - Command(s) which will be executed when connecting and reconnecting to the database server
-* **\`default\_file\`** - Read options from the specified option file. If the file is an empty string, default configuration file(s) will be used
-* **\`default\_group\`** - Read options from the specified group
-* **\`plugin\_dir\`** - Directory which contains MariaDB client plugins.
-* **\`reconnect\`** - Enables or disables automatic reconnect. Available since version 1.1.4
-* **\`ssl\_key\`** - Defines a path to a private key file to use for TLS. This option requires that you use the absolute path, not a relative path. The specified key must be in PEM format
-* **\`ssl\_cert\`** - Defines a path to the X509 certificate file to use for TLS. This option requires that you use the absolute path, not a relative path. The X609 certificate must be in PEM format.
-* **\`ssl\_ca\`** - Defines a path to a PEM file that should contain one or more X509 certificates for trusted Certificate Authorities (CAs) to use for TLS. This option requires that you use the absolute path, not a relative path.
-* **\`ssl\_capath\`** - Defines a path to a directory that contains one or more PEM files that contains one X509 certificate for a trusted Certificate Authority (CA)
-* **\`ssl\_cipher\`** - Defines a list of permitted cipher suites to use for TLS
-* **\`ssl\_crlpath\`** - Defines a path to a PEM file that should contain one or more revoked X509 certificates to use for TLS. This option requires that you use the absolute path, not a relative path.
-* **\`ssl\_verify\_cert\`** - Enables server certificate verification.
-* **\`ssl\`** - The connection must use TLS security, or it will fail.
-* **\`tls\_version\`** - A comma-separated list (without whitespaces) of TLS versions. Valid versions are TLSv1.0, TLSv1.1,TLSv1.2 and TLSv1.3. Added in version 1.1.7.
-* **\`autocommit\`** (default: False) - Specifies the autocommit settings. True will enable autocommit, False will disable it (default).
-* **\`converter\`** - Specifies a conversion dictionary, where keys are FIELD\_TYPE values and values are conversion functions
+- **\`host\`** - The host name or IP address of the database server. If MariaDB Connector/Python was built with MariaDB Connector/C 3.3, it is also possible to provide a comma separated list of hosts for simple fail over in case of one or more hosts are not available.
+- **\`user\`, \`username\`** - The username used to authenticate with the database server
+- **\`password\`, \`passwd\`** - The password of the given user
+- **\`database\`, \`db\`** - Database (schema) name to use when connecting with the database server
+- **\`unix_socket\`** - The location of the unix socket file to use instead of using an IP port to connect. If socket authentication is enabled, this can also be used in place of a password.
+- **\`port\`** - Port number of the database server. If not specified, the default value of 3306 will be used.
+- **\`connect_timeout\`** - Connect timeout in seconds
+- **\`read_timeout\`** - Read timeout in seconds
+- **\`write_timeout\`** - Write timeout in seconds
+- **\`local_infile\`** - Enables or disables the use of LOAD DATA LOCAL INFILE statements.
+- **\`compress\`** (default: False) - Uses the compressed protocol for client server communication. If the server doesn’t support compressed protocol, the default protocol will be used.
+- **\`init_command\`** - Command(s) which will be executed when connecting and reconnecting to the database server
+- **\`default_file\`** - Read options from the specified option file. If the file is an empty string, default configuration file(s) will be used
+- **\`default_group\`** - Read options from the specified group
+- **\`plugin_dir\`** - Directory which contains MariaDB client plugins.
+- **\`reconnect\`** - Enables or disables automatic reconnect. Available since version 1.1.4
+- **\`ssl_key\`** - Defines a path to a private key file to use for TLS. This option requires that you use the absolute path, not a relative path. The specified key must be in PEM format
+- **\`ssl_cert\`** - Defines a path to the X509 certificate file to use for TLS. This option requires that you use the absolute path, not a relative path. The X609 certificate must be in PEM format.
+- **\`ssl_ca\`** - Defines a path to a PEM file that should contain one or more X509 certificates for trusted Certificate Authorities (CAs) to use for TLS. This option requires that you use the absolute path, not a relative path.
+- **\`ssl_capath\`** - Defines a path to a directory that contains one or more PEM files that contains one X509 certificate for a trusted Certificate Authority (CA)
+- **\`ssl_cipher\`** - Defines a list of permitted cipher suites to use for TLS
+- **\`ssl_crlpath\`** - Defines a path to a PEM file that should contain one or more revoked X509 certificates to use for TLS. This option requires that you use the absolute path, not a relative path.
+- **\`ssl_verify_cert\`** - Enables server certificate verification.
+- **\`ssl\`** - The connection must use TLS security, or it will fail.
+- **\`tls_version\`** - A comma-separated list (without whitespaces) of TLS versions. Valid versions are TLSv1.0, TLSv1.1,TLSv1.2 and TLSv1.3. Added in version 1.1.7.
+- **\`autocommit\`** (default: False) - Specifies the autocommit settings. True will enable autocommit, False will disable it (default).
+- **\`converter\`** - Specifies a conversion dictionary, where keys are FIELD_TYPE values and values are conversion functions
 
 #### NOTE
-
 For a description of configuration file handling and settings please read the chapter [Configuration files](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/config_files#configuration-options) of the MariaDB Connector/C documentation.
 
 Example:
@@ -69,17 +77,18 @@ utf8mb4
 
 Class defining a pool of database connections
 
-MariaDB Connector/Python supports simple connection pooling. A connection pool holds a number of open connections and handles thread safety when providing connections to threads.
+MariaDB Connector/Python supports simple connection pooling.
+A connection pool holds a number of open connections and handles thread safety when providing connections to threads.
 
 The size of a connection pool is configurable at creation time, but cannot be changed afterward. The maximum size of a connection pool is limited to 64 connections.
 
 Keyword Arguments:
 
-* **\`pool\_name\`** (`str`) - Name of connection pool
-* **\`pool\_size\`** (`int`) - Size of pool. The Maximum allowed number is 64. Default to 5
-* **\`pool\_reset\_connection\`** (`bool`) - Will reset the connection before returning it to the pool. Default to True.
-* **\`pool\_validation\_interval\`** (`int`) - Specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. A value of 0 means that the status will always be checked. Default to 500 (Added in version 1.1.6)
-* **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
+- **\`pool_name\`** (`str`) - Name of connection pool
+- **\`pool_size\`** (`int`) - Size of pool. The Maximum allowed number is 64. Default to 5
+- **\`pool_reset_connection\`** (`bool`) - Will reset the connection before returning it to the pool. Default to True.
+- **\`pool_validation_interval\`** (`int`) - Specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. A value of 0 means that the status will always be checked. Default to 500 (Added in version 1.1.6)
+- **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
 
 ### Type constructors
 
@@ -93,7 +102,10 @@ Constructs an object holding a date value.
 
 ### DateFromTicks(ticks)
 
-Constructs an object holding a date value from the given ticks value (number of seconds since the epoch). For more information see the documentation of the standard Python time module.
+Constructs an object holding a date value from the given ticks value
+(number of seconds since the epoch).
+For more information see the documentation of the standard Python
+time module.
 
 ### Time(hour, minute, second)
 
@@ -101,7 +113,10 @@ Constructs an object holding a time value.
 
 ### TimeFromTicks(ticks)
 
-Constructs an object holding a time value from the given ticks value (number of seconds since the epoch). For more information see the documentation of the standard Python time module.
+Constructs an object holding a time value from the given ticks value
+(number of seconds since the epoch).
+For more information see the documentation of the standard Python
+time module.
 
 ### Timestamp(year, month, day, hour, minute, second)
 
@@ -109,83 +124,100 @@ Constructs an object holding a datetime value.
 
 ### TimestampFromTicks(ticks)
 
-Constructs an object holding a datetime value from the given ticks value (number of seconds since the epoch). For more information see the documentation of the standard Python time module.
+Constructs an object holding a datetime value from the given ticks value
+(number of seconds since the epoch).
+For more information see the documentation of the standard Python
+time module.
 
 ## Attributes
 
 ### apilevel
 
-String constant stating the supported DB API level. The value for mariadb is `2.0`.
+String constant stating the supported DB API level. The value for mariadb is
+`2.0`.
 
 ### threadsafety
 
-Integer constant stating the level of thread safety. For mariadb the value is 1, which means threads can share the module but not the connection.
+Integer constant stating the level of thread safety. For mariadb the value is 1,
+which means threads can share the module but not the connection.
 
 ### paramstyle
 
-String constant stating the type of parameter marker. For mariadb the value is qmark. For compatibility reasons mariadb also supports the format and pyformat paramstyles with the limitation that they can’t be mixed inside a SQL statement.
+String constant stating the type of parameter marker. For mariadb the value is
+qmark. For compatibility reasons mariadb also supports the format and
+pyformat paramstyles with the limitation that they can’t be mixed inside a SQL statement.
 
-### mariadbapi\_version
+### mariadbapi_version
 
 String constant stating the version of the used MariaDB Connector/C library.
 
-### client\_version
+### client_version
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
-Returns the version of MariaDB Connector/C library in use as an integer. The number has the following format: MAJOR\_VERSION \* 10000 + MINOR\_VERSION \* 1000 + PATCH\_VERSION
+Returns the version of MariaDB Connector/C library in use as an integer.
+The number has the following format:
+MAJOR_VERSION \* 10000 + MINOR_VERSION \* 1000 + PATCH_VERSION
 
-### client\_version\_info
+### client_version_info
 
-_Since version 1.1.0_ Returns the version of MariaDB Connector/C library as a tuple in the following format: (MAJOR\_VERSION, MINOR\_VERSION, PATCH\_VERSION)
+*Since version 1.1.0*
+Returns the version of MariaDB Connector/C library as a tuple in the
+following format:
+(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
 ## Exceptions
 
-Compliant to DB API 2.0 MariaDB Connector/C provides information about errors through the following exceptions:
+Compliant to DB API 2.0 MariaDB Connector/C provides information about errors
+through the following exceptions:
 
-### _exception_ DataError
+### *exception* DataError
 
 Exception raised for errors that are due to problems with the processed data like division by zero, numeric value out of range, etc.
 
-### _exception_ DatabaseError
+### *exception* DatabaseError
 
 Exception raised for errors that are related to the database
 
-### _exception_ InterfaceError
+### *exception* InterfaceError
 
 Exception raised for errors that are related to the database interface rather than the database itself
 
-### _exception_ Warning
+### *exception* Warning
 
 Exception raised for important warnings like data truncations while inserting, etc
 
-### _exception_ PoolError
+### *exception* PoolError
 
 Exception raised for errors related to ConnectionPool class.
 
-### _exception_ OperationalError
+### *exception* OperationalError
 
 Exception raised for errors that are related to the database’s operation and not necessarily under the control of the programmer.
 
-### _exception_ IntegrityError
+### *exception* IntegrityError
 
 Exception raised when the relational integrity of the database is affected, e.g. a foreign key check fails
 
-### _exception_ InternalError
+### *exception* InternalError
 
 Exception raised when the database encounters an internal error, e.g. the cursor is not valid anymore
 
-### _exception_ ProgrammingError
+### *exception* ProgrammingError
 
 Exception raised for programming errors, e.g. table not found or already exists, syntax error in the SQL statement
 
-### _exception_ NotSupportedError
+### *exception* NotSupportedError
 
 Exception raised in case a method or database API was used which is not supported by the database
 
 ### Type objects
 
-MariaDB Connector/Python type objects are immutable sets for type settings and defined in DBAPI 2.0 (PEP-249).
+<!-- _Note: Type objects are handled as constants, therefore we can't
+use autodata. -->
+
+MariaDB Connector/Python type objects are immutable sets for type settings
+and defined in DBAPI 2.0 (PEP-249).
 
 Example:
 
@@ -208,11 +240,13 @@ False
 
 ### STRING
 
-This type object is used to describe columns in a database that are string-based (e.g. CHAR1).
+This type object is used to describe columns in a database that are
+string-based (e.g. CHAR1).
 
 ### BINARY
 
-This type object is used to describe (long) binary columns in a database (e.g. LONG, RAW, BLOBs).
+This type object is used to describe (long) binary columns in a database
+(e.g. LONG, RAW, BLOBs).
 
 ### NUMBER
 
@@ -224,8 +258,7 @@ This type object is used to describe date/time columns in a database.
 
 ### ROWID
 
-This type object is not supported in MariaDB Connector/Python and represents an empty set.
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
+This type object is not supported in MariaDB Connector/Python and represents
+an empty set.
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/pool.md
+++ b/connectors/mariadb-connector-python/pool.md
@@ -1,63 +1,66 @@
 # The ConnectionPool class
 
-### _class_ ConnectionPool(\*args, \*\*kwargs)
+### *class* ConnectionPool(\*args, \*\*kwargs)
 
 Class defining a pool of database connections
 
-MariaDB Connector/Python supports simple connection pooling. A connection pool holds a number of open connections and handles thread safety when providing connections to threads.
+MariaDB Connector/Python supports simple connection pooling.
+A connection pool holds a number of open connections and handles thread safety when providing connections to threads.
 
 The size of a connection pool is configurable at creation time, but cannot be changed afterward. The maximum size of a connection pool is limited to 64 connections.
 
 Keyword Arguments:
 
-* **\`pool\_name\`** (`str`) - Name of connection pool
-* **\`pool\_size\`** (`int`) - Size of pool. The Maximum allowed number is 64. Default to 5
-* **\`pool\_reset\_connection\`** (`bool`) - Will reset the connection before returning it to the pool. Default to True.
-* **\`pool\_validation\_interval\`** (`int`) - Specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. A value of 0 means that the status will always be checked. Default to 500 (Added in version 1.1.6)
-* **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
+- **\`pool_name\`** (`str`) - Name of connection pool
+- **\`pool_size\`** (`int`) - Size of pool. The Maximum allowed number is 64. Default to 5
+- **\`pool_reset_connection\`** (`bool`) - Will reset the connection before returning it to the pool. Default to True.
+- **\`pool_validation_interval\`** (`int`) - Specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. A value of 0 means that the status will always be checked. Default to 500 (Added in version 1.1.6)
+- **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
 
 ## ConnectionPool methods
 
-#### ConnectionPool.add\_connection(connection=None)
+#### ConnectionPool.add_connection(connection=None)
 
 Adds a connection object to the connection pool.
 
-In case that the pool doesn’t have a free slot or is not configured, a PoolError exception will be raised.
+In case that the pool doesn’t have a free slot or is not configured,
+a PoolError exception will be raised.
 
 #### ConnectionPool.close()
 
 Closes connection pool and all connections.
 
-#### ConnectionPool.get\_connection()
+#### ConnectionPool.get_connection()
 
-Returns a connection from the connection pool or raises a PoolError exception if a connection is not available.
+Returns a connection from the connection pool or raises a PoolError
+exception if a connection is not available.
 
-#### ConnectionPool.set\_config(\*\*kwargs)
+#### ConnectionPool.set_config(\*\*kwargs)
 
-Sets the connection configuration for the connection pool. For valid connection arguments, check the mariadb.connect() method.
+Sets the connection configuration for the connection pool.
+For valid connection arguments, check the mariadb.connect() method.
 
-Note: This method doesn’t create connections in the pool. To fill the pool, one has to use add\_connection() ḿethod.
+Note: This method doesn’t create connections in the pool.
+To fill the pool, one has to use add_connection() ḿethod.
 
 ## ConnectionPool attributes
 
-#### ConnectionPool.connection\_count
+#### ConnectionPool.connection_count
 
 Returns the number of connections in connection pool.
 
-_Since version 1.1.0_
+*Since version 1.1.0*
 
-#### ConnectionPool.max\_size
+#### ConnectionPool.max_size
 
 Returns the maximum size for connection pools.
 
-#### ConnectionPool.pool\_size
+#### ConnectionPool.pool_size
 
 Returns the size of the connection pool.
 
-#### ConnectionPool.pool\_name
+#### ConnectionPool.pool_name
 
 Returns the name of the connection pool.
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/pooling.md
+++ b/connectors/mariadb-connector-python/pooling.md
@@ -1,8 +1,11 @@
-# Connection Pooling
+# Connection pooling
 
-A connection pool is a cache of connections to a database server where connections can be reused for future requests. Since establishing a connection is resource-expensive and time-consuming, especially when used inside a middle tier environment which maintains multiple connections and requires connections to be immediately available on the fly.
+A connection pool is a cache of connections to a database server where connections can be reused for future requests.
+Since establishing a connection is resource-expensive and time-consuming, especially when used inside a middle tier
+environment which maintains multiple connections and requires connections to be immediately available on the fly.
 
-Especially for server-side web applications, a connection pool is the standard way to maintain a pool of database connections which are reused across requests.
+Especially for server-side web applications, a connection pool is the standard way to maintain a pool of database connections
+which are reused across requests.
 
 ## Configuring and using a connection pool
 
@@ -19,16 +22,16 @@ When creating a connection pool, the following parameters have to be provided:
 
 1. Connection pool specific parameters
 
-* **\`pool\_name\`**: The name of the pool, if not specified MariaDB Connector/Python will raise an exception.
-* **\`pool\_size\`**: The size of the pool, if not specified a default of 5 will be set.
-* **\`pool\_reset\_session\`**: If set to True, the connection will be reset before returned to the pool
-* **\`pool\_invalidation\_interval\`**: specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. The default values is 500 milliseconds, a value of 0 means that the status will always be checked. Since 1.1.0
+- **\`pool_name\`**: The name of the pool, if not specified MariaDB Connector/Python will raise an exception.
+- **\`pool_size\`**: The size of the pool, if not specified a default of 5 will be set.
+- **\`pool_reset_session\`**: If set to True, the connection will be reset before returned to the pool
+- **\`pool_invalidation_interval\`**: specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. The default values is 500 milliseconds, a value of 0 means that the status will always be checked. Since 1.1.0
 
 1. Connection parameters
 
-* In addition to the connection pool specific parameters initialization method of ConnectionPool Class accepts the same parameters as the connect() method of mariadb module.
+- In addition to the connection pool specific parameters initialization method of ConnectionPool Class accepts the same parameters as the connect() method of mariadb module.
 
-_Example_:
+*Example*:
 
 ```python
 import mariadb
@@ -51,13 +54,11 @@ with mariadb.ConnectionPool(pool_name="myfirstpool", pool_size=5, **conn_params)
         print("Current database: %s" % conn.database)
 ```
 
-_Output_:
+*Output*:
 
 ```none
 Pool size of 'myfirstpool': 5
 Current database: test
 ```
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-python/usage.md
+++ b/connectors/mariadb-connector-python/usage.md
@@ -1,11 +1,34 @@
-# Basic Usage
+# Basic usage
 
 ## Connecting
 
-The basic usage of MariaDB Connector/Python is similar to other database drivers which implement DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)).
+The basic usage of MariaDB Connector/Python is similar to other database drivers which
+implement DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)).
 
 Below is a simple example of a typical use of MariaDB Connector/Python
 
+<!-- import mariadb
+
+# connection parameters
+conn_params= {
+   "user" : "example_user",
+   "password" : "GHbe_Su3B8",
+   "host" : "localhost",
+   "database" : "test"
+}
+
+# Establish a connection
+with mariadb.connect(**conn_params) as conn:
+   with conn.cursor() as cursor:
+      cursor.execute("CREATE OR REPLACE TABLE `countries` ("
+                "`id` int(10) unsigned NOT NULL AUTO_INCREMENT,"
+                "`name` varchar(50) NOT NULL,"
+                "`country_code` char(3) NOT NULL,"
+                "`capital` varchar(50) DEFAULT NULL,"
+                "PRIMARY KEY (`id`),"
+                "KEY `name` (`name`),"
+                "KEY `capital` (`capital`)"
+                ") ENGINE=InnoDB DEFAULT CHARSET=latin1") -->
 ```python
 import mariadb
 
@@ -32,19 +55,26 @@ with mariadb.connect(**conn_params) as conn:
         print(*row, sep=' ')
 ```
 
-_Output_:
+*Output*:
 
 ```none
 Germany GER Berlin
 ```
 
-Before MariaDB Connector/Python can be used, the MariaDB Connector/Python module must be imported. Once the mariadb module is loaded, a connection to a database server will be established using the method [`connect()`](module.md#mariadb.connect).
+Before MariaDB Connector/Python can be used, the MariaDB Connector/Python module must be
+imported.
+Once the mariadb module is loaded, a connection to a database server will be established
+using the method [`connect()`](module.md#mariadb.connect).
 
-In order to be able to communicate with the database server in the form of SQL statements, a cursor object must be created first.
+In order to be able to communicate with the database server in the form of SQL statements,
+a cursor object must be created first.
 
-The method name cursor may be a little misleading: unlike a cursor in MariaDB that can only read and return data, a cursor in Python can be used for all types of SQL statements.
+The method name cursor may be a little misleading: unlike a cursor in MariaDB that can only
+read and return data, a cursor in Python can be used for all types of SQL statements.
 
-After creating the table mytest, everything is ready to insert some data: Column values that are to be inserted in the database are identified by place holders, the data is then passed in the form of a tuple as a second parameter.
+After creating the table mytest, everything is ready to insert some data: Column values
+that are to be inserted in the database are identified by place holders, the data is then passed in
+the form of a tuple as a second parameter.
 
 After creating and populating the table mytest the cursor will be used to retrieve the data.
 
@@ -52,7 +82,9 @@ At the end we free resources and close cursor and connection.
 
 ## Passing parameters to SQL statements
 
-As shown in previous example, passing parameters to SQL statements happens by using placeholders in the statement. By default MariaDB Connector/Python uses a question mark as a placeholder, for compatibility reason also %s placeholders are supported. Passing parameters is supported in methods `execute()` and `executemany()` of the cursor class.
+As shown in previous example, passing parameters to SQL statements happens by using placeholders in the statement. By default
+MariaDB Connector/Python uses a question mark as a placeholder, for compatibility reason also %s placeholders are supported.
+Passing parameters is supported in methods `execute()` and `executemany()` of the cursor class.
 
 Since MariaDB Connector/Python uses binary protocol, escaping strings or binary data like in other database drivers is not required.
 
@@ -84,7 +116,8 @@ with mariadb.connect(**conn_params) as conn:
         conn.commit()
 ```
 
-Often there is a requirement to update, delete or insert multiple records. This could be done be using `execute()` in a loop, but much more effective is using the `executemany()` method, especially when using a MariaDB database server 10.2 and above, which supports a special “bulk” protocol. The executemany() works similar to execute(), but accepts data as a list of tuples:
+Often there is a requirement to update, delete or insert multiple records. This could be done be using `execute()` in
+a loop, but much more effective is using the `executemany()` method, especially when using a MariaDB database server 10.2 and above, which supports a special “bulk” protocol. The executemany() works similar to execute(), but accepts data as a list of tuples:
 
 ```python
 import mariadb
@@ -137,9 +170,8 @@ with mariadb.connect(**conn_params) as connection:
 ```
 
 When using executemany(), there are a few restrictions:
-
-* All tuples must have the same types as in first tuple. E.g. the parameter \[(1),(1.0)] or \[(1),(None)] are invalid.
-* Special values like None or column default value needs to be indicated by an indicator.
+- All tuples must have the same types as in first tuple. E.g. the parameter [(1),(1.0)] or [(1),(None)] are invalid.
+- Special values like None or column default value needs to be indicated by an indicator.
 
 ### Using indicators
 
@@ -170,13 +202,12 @@ with mariadb.connect(**conn_params) as connection:
         cursor.executemany(sql, data)
 ```
 
-Beside the default indicator which inserts the default value of 1.99, the following indicators are supported: : \* INDICATOR.IGNORE: Ignores the value (only update commands)
-
-* INDICATOR.NULL: Value is NULL
-* INDICATOR.IGNORE\_ROW: Don’t update or insert row
+Beside the default indicator which inserts the default value of 1.99, the following indicators are supported:
+: * INDICATOR.IGNORE: Ignores the value (only update commands)
+  * INDICATOR.NULL: Value is NULL
+  * INDICATOR.IGNORE_ROW: Don’t update or insert row
 
 #### NOTE
-
 * Mixing different parameter styles is not supported and will raise an exception
 * The Python string operator % must not be used. The `execute()` method accepts a tuple or list as second parameter.
 * Placeholders between quotation marks are interpreted as a string.
@@ -190,7 +221,7 @@ Several standard python types are converted into SQL types and returned as Pytho
 #### Supported Data Types
 
 | Python type      | SQL type                             |
-| ---------------- | ------------------------------------ |
+|------------------|--------------------------------------|
 | None             | NULL                                 |
 | Bool             | TINYINT                              |
 | Float, Double    | DOUBLE                               |
@@ -202,7 +233,5 @@ Several standard python types are converted into SQL types and returned as Pytho
 | Date             | DATE                                 |
 | Time             | TIME                                 |
 | Timestamp        | TIMESTAMP                            |
-
-<sub>_This page is_</sub> [<sub>_covered_</sub>](license.md) <sub>_by the_</sub> [<sub>_Creative Commons Attribution 3.0 license_</sub>](https://creativecommons.org/licenses/by/3.0/legalcode)<sub>_._</sub>
 
 {% @marketo/form formId="4316" %}


### PR DESCRIPTION
This PR automatically updates the documentation subdirectory with the latest Sphinx-generated markdown from [mariadb-corporation/mariadb-connector-python](https://github.com/mariadb-corporation/mariadb-connector-python).
**Changes:**
- Updated documentation generated from commit 0e766904b5612d15b826c55b5a4be44b1f009982
- Generated on: 18413631232