### PR TITLE
Fix the documented lock type acquired by `LOCK IN SHARE MODE` in `lock-in-share-mode.md`.

### DIFF
--- a/server/reference/sql-statements/data-manipulation/selecting-data/lock-in-share-mode.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/lock-in-share-mode.md
@@ -8,7 +8,7 @@ description: >-
 
 InnoDB supports row-level locking. Selected rows can be locked using `LOCK IN SHARE MODE` or [FOR UPDATE](for-update.md). In both cases, a lock is acquired on the rows read by the query, and it will be released when the current transaction is committed.
 
-When `LOCK IN SHARE MODE` is specified in a [SELECT](select.md) statement, MariaDB will wait until all transactions that have modified the rows are committed. Then, a write lock is acquired. All transactions can read the rows, but if they want to modify them, they have to wait until your transaction is committed.
+When `LOCK IN SHARE MODE` is specified in a [SELECT](select.md) statement, MariaDB will wait until all transactions that have modified the rows are committed. Then, a read lock is acquired. All transactions can read the rows, but if they want to modify them, they have to wait until your transaction is committed.
 
 InnoDB locks index records rather than logical rows. If a `SELECT` is satisfied by a secondary index (a covering index read), it just locks that index. Instead, the primary key records will be locked if a concurrent `UPDATE` modifies columns outside of that index. These locks do not overlap under `READ COMMITTED` isolation level, so the update can proceed. To ensure a block is used, the `SELECT` query must reference columns from the primary index.
 


### PR DESCRIPTION
In `lock-in-share-mode.md`, it mentions that `LOCK IN SHARE MODE` acquires a write lock. However, it seems like this is wrong as it allows parallel read and block writers, so it should either be a "shared" lock or a "read" lock.