### PR TITLE
Fix typo in maximum length of text data type

### DIFF
--- a/server/reference/data-types/string-data-types/blob.md
+++ b/server/reference/data-types/string-data-types/blob.md
@@ -8,7 +8,7 @@ BLOB[(M)]
 
 ## Description
 
-A `BLOB` column with a maximum length of `65,535` (`216 - 1`) bytes. Each`BLOB` value is stored using a two-byte length prefix that indicates the number of bytes in the value.
+A `BLOB` column with a maximum length of 65,535 (2¹⁶ - 1) bytes. Each `BLOB` value is stored using a two-byte length prefix that indicates the number of bytes in the value.
 
 An optional length `M` can be given for this type. If this is done, MariaDB creates the column as the smallest `BLOB` type large enough to hold values _`M`_ bytes long.
 

--- a/server/reference/data-types/string-data-types/longblob.md
+++ b/server/reference/data-types/string-data-types/longblob.md
@@ -8,7 +8,7 @@ LONGBLOB
 
 ## Description
 
-A [BLOB](blob.md) column with a maximum length of 4,294,967,295 bytes (232<sup>-1</sup>), or 4GB. The effective maximum length of `LONGBLOB` columns depends on the configured maximum packet size in the client/server protocol and available memory. Each `LONGBLOB` value is stored using a four-byte length prefix that indicates the number of bytes in the value.
+A [BLOB](blob.md) column with a maximum length of 4,294,967,295 bytes (2³² - 1), or 4GB. The effective maximum length of `LONGBLOB` columns depends on the configured maximum packet size in the client/server protocol and available memory. Each `LONGBLOB` value is stored using a four-byte length prefix that indicates the number of bytes in the value.
 
 ### Oracle Mode
 

--- a/server/reference/data-types/string-data-types/longtext.md
+++ b/server/reference/data-types/string-data-types/longtext.md
@@ -8,7 +8,7 @@ LONGTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ## Description
 
-A [TEXT](text.md) column with a maximum length of 4,294,967,295 or 4GB (`232 - 1`) characters. The effective maximum length is less if the value contains multi-byte characters. The effective maximum length of `LONGTEXT` columns also depends on the configured maximum packet size in the client/server protocol and available memory. Each `LONGTEXT` value is stored using a four-byte length prefix that indicates the number of bytes in the value.
+A [TEXT](text.md) column with a maximum length of 4,294,967,295 or 4GB (2³² - 1) characters. The effective maximum length is less if the value contains multi-byte characters. The effective maximum length of `LONGTEXT` columns also depends on the configured maximum packet size in the client/server protocol and available memory. Each `LONGTEXT` value is stored using a four-byte length prefix that indicates the number of bytes in the value.
 
 `JSON` is an alias for `LONGTEXT`. See [JSON Data Type](json.md) for details.
 

--- a/server/reference/data-types/string-data-types/mediumblob.md
+++ b/server/reference/data-types/string-data-types/mediumblob.md
@@ -8,7 +8,7 @@ MEDIUMBLOB
 
 ## Description
 
-A [BLOB](blob.md) column with a maximum length of 16,777,215 (224 - 1) bytes. Each `MEDIUMBLOB` value is stored using a three-byte length prefix that indicates the number of bytes in the value.
+A [BLOB](blob.md) column with a maximum length of 16,777,215 (2²⁴ - 1) bytes. Each `MEDIUMBLOB` value is stored using a three-byte length prefix that indicates the number of bytes in the value.
 
 `LONG VARBINARY` is a synonym for `MEDIUMBLOB` .
 

--- a/server/reference/data-types/string-data-types/mediumtext.md
+++ b/server/reference/data-types/string-data-types/mediumtext.md
@@ -8,7 +8,7 @@ MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ## Description
 
-A [TEXT](text.md) column with a maximum length of 16,777,215 (`224 - 1`) characters. The effective maximum length is less if the value contains multi-byte characters. Each `MEDIUMTEXT` value is stored using\
+A [TEXT](text.md) column with a maximum length of 16,777,215 (2²⁴ - 1) characters. The effective maximum length is less if the value contains multi-byte characters. Each `MEDIUMTEXT` value is stored using\
 a three-byte length prefix that indicates the number of bytes in the value.
 
 ### SYNONYMS

--- a/server/reference/data-types/string-data-types/text.md
+++ b/server/reference/data-types/string-data-types/text.md
@@ -8,7 +8,7 @@ TEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ## Description
 
-A `TEXT` column with a maximum length of `65,535` (`2^16 - 1`) characters. The effective maximum length is less if the value contains multi-byte characters. Each `TEXT` value is stored using a two-byte length prefix that indicates the number of bytes in the value. If you need a bigger storage, consider using [MEDIUMTEXT](mediumtext.md) instead.
+A `TEXT` column with a maximum length of 65,535 (2¹⁶ - 1) characters. The effective maximum length is less if the value contains multi-byte characters. Each `TEXT` value is stored using a two-byte length prefix that indicates the number of bytes in the value. If you need a bigger storage, consider using [MEDIUMTEXT](mediumtext.md) instead.
 
 An optional length `M` can be given for this type. If this is done, MariaDB creates the column as the smallest `TEXT` type large enough to hold values`M` characters long.
 

--- a/server/reference/data-types/string-data-types/tinyblob.md
+++ b/server/reference/data-types/string-data-types/tinyblob.md
@@ -8,7 +8,7 @@ TINYBLOB
 
 ## Description
 
-A [BLOB](blob.md) column with a maximum length of 255 (28 - 1) bytes. Each `TINYBLOB` value is stored using a one-byte length prefix that indicates the number of bytes in the value.
+A [BLOB](blob.md) column with a maximum length of 255 (2⁸ - 1) bytes. Each `TINYBLOB` value is stored using a one-byte length prefix that indicates the number of bytes in the value.
 
 ## EXAMPLES
 

--- a/server/reference/data-types/string-data-types/tinytext.md
+++ b/server/reference/data-types/string-data-types/tinytext.md
@@ -8,7 +8,7 @@ TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ## Description
 
-A [TEXT](text.md) column with a maximum length of 255 (`2⁸ - 1`) characters. The effective maximum length is less if the value contains multi-byte characters. Each `TINYTEXT` value is stored using a one-byte length prefix that indicates the number of bytes in the value.
+A [TEXT](text.md) column with a maximum length of 255 (2⁸ - 1) characters. The effective maximum length is less if the value contains multi-byte characters. Each `TINYTEXT` value is stored using a one-byte length prefix that indicates the number of bytes in the value.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Fixes a small typo in the docs for the TEXT data type