### PR TITLE
feat: add documentation for MARIADB_USER_HOST

### DIFF
--- a/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/mariadb-server-docker-official-image-environment-variables.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/mariadb-server-docker-official-image-environment-variables.md
@@ -37,7 +37,7 @@ Define a non-empty value, such as "yes," to auto-generate a random initial passw
 
 ### `MARIADB_USER_HOST`
 
-`%` is the default hostname part of the user created with `MYSQL_USER / MARIADB_USER` in MariaDB. This can be changed to any valid hostname or IP. Setting it to `localhost` restricts user access to only the local machine via the Unix socket.
+`%` is the default hostname part of the user created through `MYSQL_USER / MARIADB_USER` in MariaDB. This can be changed to any valid hostname or IP. Setting it to `localhost` restricts user access to only the local machine via the Unix socket.
 
 ### `MARIADB_DATABASE / MYSQL_DATABASE`
 


### PR DESCRIPTION
Add the documentation for the upcoming new env variable MARIADB_USER_HOST

This variable is intended to setup on init a hostname/IP/IP range for the user created through MYSQL_USER / MARIADB_USER on init

Relate to https://github.com/MariaDB/mariadb-docker/pull/680
