### PR TITLE
MXS-6546: Document mariadbmon-readwritesplit interaction

### DIFF
--- a/maxscale/mariadb-maxscale-tutorials/analyzing-maxctrl-create-report-output.md
+++ b/maxscale/mariadb-maxscale-tutorials/analyzing-maxctrl-create-report-output.md
@@ -4,9 +4,6 @@
 The output of the `maxctrl create report` command produces a JSON payload that contains the current state of MaxScale. This includes the runtime configuration and the status all objects in MaxScale.
 
 
-The `maxctrl create report` command was added in MaxScale 2.5.20.
-
-
 ## Creating a MaxCtrl Report
 
 

--- a/maxscale/mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md
@@ -299,6 +299,54 @@ $ maxctrl list servers
 └─────────┴─────────────────┴──────┴─────────────┴─────────────────┘
 ```
 
+## Using MariaDB Monitor With ReadWriteSplit
+
+When a cluster managed by `mariadbmon` is accessed through a
+[readwritesplit](../reference/maxscale-routers/maxscale-readwritesplit.md)
+service, enabling `transaction_replay` on the router makes failover and
+switchover transparent to the application. When the primary fails, the router
+remembers any in-progress transaction and replays it on the newly promoted
+primary once failover completes. The replay is verified using checksums to
+confirm the results are identical, making it safe to use in production. If the
+replay succeeds, the client sees no error. Without `transaction_replay`, writes
+will be interrupted and in-flight transactions will be lost during the failover
+window.
+
+`transaction_replay=true` enables all required high-availability features in
+`readwritesplit` automatically. No additional router parameters are needed.
+
+```ini
+[MariaDB-Monitor]
+type=monitor
+module=mariadbmon
+servers=server1,server2,server3
+auto_failover=true
+auto_rejoin=true
+
+[Split-Router]
+type=service
+router=readwritesplit
+cluster=MariaDB-Monitor
+transaction_replay=true
+```
+
+`failover_timeout` controls how long the monitor will attempt failover before
+giving up and disabling automatic failover. Set it based on your cluster's
+expected failover time. `transaction_replay_timeout` on the router controls how
+long the client will wait for a replay to succeed before receiving an error; the
+default of 30 seconds is appropriate for most deployments.
+
+Transactions exceeding `transaction_replay_max_size` (default 1 MiB) will not be
+replayed and will result in a client error. Increase this limit for workloads
+with large transactions.
+
+## Planned Switchover With ReadWriteSplit
+
+For planned switchovers, the monitor and router cooperate automatically to
+drain in-progress transactions before the switchover proceeds. See the
+[Switchover](#switchover) section for details on how to perform a planned
+switchover.
+
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/maxscale/mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md
+++ b/maxscale/mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md
@@ -128,9 +128,6 @@ $ maxctrl list servers
 Had `auto_rejoin=true` been specified in the monitor section, then an
 attempt to rejoin `server1` would have been made.
 
-In MaxScale 2.2.1, rejoining cannot be initiated manually, but in a
-subsequent version a command to that effect will be provided.
-
 ## Automatic Failover
 
 To enable automatic failover, simply add `auto_failover=true` to the

--- a/maxscale/mariadb-maxscale-tutorials/configuring-the-mariadb-monitor.md
+++ b/maxscale/mariadb-maxscale-tutorials/configuring-the-mariadb-monitor.md
@@ -39,6 +39,10 @@ will require additional grants. Execute the following SQL to grant them.
 GRANT SUPER, RELOAD ON *.* TO 'monitor_user'@'%';
 ```
 
+For a tutorial on setting up automatic failover with `mariadbmon` and
+making it transparent to applications using the ReadWriteSplit router, see
+[Using MariaDB Monitor With ReadWriteSplit](automatic-failover-with-mariadb-monitor.md#using-mariadb-monitor-with-readwritesplit).
+
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/maxscale/mariadb-maxscale-tutorials/encrypting-passwords.md
+++ b/maxscale/mariadb-maxscale-tutorials/encrypting-passwords.md
@@ -2,8 +2,6 @@
 
 ## Encrypting Passwords
 
-**Note**: The password encryption format changed in MaxScale 2.5. All encrypted passwords created with MaxScale 2.4 or older need to be re-encrypted.
-
 There are two options for representing the password, either plain text or encrypted passwords may be used. In order to use encrypted passwords a set of keys must be generated that will be used by the encryption and decryption process. To generate the keys, use the `maxkeys` command.
 
 ```

--- a/maxscale/mariadb-maxscale-tutorials/maxscale-administration-tutorial.md
+++ b/maxscale/mariadb-maxscale-tutorials/maxscale-administration-tutorial.md
@@ -11,8 +11,7 @@ The generated file is a csv file that can be opened in most spread sheet program
 \[Rotating Log Files]\(#Rotating Log Files) also applies to the audit file. The admin audit file will never be overwritten as a result of a rotate, unlike the regular log file (in case a rotate is issued, but the file name has not been moved). There is also the option to change the audit file name, which effectively rotates it independently of the regular log file. For example:
 
 ```bash
-maxctrl alter maxscale 
-admin_audit_file=/var/log/maxscale/admin_audit.march.csv.
+maxctrl alter maxscale admin_audit_file=/var/log/maxscale/admin_audit.march.csv.
 ```
 
 ### Starting and Stopping MariaDB MaxScale
@@ -110,10 +109,6 @@ kill -USR1 `cat /run/maxscale/maxscale.pid`
 endscript
 }
 ```
-
-In older versions MaxScale renamed the log file, behavior which is not fully
-compliant with the assumptions of logrotate and may lead to issues, depending on
-the used logrotate configuration file. From version 2.1 onward, MaxScale will not itself rename the log file, but when the log is rotated, MaxScale will simply close and reopen the same log file. That will make the behavior fully compliant with logrotate.
 
 ### Taking Objects Temporarily Out of Use
 
@@ -231,8 +226,7 @@ Servers with the `Master` state cannot be drained. To drain them, first perform 
 **Create a new Monitor**
 
 ```bash
-maxctrl create monitor db-monitor mariadbmon 
-user=db-user password=db-password
+maxctrl create monitor db-monitor mariadbmon user=db-user password=db-password
 ```
 
 **Modify a Monitor**
@@ -266,8 +260,7 @@ A monitor can only be destroyed if it is not monitoring any servers. To automati
 **Create a New Service**
 
 ```bash
-maxctrl create service db-service readwritesplit 
-user=db-user password=db-password
+maxctrl create service db-service readwritesplit user=db-user password=db-password
 ```
 
 **Modify a Service**
@@ -313,19 +306,22 @@ The service can only be destroyed if it uses no servers or clusters and has no l
 **Create a New Filter**
 
 ```bash
-maxctrl create filter regexfilter match=ENGINE=MyISAM 
-replace=ENGINE=InnoDB
+maxctrl create filter my-filter regexfilter match=ENGINE=MyISAM replace=ENGINE=InnoDB
+```
+
+**Alter a Filter**
+
+```bash
+maxctrl alter filter my-filter match=ENGINE=InnoDB
 ```
 
 **Destroy a Filter**
 
 ```bash
-maxctrl destroy filter my-regexfilter
+maxctrl destroy filter my-filter
 ```
 
 A filter can only be destroyed if it is not used by any services. To automatically remove the filter from all services using it, use the `--force`flag.
-
-Filters cannot be altered at runtime in MaxScale 2.5. To modify the parameters of a filter, destroy it and recreate it with the modified parameters.
 
 #### Managing Listeners
 

--- a/maxscale/mariadb-maxscale-tutorials/schemarouter-simple-sharding-with-two-servers.md
+++ b/maxscale/mariadb-maxscale-tutorials/schemarouter-simple-sharding-with-two-servers.md
@@ -154,7 +154,6 @@ ignore_tables_regex=.*
 [Sharded-Service-Listener]
 type=listener
 service=Sharded-Service
-protocol=MariaDBClient
 port=4000
 
 [Shard-Monitor]

--- a/maxscale/mariadb-maxscale-tutorials/setting-up-mariadb-maxscale.md
+++ b/maxscale/mariadb-maxscale-tutorials/setting-up-mariadb-maxscale.md
@@ -35,8 +35,6 @@ GRANT SELECT ON mysql.roles_mapping TO 'maxscale'@'%';
 GRANT SHOW DATABASES ON *.* TO 'maxscale'@'%';
 ```
 
-MariaDB versions 10.2.2 to 10.2.10 also require `GRANT SELECT ON mysql.* TO 'maxscale'@'%';`
-
 ### Creating client user accounts
 
 Because MariaDB MaxScale sits between the clients and the backend databases, the backend databases will see all clients as if they were connecting from MaxScale's address. This usually means that two sets of grants for each user are required.

--- a/maxscale/maxscale-architecture/mariadb-maxscale-overview.md
+++ b/maxscale/maxscale-architecture/mariadb-maxscale-overview.md
@@ -17,6 +17,10 @@ MariaDB MaxScale is an advanced proxy, router, and load balancer:
 * MaxScale's ReadWriteSplit router performs query-based load balancing.
   ReadWriteSplit routes each write statement to the current primary server
   and load balances read statements by routing them to the replica servers.
+  When used together with automated failover, ReadWriteSplit can make primary
+  failures fully transparent to the application. For a tutorial on setting
+  this up, see
+  [Using MariaDB Monitor With ReadWriteSplit](../mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md#using-mariadb-monitor-with-readwritesplit).
 * MaxScale's ReadConnRoute router performs connection-based load balancing.
   ReadConnRoute routes each connection to a single primary or replica node,
   depending on configuration.

--- a/maxscale/maxscale-quickstart-guides/mariadb-maxscale-authenticators-guide.md
+++ b/maxscale/maxscale-quickstart-guides/mariadb-maxscale-authenticators-guide.md
@@ -52,7 +52,6 @@ password=maxscale_password
 [my_listener]
 type=listener
 service=my_service
-protocol=MariaDBClient
 port=3306
 authenticator=MariaDBAuth # Example: Use the standard MariaDB password authentication
 # authenticator=GSSAPIAuth # Or GSSAPI authentication

--- a/maxscale/reference/maxscale-filters/maxscale-workload-capture-and-replay.md
+++ b/maxscale/reference/maxscale-filters/maxscale-workload-capture-and-replay.md
@@ -120,7 +120,6 @@ filters=CAPTURE_FLTR
 [RWS-Listener]
 type=listener
 service=RWS-Router
-protocol=MariaDBClient
 port=4006
 ```
 

--- a/maxscale/reference/maxscale-monitors/mariadb-monitor.md
+++ b/maxscale/reference/maxscale-monitors/mariadb-monitor.md
@@ -1055,6 +1055,12 @@ the above requirements. Rejoin does not obey `failcount` and will attempt to
 rejoin any valid servers immediately. When activating rejoin manually, the
 user-designated server must fulfill the same requirements.
 
+### Using with ReadWriteSplit
+
+For a tutorial on setting up `mariadbmon` and `readwritesplit` for
+automatic failover with transparent transaction replay, see
+[Using MariaDB Monitor With ReadWriteSplit](../../mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md#using-mariadb-monitor-with-readwritesplit).
+
 ### Limitations and requirements
 
 Switchover and failover are meant for simple topologies (one primary and

--- a/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
+++ b/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
@@ -534,6 +534,10 @@ Limitations](maxscale-readwritesplit.md#transaction-replay-limitations)
 section for a more detailed explanation of what should and should not be done
 with transaction replay.
 
+For a tutorial on setting up `mariadbmon` and `readwritesplit` for
+automatic failover with transparent transaction replay, see
+[Using MariaDB Monitor with Readwritesplit](../../mariadb-maxscale-tutorials/automatic-failover-with-mariadb-monitor.md#using-mariadb-monitor-with-readwritesplit).
+
 ### `transaction_replay_max_size`
 
 * Type: [size](../../maxscale-management/deployment/maxscale-configuration-guide.md#sizes)


### PR DESCRIPTION
The automated failover tutorial now has a section that covers how to configure both mariadbmon and readwritesplit for smooth, automated switchovers and failovers.