### PR TITLE
myisam_mmap_size is global only

### DIFF
--- a/server/server-usage/storage-engines/myisam-storage-engine/myisam-system-variables.md
+++ b/server/server-usage/storage-engines/myisam-storage-engine/myisam-system-variables.md
@@ -110,7 +110,7 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 * Description: Maximum memory in bytes that can be used for memory mapping compressed MyISAM files. Too high a value may result in swapping if there are many compressed MyISAM tables.
 * Command line: `--myisam-mmap-size=#`
-* Scope: Global, Session
+* Scope: Global
 * Dynamic: Yes
 * Data Type: `numeric`
 * Default Value - 32 bit: `4294967295`


### PR DESCRIPTION
see the definition:

static MYSQL_SYSVAR_ULONGLONG(mmap_size, myisam_mmap_size,
  PLUGIN_VAR_RQCMDARG|PLUGIN_VAR_READONLY, "Restricts the total memory "
  "used for memory mapping of MySQL tables", NULL, NULL,
  SIZE_T_MAX, MEMMAP_EXTRA_MARGIN, SIZE_T_MAX, 1);