### PR TITLE
DOCS-6167 Fix mariadb.sys typo in system users page

### DIFF
--- a/server/security/user-account-management/roles/system-users-roles-and-privileges.md
+++ b/server/security/user-account-management/roles/system-users-roles-and-privileges.md
@@ -23,7 +23,7 @@ These user accounts are created by the `mariadb-install-db` script during the in
 | **Purpose**    | Serves as the primary administrative account for initial server setup and management.                                                                                                                                                           |
 | **Management** | It is highly recommended to secure this account immediately after installation. _Standard security practices include setting a strong password, renaming the account, or removing it entirely in favor of other named administrative accounts._ |
 
-### `mariadb-sys@localhost`
+### `mariadb.sys@localhost`
 
 | **Creation**   | Created automatically by `mariadb-install-db`.                                                                        |
 | -------------- | --------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Addresses [DOCS-6167](https://mariadbcorp.atlassian.net/browse/DOCS-6167).

The default-account heading on the system users / roles / privileges page spelled the account name with a hyphen (`mariadb-sys@localhost`) instead of a dot (`mariadb.sys@localhost`). The dotted form is the actual user name created by `mariadb-install-db`; the other four pages in the repo that reference this account (`account-locking.md`, `authentication-from-mariadb-10-4.md`, `mariadb-install-db.md`, `mysql-user-table.md`) already use the correct form.

One-character fix in a heading.

[DOCS-6167]: https://mariadbcorp.atlassian.net/browse/DOCS-6167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ