### PR TITLE
Update mysql_thread_id.md to remove outdated note

### DIFF
--- a/connectors/mariadb-connector-c/api-functions/mysql_thread_id.md
+++ b/connectors/mariadb-connector-c/api-functions/mysql_thread_id.md
@@ -16,9 +16,6 @@ The `mysql_thread_id()` function returns the thread id for the current connectio
 The current connection can be killed with [mysql\_kill()](mysql_kill.md). If reconnect option is enabled the thread id might change if the client reconnects to the server.
 {% endhint %}
 
-{% hint style="info" %}
-Note that connector will return only the first 32connectionsbits value. If your database might expect to create more than 4.3 billion connections without a restart, it's better to query 'select `CONNECTION_ID()`'
-{% endhint %}
 
 ## See also
 


### PR DESCRIPTION
Removed note about connection bits limitation and alternative query. thread_id is always within 4 bytes, since 10.2 https://jira.mariadb.org/browse/MDEV-15089