### PR TITLE
DOCS-6179 Clarify Master_SSL_Allowed Ignored value on SHOW REPLICA STATUS

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status.md
@@ -137,7 +137,7 @@ These columns cannot be viewed/extracted from the [INFORMATION\_SCHEMA.SLAVE\_ST
 
 **Until\_Log\_Pos:** The MASTER\_LOG\_POS value of the [START SLAVE UNTIL](../replication-statements/start-replica.md) condition.
 
-**Master\_SSL\_Allowed:** Whether an SSL connection is permitted (Yes), not permitted (No) or permitted but without the replica having SSL support enabled (Ignored)
+**Master\_SSL\_Allowed:** Whether an SSL connection to the master is permitted (Yes) or not permitted (No). The value reflects the `MASTER_SSL` option configured via [CHANGE MASTER TO](../replication-statements/change-master-to.md) and is independent of the runtime `have_ssl` state. A third value, Ignored, is emitted only on MariaDB builds compiled without SSL/TLS support (`HAVE_OPENSSL` undefined at build time); this does not apply to standard packaged builds, which always include OpenSSL, WolfSSL, or GnuTLS support.
 
 **Master\_SSL\_CA\_File:** The MASTER\_SSL\_CA option of the [CHANGE MASTER TO](../replication-statements/change-master-to.md) statement.
 


### PR DESCRIPTION
Addresses [DOCS-6179](https://mariadbcorp.atlassian.net/browse/DOCS-6179). Reported via Slack (Esa Korhonen, 2026-05-21).

The `Master_SSL_Allowed` description previously stated that the `Ignored` value meant the replica had "SSL support enabled" set to off, implying a runtime condition. Reading the server source (`sql/slave.cc:2872-2876` and `:3003-3009`):

```c
#ifndef HAVE_OPENSSL
static const LEX_CSTRING msg_ignored = { STRING_WITH_LEN("Ignored") };
#endif
...
(*field++)->store(mi->master_ssl ?
#ifdef HAVE_OPENSSL
    &msg_yes
#else
    &msg_ignored
#endif
    : &msg_no, ...);
```

`Ignored` is gated on the compile-time `HAVE_OPENSSL` macro, not on any runtime state. Standard packaged MariaDB builds (including 11.4.8) are compiled with OpenSSL/WolfSSL/GnuTLS, so the value is essentially unreachable in practice. Confirmed by Esa: on his 11.4.8 server with `have_ssl=DISABLED` at runtime, `Master_SSL_Allowed` still showed `Yes`, exactly as the source predicts.

**New description:**

- Leads with the two values users will actually see (`Yes` / `No`) and what they mean.
- Notes that the value reflects the `MASTER_SSL` option from `CHANGE MASTER TO` and is independent of the runtime `have_ssl` state.
- Mentions `Ignored` as a compile-time-only condition that does not apply to standard packaged builds.

[DOCS-6179]: https://mariadbcorp.atlassian.net/browse/DOCS-6179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ