### PR TITLE
Enhance DATE_ADD function documentation

### DIFF
--- a/server/reference/sql-functions/date-time-functions/date_add.md
+++ b/server/reference/sql-functions/date-time-functions/date_add.md
@@ -14,7 +14,16 @@ DATE_ADD(date,INTERVAL expr unit)
 
 ## Description
 
-Performs date arithmetic. The _date_ argument specifies the starting date or datetime value. _expr_ is an expression specifying the interval value to be added to the starting date. _expr_ is a string; it may start with a "`-`" for negative intervals. _unit_ is a keyword indicating the units in which the expression should be interpreted. See [Date and Time Units](date-and-time-units.md) for a complete list of permitted units.
+Performs date arithmetic. The _date_ argument specifies the starting date or datetime value. _expr_ is an expression specifying the interval value to be added to the starting date. _expr_ is a string; it may start with a "`-`" for negative intervals. For composite interval units (such as DAY_HOUR, MINUTE_SECOND, and SECOND_MICROSECOND), 
+_expr_ can contain multiple components separated by spaces or punctuation. For example:
+
+- '1 10' DAY_HOUR represents 1 day and 10 hours  
+- '1:1' MINUTE_SECOND represents 1 minute and 1 second  
+- '1.999999' SECOND_MICROSECOND represents seconds and microseconds  
+
+The exact format of _expr_ depends on the _unit_ specified.
+
+_unit_ is a keyword indicating the units in which the expression should be interpreted. See [Date and Time Units](date-and-time-units.md) for a complete list of permitted units.
 
 The result type of `DATE_ADD()` is determined as follows:
 


### PR DESCRIPTION
## Summary
This PR improves the documentation for DATE_ADD() by clarifying the format of the `expr` argument when used with composite interval units.

## Problem
The current documentation defines the syntax as:

  DATE_ADD(date, INTERVAL expr unit)

However, it does not clearly explain how `expr` should be formatted for composite units such as DAY_HOUR, MINUTE_SECOND, and SECOND_MICROSECOND.

Examples in the documentation already demonstrate usage like:
- INTERVAL '1 10' DAY_HOUR
- INTERVAL '1:1' MINUTE_SECOND
- INTERVAL '1.999999' SECOND_MICROSECOND

But the syntax/description section does not explain these formats, which can confuse users.

## Solution
Added clarification in the description section to explain:
- `expr` can be a composite string depending on the unit
- The format varies based on the unit
- Examples of valid formats for composite units

## Changes Made
Updated the description of `expr` in DATE_ADD() documentation to include:
- Support for multi-component interval values
- Explanation of formatting for composite units
- Examples aligned with existing usage

## Impact
- Improves clarity and consistency between syntax and examples
- Helps users better understand interval formats
- No functional/code changes (documentation only)

## Jira Issue
MDEV-39039