### PR TITLE
DOCS-6070 Address review of InnoDB log archiving docs

### DIFF
--- a/server/server-usage/backup-and-restore/innodb-log-archive-pitr.md
+++ b/server/server-usage/backup-and-restore/innodb-log-archive-pitr.md
@@ -21,6 +21,8 @@ Two startup parameters define the range of the log replay:
 
 You can identify candidate LSNs from the [`Innodb_lsn_archived`](../../ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md#innodb_lsn_archived) status variable on the source server, and from the file names in the data directory (each `ib_`_`lsn`_`.log` file name encodes the LSN at file offset `0x3000`).
 
+The data files in the restore must correspond to an LSN that lies between `Innodb_lsn_archived` (the first checkpoint in the first archived log file) and the end LSN of the last archived log file. To extend the available recovery range, copy additional archived log files in from the source server — no further copying of data files is required.
+
 ## Procedure
 
 {% stepper %}
@@ -58,7 +60,7 @@ To return to normal read-write operation, restart the server without `innodb_log
 {% endstepper %}
 
 {% hint style="warning" %}
-The server cannot validate every impossible value of `innodb_log_recovery_target`. If you set the target after the recovery checkpoint but before the LSN at which a data page has already been written, recovery completes in an inconsistent state where some pages carry an LSN past the requested target. See [`innodb_log_recovery_target`](../storage-engines/innodb/innodb-system-variables.md#innodb_log_recovery_target) for details.
+**No data file may carry an LSN newer than `innodb_log_recovery_target`.** Crash recovery's role is to bring every database page to the same LSN. If any data file is newer than the target, recovery completes in an inconsistent state where some pages carry an LSN past the target — the database is corrupted. The server cannot validate every such impossible target, and the resulting corruption may not surface until the affected pages are accessed (see [MDEV-34830](https://jira.mariadb.org/browse/MDEV-34830)). See [`innodb_log_recovery_target`](../storage-engines/innodb/innodb-system-variables.md#innodb_log_recovery_target) for details.
 {% endhint %}
 
 {% hint style="info" %}

--- a/server/server-usage/storage-engines/innodb/innodb-log-archiving.md
+++ b/server/server-usage/storage-engines/innodb/innodb-log-archiving.md
@@ -35,15 +35,20 @@ Each archive log file has a 12 KiB header. Completed checkpoints in the file are
 * **Startup:** With `innodb_log_archive=ON`, the server refuses to start if `ib_logfile0` exists in the data directory.
 * **Data Dictionary:** Log archiving tracks changes to InnoDB tables. It does not cover `.frm` files or other non-InnoDB metadata, which means point-in-time recovery of DDL operations is limited.
 
-## Monitoring Archiving Progress
+## Inspecting the Archive State
 
-You can monitor the status of the log archiving process by querying the `INFORMATION_SCHEMA.GLOBAL_STATUS` table. The [`Innodb_lsn_archived`](../../../ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md#innodb_lsn_archived) status variable reports the LSN since which a complete InnoDB log archive is available.
+When `innodb_log_archive=ON`, both the [`innodb_log_archive`](innodb-system-variables.md#innodb_log_archive) system variable and the [`Innodb_lsn_archived`](../../../ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md#innodb_lsn_archived) status variable remain constant by design. `Innodb_lsn_archived` reports the LSN since which a complete InnoDB log archive is available — that is, the first checkpoint in the first archived log file — and does not advance as new log records are written. It is the static lower bound of the archive.
+
+What does advance during normal operation are the [`Innodb_lsn_current`](../../../ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md#innodb_lsn_current) status variable (the LSN of the most recent log write) and the [`Innodb_lsn_last_checkpoint`](../../../ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md#innodb_lsn_last_checkpoint) status variable (the LSN of the most recent completed checkpoint). Query these to observe ongoing log activity:
 
 ```sql
-SELECT @@GLOBAL.innodb_log_archive AS archiving,
-       VARIABLE_VALUE              AS lsn_archived
+SELECT @@GLOBAL.innodb_log_archive AS archiving;
+
+SELECT VARIABLE_NAME, VARIABLE_VALUE
 FROM   INFORMATION_SCHEMA.GLOBAL_STATUS
-WHERE  VARIABLE_NAME = 'INNODB_LSN_ARCHIVED';
+WHERE  VARIABLE_NAME IN ('INNODB_LSN_ARCHIVED',
+                         'INNODB_LSN_CURRENT',
+                         'INNODB_LSN_LAST_CHECKPOINT');
 ```
 
 ## Managing Archived Log Files

--- a/server/server-usage/storage-engines/innodb/innodb-system-variables.md
+++ b/server/server-usage/storage-engines/innodb/innodb-system-variables.md
@@ -1869,7 +1869,7 @@ Automatic upward dynamic resizing is not yet implemented ([MDEV-36197](https://j
 * Introduced: MariaDB 13.0
 
 {% hint style="warning" %}
-The server cannot validate every impossible target. If you set `innodb_log_recovery_target` to a value that is after the recovery checkpoint (as influenced by [`innodb_log_recovery_start`](innodb-system-variables.md#innodb_log_recovery_start)) but before the LSN at which a data page has already been written, recovery completes in an inconsistent state where some pages carry an LSN past the requested target. Choose a target that lies at or beyond the highest page LSN you intend to retain.
+**No data file may carry an LSN newer than `innodb_log_recovery_target`.** Crash recovery's role is to bring every database page to the same logical point in time (the same LSN). If any data file is newer than the target, recovery completes in an inconsistent state where some pages carry an LSN past the requested target — that is, the database is corrupted. The server cannot validate every such impossible target, and the resulting corruption may not be detected until the affected pages are accessed (see [MDEV-34830](https://jira.mariadb.org/browse/MDEV-34830)). Choose a target that lies at or beyond the highest page LSN you intend to retain.
 
 If you set a target that is unreachable in the other direction (for example, lower than the current checkpoint), the server terminates with an error message containing the available LSN range.
 {% endhint %}


### PR DESCRIPTION
Marko's second-round review (DOCS-6070 comment 1109255):

- innodb-log-archiving.md: rename "Monitoring Archiving Progress" to "Inspecting the Archive State" and clarify that innodb_log_archive and Innodb_lsn_archived stay constant by design, while Innodb_lsn_current and Innodb_lsn_last_checkpoint advance.
- innodb-system-variables.md: lead the innodb_log_recovery_target warning with the hard rule that no data file may carry an LSN newer than the target; cite MDEV-34830 for the silent-corruption consequence.
- innodb-log-archive-pitr.md: add the LSN-range constraint on the restored data files (between Innodb_lsn_archived and the end LSN of the last archived log file) and the "extend the range by copying further log files only" note; match the warning rewrite.