### PR TITLE
DOCS-6178 Add PARSEC to authentication overview

### DIFF
--- a/server/reference/plugins/authentication-plugins/pluggable-authentication-overview.md
+++ b/server/reference/plugins/authentication-plugins/pluggable-authentication-overview.md
@@ -26,7 +26,7 @@ The authentication process is a conversation between the server and a client. Ma
 
 ### Supported Server Authentication Plugins
 
-MariaDB provides eight server-side authentication plugins:
+MariaDB provides nine server-side authentication plugins:
 
 * [mysql\_native\_password](authentication-plugin-mysql_native_password.md)
 * [mysql\_old\_password](authentication-plugin-mysql_old_password.md)
@@ -35,6 +35,7 @@ MariaDB provides eight server-side authentication plugins:
 * [pam](authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md) (Unix only)
 * [unix\_socket](authentication-plugin-unix-socket.md) (Unix only)
 * [named\_pipe](authentication-plugin-named-pipe.md) (Windows only)
+* [PARSEC](authentication-plugin-parsec.md) (from MariaDB Community Server 11.6 and MariaDB Enterprise Server 11.8)
 * [caching\_sha2\_password](authentication-plugin-caching_sha2_password.md) (from MariaDB Community Server 12.1 and MariaDB Enterprise Server 11.8)
 
 ### Supported Client Authentication Plugins
@@ -355,6 +356,12 @@ Bye
 C:\> mysql --user=monty  --protocol=PIPE
 ERROR 1698 (28000): Access denied for user 'monty'@'localhost'
 ```
+
+#### `PARSEC`
+
+The [PARSEC](authentication-plugin-parsec.md) (Password Authentication using Response Signed with Elliptic Curve) authentication plugin uses salted passwords, key derivation, an extensible password storage format, and both server- and client-side scrambles. It signs the authentication response with stock unmodified `ed25519` (as provided by OpenSSL, WolfSSL, or GnuTLS). PARSEC is intended to become the default authentication plugin in a future release.
+
+This plugin is available from MariaDB Community Server 11.6 and MariaDB Enterprise Server 11.8.
 
 #### `caching_sha2_password`
 


### PR DESCRIPTION
Addresses [DOCS-6178](https://mariadbcorp.atlassian.net/browse/DOCS-6178). Direct follow-up to DOCS-6170 (#504) on the same overview page.

The pluggable-authentication overview did not list PARSEC as a supported server authentication plugin, even though it was added in **MariaDB Community Server 11.6** ([MDEV-32618](https://jira.mariadb.org/browse/MDEV-32618)) and **MariaDB Enterprise Server 11.8**.

Two edits on the overview page:

- **Supported Server Authentication Plugins:** count bumped from eight to nine; PARSEC added before `caching_sha2_password` in the list. PARSEC was introduced first (11.6 vs 12.1.2), and the existing `caching_sha2_password` entry already recommends PARSEC for new accounts, so defining PARSEC first reads more naturally.
- **Available Authentication Plugins → Server Authentication Plugins:** added a descriptive `#### PARSEC` entry covering the cryptographic design (salted passwords, key derivation, `ed25519` signature over the response), the "intended to be the default in a future release" note from the per-plugin page, and version availability.

After this PR, the overview is consistent with the per-plugin page set in `server/reference/plugins/authentication-plugins/`.

[DOCS-6178]: https://mariadbcorp.atlassian.net/browse/DOCS-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ