### PR TITLE
Correct SQL query for generating RENAME TABLE statements

### DIFF
--- a/server/reference/sql-statements/data-definition/renaming-databases.md
+++ b/server/reference/sql-statements/data-definition/renaming-databases.md
@@ -49,7 +49,7 @@ Run the following query to generate a script with the necessary `RENAME TABLE` s
 
 ```sql
 mysql -ss -e"SELECT CONCAT('RENAME TABLE PROD.', TABLE_NAME, ' TO TEST.', \
-TABLE_NAME, ';'FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PROD'" \
+TABLE_NAME, ';') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PROD'" \
 > PROD_rename_table.sql
 ```
 {% endstep %}


### PR DESCRIPTION
Fix SQL syntax in the RENAME TABLE script example.

Also I noticed the example are still using the `mysql` binary instead of `mariadb`. But that should be in another PR.