### PR TITLE
DOCS-6136 Fix wrong mariadb-admin analyze command in migration guide

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migration-the-master-guide.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migration-the-master-guide.md
@@ -279,8 +279,8 @@ Once your data is moved (via either method), complete these three steps to ensur
 MariaDB uses a sophisticated cost-based optimizer that may differ from MySQL’s. To ensure your queries use the most efficient execution plans, force a fresh analysis of all tables:
 
 ```bash
-# Run on all tables to refresh statistics
-mariadb-admin -u root -p analyze
+# Run ANALYZE TABLE on every table in every database to refresh statistics
+mariadb-check -u root -p --analyze --all-databases
 ```
 
 This makes the difference between a migration that "works" and a migration that "works fast".
@@ -349,7 +349,7 @@ Even with careful preparation, migrations can encounter specific hurdles. Here a
 | ------------------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | "Table 'mysql.user' doesn't exist"         | Missing `mariadb-upgrade` step. | The system tables must be converted. Run `sudo mariadb-upgrade -u root -p` immediately after starting the service.         |
 | Replication fails with "relay log" errors. | GTID Incompatibility.           | MariaDB cannot use MySQL GTIDs. You must switch to position-based replication (File and Position) to link the two systems. |
-| Slow queries after migration.              | Outdated optimizer statistics.  | MariaDB's optimizer needs fresh data. Run `ANALYZE TABLE` on all large tables or use `mariadb-admin analyze`.              |
+| Slow queries after migration.              | Outdated optimizer statistics.  | MariaDB's optimizer needs fresh data. Run `ANALYZE TABLE` on all large tables, or use `mariadb-check --analyze --all-databases`.              |
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Addresses [DOCS-6136](https://mariadbcorp.atlassian.net/browse/DOCS-6136), reported externally as #473.

**Problem:** The MySQL→MariaDB migration guide's "Verification and Optimization" section tells users to run `mariadb-admin -u root -p analyze` to refresh optimizer statistics. `mariadb-admin` has no `analyze` subcommand, so the call fails with `mariadb-admin: Unknown command: 'analyze'`. The same wrong command was repeated in the troubleshooting table further down the page.

**Fix:** Both occurrences are replaced with `mariadb-check --analyze --all-databases`, which is the actual command-line wrapper for `ANALYZE TABLE` in MariaDB.

**Verification:** The `mariadb-check` page confirms `-a` / `--analyze` runs `ANALYZE TABLE` on given tables, and `--all-databases` covers all databases.

Closes #473.

[DOCS-6136]: https://mariadbcorp.atlassian.net/browse/DOCS-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ