### PR TITLE
DOCS-6170 Add caching_sha2_password to authentication overview

### DIFF
--- a/server/reference/plugins/authentication-plugins/pluggable-authentication-overview.md
+++ b/server/reference/plugins/authentication-plugins/pluggable-authentication-overview.md
@@ -26,7 +26,7 @@ The authentication process is a conversation between the server and a client. Ma
 
 ### Supported Server Authentication Plugins
 
-MariaDB provides seven server-side authentication plugins:
+MariaDB provides eight server-side authentication plugins:
 
 * [mysql\_native\_password](authentication-plugin-mysql_native_password.md)
 * [mysql\_old\_password](authentication-plugin-mysql_old_password.md)
@@ -35,6 +35,7 @@ MariaDB provides seven server-side authentication plugins:
 * [pam](authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md) (Unix only)
 * [unix\_socket](authentication-plugin-unix-socket.md) (Unix only)
 * [named\_pipe](authentication-plugin-named-pipe.md) (Windows only)
+* [caching\_sha2\_password](authentication-plugin-caching_sha2_password.md) (from MariaDB Community Server 12.1 and MariaDB Enterprise Server 11.8)
 
 ### Supported Client Authentication Plugins
 
@@ -47,7 +48,7 @@ MariaDB provides eight client-side authentication plugins:
 * [dialog](authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md#client-authentication-plugins)
 * [mysql\_clear\_password](authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md#client-authentication-plugins)
 * [sha256\_password](authentication-plugin-sha-256.md#client-authentication-plugins)
-* [caching\_sha256\_password](authentication-plugin-sha-256.md#client-authentication-plugins)
+* [caching\_sha2\_password](authentication-plugin-caching_sha2_password.md)
 
 ## Options Related to Authentication Plugins
 
@@ -354,6 +355,12 @@ Bye
 C:\> mysql --user=monty  --protocol=PIPE
 ERROR 1698 (28000): Access denied for user 'monty'@'localhost'
 ```
+
+#### `caching_sha2_password`
+
+The [caching\_sha2\_password](authentication-plugin-caching_sha2_password.md) authentication plugin provides MySQL-compatible authentication and allows users to be moved from MySQL to MariaDB without changing their passwords. It is intended primarily as a migration aid; for new accounts the more secure [PARSEC](authentication-plugin-parsec.md) authentication plugin is recommended.
+
+This plugin is available from MariaDB Community Server 12.1 and MariaDB Enterprise Server 11.8, and is not installed by default — see [Authentication Plugin - caching\_sha2\_password](authentication-plugin-caching_sha2_password.md) for installation instructions.
 
 ## See Also
 


### PR DESCRIPTION
Addresses [DOCS-6170](https://mariadbcorp.atlassian.net/browse/DOCS-6170).

The pluggable-authentication overview did not list `caching_sha2_password` as a supported server authentication plugin, even though it was added in **MariaDB Community Server 12.1.2** ([MDEV-9804](https://jira.mariadb.org/browse/MDEV-9804)) and **MariaDB Enterprise Server 11.8.3-1**.

Three edits on the overview page:

- **Supported Server Authentication Plugins:** count bumped from seven to eight; `caching_sha2_password` added with introduction versions noted in parentheses.
- **Supported Client Authentication Plugins:** corrected a pre-existing typo (`caching_sha256_password` → `caching_sha2_password`) and pointed it at the dedicated per-plugin page instead of the unrelated `sha256_password` page. The actual plugin name is `caching_sha2_password` per the server source (`mariadb-server/plugin/auth_mysql_sha2/mysql_sha2.h`: `#define SELF "caching_sha2_password"`).
- **Available Authentication Plugins → Server Authentication Plugins:** added a descriptive entry covering purpose (MySQL migration aid), the recommendation to use [PARSEC](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-parsec) for new accounts, version availability, and a pointer to the per-plugin page for installation steps.

**Note (not in scope, flagging for later):** the PARSEC plugin is also absent from this overview page — it has a per-plugin page but is missing from both the supported-plugins list and the descriptive section. A separate follow-up ticket may be worthwhile.

[DOCS-6170]: https://mariadbcorp.atlassian.net/browse/DOCS-6170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ