### PR TITLE
DOCS-4202 Sharpen window-function Optimization section against the source

### DIFF
--- a/server/reference/sql-functions/special-functions/window-functions/window-functions-overview.md
+++ b/server/reference/sql-functions/special-functions/window-functions/window-functions-overview.md
@@ -164,7 +164,7 @@ Window functions are evaluated after `WHERE`, `GROUP BY`, and `HAVING`. Filter t
 
 ## Optimization
 
-Window functions often need sorted input. Query shape can decide whether MariaDB can reuse an existing order or must sort again.
+Window function evaluation invokes a sort pass per group of compatible windows. Each such pass appears as a `filesort` node in the execution plan. Query shape decides how many passes are needed and how cheap each one is to perform.
 
 ### `GROUP BY` Comes First
 
@@ -173,12 +173,12 @@ If a query uses both `GROUP BY` and window functions, MariaDB executes the group
 This affects index usage. An index that helps the base table scan does not automatically avoid later sorting for the window stage.
 
 {% hint style="info" %}
-When tuning this pattern, optimize the `GROUP BY` step first. Then check whether the window step still needs its own sort.
+When tuning this pattern, optimize the `GROUP BY` step first. Then check `EXPLAIN FORMAT=JSON` to confirm the window step's sort cost is low.
 {% endhint %}
 
 ### Sort Reuse Depends on Sort Keys
 
-If the `GROUP BY` definition and the window's `PARTITION BY` and `ORDER BY` definition use different sort keys, MariaDB usually needs another sort pass before evaluating the window functions.
+If the `GROUP BY` definition and the window's `PARTITION BY` and `ORDER BY` definition use different sort keys, the window's sort pass cannot reuse the grouped output's order — it has to re-sort the rows. Aligning the keys keeps the sort cheap; misaligning them forces a full sort.
 
 For example, this shape can require an extra sort:
 
@@ -199,7 +199,9 @@ The grouped result is ordered by `month, dept`. The window step needs `dept, mon
 
 ### Multiple Window Functions Can Share One Sort
 
-Multiple window functions can share the same sort pass when they use the same `PARTITION BY` and `ORDER BY` clause.
+Multiple window functions can share the same sort pass when their `PARTITION BY` and `ORDER BY` clauses are compatible. Two specs are compatible if they are identical, or if one is a prefix of the other — the longer specification then becomes the canonical sort order.
+
+**Identical specs:**
 
 ```sql
 SELECT
@@ -218,14 +220,28 @@ SELECT
 FROM revenue;
 ```
 
-Both window functions use the same partitioning and ordering. MariaDB can reuse the same sorted stream for both.
+Both window functions use the same partitioning and ordering. MariaDB reuses the same sorted stream for both — one `filesort` pass.
+
+**Prefix-compatible specs:**
+
+```sql
+SELECT
+  dept,
+  month,
+  day,
+  ROW_NUMBER() OVER (PARTITION BY dept ORDER BY month)      AS rn,
+  SUM(sales)   OVER (PARTITION BY dept ORDER BY month, day) AS running_sales
+FROM revenue;
+```
+
+The first window's order key (`dept`, `month`) is a prefix of the second's (`dept`, `month`, `day`). MariaDB sorts once by the longer key (`dept, month, day`) and both window functions consume the result.
 
 ### Practical Tuning Tips
 
 * Expect `GROUP BY` to shape the input seen by window functions.
-* Align `GROUP BY` keys with the window sort keys when possible.
-* Reuse the same `PARTITION BY` and `ORDER BY` across multiple window functions.
-* Check the execution plan to see whether an extra sort is still present.
+* Align `GROUP BY` keys with the window sort keys when possible — the sort still runs, but it is cheap when the data is already in the right order.
+* Reuse the same `PARTITION BY` and `ORDER BY` across multiple window functions, or make one a prefix of another, so MariaDB can collapse them into a single sort pass.
+* Use `EXPLAIN FORMAT=JSON` (or `ANALYZE FORMAT=JSON` for real timings) to count the window-function sort passes — each pass appears as a `filesort` node under the aggregation step.
 
 ## Examples
 


### PR DESCRIPTION
Follow-up to [DOCS-4202](https://mariadbcorp.atlassian.net/browse/DOCS-4202). Your earlier rewrite of `window-functions-overview.md` landed the Optimization section in April; this PR refines that section based on a cross-walk against `mariadb-server/sql/sql_window.cc` and `sql/sql_select.cc`.

Tagging this back to DOCS-4202 so @sergeypetrunya can re-loop on the same review.

## What was audited

- **Confirmed accurate:** "`GROUP BY` Comes First" matches `sql/sql_select.cc:4322-4340`, where the canonical comment is "Window functions computation step should be attached to the last join_tab that's doing aggregation. … sorting [and] duplicate value removal … are done after window function computation step." Execution order: `GROUP BY → window → ORDER BY / DISTINCT / LIMIT`.
- **Confirmed accurate:** "Multiple Window Functions Can Share One Sort" matches `order_window_funcs_by_window_specs` (`sql/sql_window.cc:735-782`) and `Window_funcs_sort::setup` (`sql/sql_window.cc:3119-3158`) — compatible windows are grouped, one `Window_funcs_sort` per group, one `filesort` per group.

## Four refinements

1. **Intro reframed.** The previous wording ("can reuse an existing order or must sort again") implied an aligned `GROUP BY` could avoid sorting altogether. The implementation in `Window_funcs_sort::exec` (`sql/sql_window.cc:3095-3102`) unconditionally calls `create_sort_index` per group of compatible windows — see also the TODO at `sql/sql_window.cc:3161` confirming this is a known limitation. New wording: "a sort pass per group of compatible windows," each visible as a `filesort` node in the plan, with query shape deciding the count and per-pass cost.

2. **"Sort Reuse Depends on Sort Keys" tightened.** Was: "MariaDB usually needs another sort pass." Now: "the window's sort pass cannot reuse the grouped output's order — it has to re-sort the rows. Aligning the keys keeps the sort cheap; misaligning them forces a full sort." Matches what `filesort` actually does in either case.

3. **"Multiple Window Functions Can Share One Sort" expanded** to document the prefix-compatibility rule from `compare_window_funcs_by_window_specs` and the `CMP_LT_C` / `CMP_GT_C` handling in `order_window_funcs_by_window_specs`. When one window's order key is a prefix of another's, MariaDB collapses them into a single sort by the longer key. Previous wording only mentioned identical specs and would have led readers to assume two such windows required two sorts. Added a second code example showing the prefix case.

4. **"Practical Tuning Tips" made concrete.** Replaced "Check the execution plan to see whether an extra sort is still present" with `EXPLAIN FORMAT=JSON` / `ANALYZE FORMAT=JSON` guidance and a pointer to the `filesort` node under the aggregation step (where `Explain_aggr_filesort` is emitted at `sql/sql_window.cc:3267`). Also tightened the hint above the `GROUP BY` Comes First subsection to match.

No structural changes; only wording and one new code example.

## Asking @sergeypetrunya to review

Specifically:
- Whether the prefix-compatibility framing is the right level of detail (it's mentioned in `compare_window_spec_joined_lists` but I haven't found a user-facing doc that calls it out).
- Whether there's a more user-visible name for the "group of compatible windows" concept than what I used.

[DOCS-4202]: https://mariadbcorp.atlassian.net/browse/DOCS-4202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ