### PR TITLE
Add missing 'up -d' to docker compose command in MariaDB AI RAG deployment docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.wordWrap": "on"
+  "editor.wordWrap": "on",
+  "editor.formatOnSave": false
 }

--- a/tools/mariadb-ai-rag/deployment/overview.md
+++ b/tools/mariadb-ai-rag/deployment/overview.md
@@ -178,7 +178,7 @@ Run the following command to start the service
 
 {% code title="" overflow="wrap" %}
 ```bash
-docker compose -f docker-compose.dockerhub-dev.yml --env-file config.env.secure 
+docker compose -f docker-compose.dockerhub-dev.yml --env-file config.env.secure up -d
 ```
 {% endcode %}
 {% endstep %}


### PR DESCRIPTION
- User receives docker cli usage error if not include `up -d` as part of the `docker compose` command
- Also disable formatOnSave due to prettier auto-formatting .md