### PR TITLE
Fix RANGE COLUMNS row matching criterion

### DIFF
--- a/server/server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md
@@ -45,7 +45,7 @@ To determine which partition should contain a row, all specified columns are com
 
 With `LIST COLUMNS`, a row matches a partition if all row values are identical to the specified values. At most one partition can match the row.
 
-With `RANGE COLUMNS`, a row matches a partition if all row values are less than the specified values. The first partition that matches the row values are used.
+With `RANGE COLUMNS`, a row matches a partition if it is less than the specified value tuple in lexicographic order. The first partition that matches the row values are used.
 
 The `DEFAULT` partition catches all records which do not fit in other partitions. Only one `DEFAULT` partition is allowed.
 


### PR DESCRIPTION
For example:

create table t1 (c1 int, c2 int) partition by range columns (c1, c2) (
partition p0 values less than (1, 2),
partition p1 values less than (2, 1)
);
insert into t1 values (0, 1), (1, 0), (1, 1), (1, 2); select * from t1 partition (p0);
c1	c2
0	1
1	0
1	1
select * from t1 partition (p1);
c1	c2
1	2
drop table t1;