### PR TITLE
DOCS-6124 Show distinct SHOW BINLOG STATUS examples per version

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/show/show-binlog-status.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-binlog-status.md
@@ -45,7 +45,22 @@ To see information about the current [GTIDs](../../../../ha-and-performance/stan
 
 ## Example
 
-The following example works in all MariaDB versions. From MariaDB 12.3, the second statement doesn't have to be run, though, because `SHOW BINLOG STATUS` shows the value of `@@global.gtid_binlog_pos`, too.
+{% tabs %}
+{% tab title="Current" %}
+From MariaDB 12.3, `SHOW BINLOG STATUS` includes the `Gtid_Binlog_Pos` column, so a separate `SELECT @@global.gtid_binlog_pos` statement is no longer required to see the current GTID position:
+
+```sql
+SHOW BINLOG STATUS;
++--------------------+----------+--------------+------------------+-----------------+
+| File               | Position | Binlog_Do_DB | Binlog_Ignore_DB | Gtid_Binlog_Pos |
++--------------------+----------+--------------+------------------+-----------------+
+| mariadb-bin.000016 |      475 |              |                  | 0-1-2           |
++--------------------+----------+--------------+------------------+-----------------+
+```
+{% endtab %}
+
+{% tab title="< 12.3" %}
+Before MariaDB 12.3, `SHOW BINLOG STATUS` (or `SHOW MASTER STATUS`) does not include the `Gtid_Binlog_Pos` column. To see the current GTID position, run an additional `SELECT @@global.gtid_binlog_pos`:
 
 ```sql
 SHOW BINLOG STATUS;
@@ -61,6 +76,8 @@ SELECT @@global.gtid_binlog_pos;
 | 0-1-2                    |
 +--------------------------+
 ```
+{% endtab %}
+{% endtabs %}
 
 ## See Also
 


### PR DESCRIPTION
Addresses [DOCS-6124](https://mariadbcorp.atlassian.net/browse/DOCS-6124).

The reviewer asked that the Example section give a separate example for **MariaDB 12.3 and later** (where `SHOW BINLOG STATUS` includes the new `Gtid_Binlog_Pos` column) versus **older release series** (where the GTID position has to be retrieved with a follow-up `SELECT @@global.gtid_binlog_pos`).

Implementation matches the page's existing pattern for version-specific content: a `{% tabs %}` block paralleling the Syntax and Description sections.

- **Current tab** — 5-column output (`File`, `Position`, `Binlog_Do_DB`, `Binlog_Ignore_DB`, `Gtid_Binlog_Pos`), no follow-up `SELECT` required.
- **< 12.3 tab** — original 4-column output plus the additional `SELECT @@global.gtid_binlog_pos` statement.

Column list verified against the server source (`sql/sql_repl.cc::show_binlog_info_get_fields`).

[DOCS-6124]: https://mariadbcorp.atlassian.net/browse/DOCS-6124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ