### PR TITLE
DOCS-5615 Expand minor-version upgrade page into a full how-to (draft for Uday)

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-between-minor-versions-on-linux.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-between-minor-versions-on-linux.md
@@ -7,17 +7,19 @@ description: >-
 
 # Upgrading Between Minor MariaDB Versions
 
-These instructions detail a **minor release upgrade** of **MariaDB Community Server** on Linux. A minor release upgrade is a change from one release to a later release within the same release series — for example, from MariaDB 11.4.4 to MariaDB 11.4.5.
+These instructions detail a **minor release upgrade** of **MariaDB Community Server** on Linux. A minor release upgrade refers to upgrading within the same release series. For example, upgrading from MariaDB 11.4.4 to MariaDB 11.4.5 without changing the major version. Minor releases typically deliver bug fixes, security patches, and stability improvements.
 
-For Windows, see [Upgrading MariaDB on Windows](upgrading-mariadb-on-windows.md) instead. For major version upgrades (e.g., MariaDB 10.11 to MariaDB 11.4), see [Upgrading Between Major MariaDB Versions](upgrading-between-major-mariadb-versions.md) and the per-version guides listed in [See Also](#see-also).
+For Windows, see [Upgrading MariaDB on Windows](upgrading-mariadb-on-windows.md). For major version upgrades (for example, MariaDB 10.11 to MariaDB 11.4), see [Upgrading Between Major MariaDB Versions](upgrading-between-major-mariadb-versions.md) and the per-version guides listed in [See Also](#see-also).
 
 {% hint style="info" %}
-The examples in this guide use MariaDB Community Server 11.4.4 → 11.4.5 as the worked scenario, but the same procedure applies to any supported minor-version upgrade within a release series.
+The examples in this page use MariaDB Community Server 11.4.4 → 11.4.5 as the worked scenario. The same procedure applies to any supported minor-version upgrade within a release series.
 {% endhint %}
 
 ## Data Backup
 
-Occasionally, issues can be encountered during upgrades. These issues can even potentially corrupt the database's data files, preventing you from easily reverting to the old installation. It is generally best to perform a backup prior to upgrading. If an issue is encountered during the upgrade, you can use the backup to restore your MariaDB Server database to the old version. If the upgrade finishes without issue, then the backup can be deleted.
+Occasionally, issues can be encountered during an upgrade. These issues can even potentially corrupt the database's data files, making it difficult to revert to the previous installation. It is strongly recommended to create a backup before upgrading. 
+* If the upgrade fails, the backup can be used to restore the database to the previous version of MariaDB Server. 
+* If the upgrade finishes successfully, then the backup can be deleted.
 
 The instructions below show how to perform a backup using [MariaDB Backup](../../../server-usage/backup-and-restore/mariadb-backup/). For more information about backing up and restoring the database, see the [Recovery Guide](../../../server-usage/backup-and-restore/).
 
@@ -30,6 +32,7 @@ The instructions below show how to perform a backup using [MariaDB Backup](../..
           --target-dir=/data/backup/preupgrade_backup
     ```
 
+    Replace `mariadb-backup_user` and `mariadb-backup_passwd` with your actual backup user credentials.
     Confirm successful completion of the backup operation.
 2.  Prepare the backup so it is ready for immediate restoration if required:
 
@@ -45,7 +48,7 @@ The instructions below show how to perform a backup using [MariaDB Backup](../..
 
 Before the new packages are installed, stop the running server.
 
-1.  Set the [innodb\_fast\_shutdown](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_fast_shutdown) system variable to `1` so InnoDB closes cleanly:
+1.  Set the [innodb\_fast\_shutdown](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_fast_shutdown) system variable to `1` so InnoDB flushes all dirty pages and closes cleanly:
 
     ```sql
     SET GLOBAL innodb_fast_shutdown = 1;
@@ -65,7 +68,7 @@ Before the new packages are installed, stop the running server.
 
 ## Install the New Version
 
-Unlike a major-version upgrade, a minor-version upgrade does **not** require uninstalling the old packages first. The distribution's package manager handles the upgrade in place.
+Unlike a major-version upgrade, a minor-version upgrade does **not** require uninstalling the old packages first. The distribution's package manager upgrades the packages in place, while keeping the data directory and configuration files unchanged.
 
 MariaDB Community Server provides a setup script, [`mariadb_repo_setup`](../mariadb-package-repository-setup-and-usage.md), that configures the package repository for your distribution. To pin to a specific minor release, pass the full version number to `--mariadb-server-version`, prefixed with `mariadb-`. For example, to install MariaDB 11.4.5 instead of the latest 11.4.x release:
 
@@ -83,7 +86,7 @@ To track the latest release in a series rather than pinning to a specific minor,
 {% tab title="Upgrade via YUM" %}
 **Upgrade via YUM (RHEL, AlmaLinux, CentOS, Rocky Linux)**
 
-1.  Configure the YUM package repository for the target release. The example pins to MariaDB 11.4.5:
+1.  Configure the YUM package repository for the target release. The following example uses MariaDB 11.4.5; adjust the version number for your target release:
 
     ```bash
     sudo yum install curl
@@ -108,13 +111,13 @@ To track the latest release in a series rather than pinning to a specific minor,
     sudo yum update "MariaDB-*" "galera*"
     ```
 
-    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+    Check that the wildcards do not unintentionally match any custom applications.
 {% endtab %}
 
 {% tab title="Upgrade via APT" %}
 **Upgrade via APT (Debian, Ubuntu)**
 
-1.  Configure the APT package repository for the target release. The example pins to MariaDB 11.4.5:
+1.  Configure the APT package repository for the target release. The following example uses MariaDB 11.4.5; adjust the version number for your target release:
 
     ```bash
     sudo apt install curl
@@ -141,13 +144,13 @@ To track the latest release in a series rather than pinning to a specific minor,
     sudo apt install --only-upgrade "mariadb-*" "galera*"
     ```
 
-    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+    Check that the wildcards do not unintentionally match any custom applications.
 {% endtab %}
 
 {% tab title="Upgrade via ZYpp" %}
 **Upgrade via ZYpp (SLES, openSUSE)**
 
-1.  Configure the ZYpp package repository for the target release. The example pins to MariaDB 11.4.5:
+1.  Configure the ZYpp package repository for the target release. The following example uses MariaDB 11.4.5; adjust the version number for your target release:
 
     ```bash
     sudo zypper install curl
@@ -170,7 +173,7 @@ To track the latest release in a series rather than pinning to a specific minor,
     sudo zypper update "MariaDB-*" "galera*"
     ```
 
-    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+    Check that the wildcards do not unintentionally match any custom applications.
 {% endtab %}
 {% endtabs %}
 
@@ -183,7 +186,7 @@ For platforms that use YUM or ZYpp as a package manager, MariaDB Community Serve
 * `/etc/my.cnf.d/mysql-clients.cnf`
 * `/etc/my.cnf.d/server.cnf`
 
-If your version of any of these configuration files contained custom edits, then the package manager may save your edited version with the `.rpmsave` extension during the upgrade. To continue using your version with the custom edits, restore it before starting the server. For example, to restore `server.cnf`:
+If your version of any of these configuration files contained custom edits, then the package manager may save your edited version with the `.rpmsave` extension during the upgrade. To continue using your customized version, restore it before starting the server. For example, to restore `server.cnf`:
 
 ```bash
 sudo mv /etc/my.cnf.d/server.cnf /etc/my.cnf.d/server.cnf.original
@@ -214,14 +217,14 @@ For distributions that use `systemd`, manage the server process using `systemctl
 
 ## Upgrading the Data Directory
 
-MariaDB ships with a utility that identifies and corrects compatibility issues in the new version. After the server is upgraded and running, run [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) to upgrade the data directory:
+MariaDB ships with a utility that checks for and corrects any compatibility issues introduced by the upgrade. After the server is upgraded and running, run [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) to upgrade the data directory:
 
 ```bash
 sudo mariadb-upgrade
 ```
 
 {% hint style="info" %}
-Minor-version upgrades typically do not change the data dictionary, and recent MariaDB versions detect this and exit quickly. Running `mariadb-upgrade` is still recommended as a safety check, and is harmless when no work is needed.
+Minor-version upgrades do not change the data dictionary. On mariadb-upgrade 2.0 and later, `mariadb-upgrade` detects this automatically and exits immediately with a message confirming no upgrade is needed and this is expected behaviour. Running `mariadb-upgrade` after a minor upgrade is still recommended as a safety check, and is harmless when no work is needed. Use `--force` to run the full check regardless. 
 {% endhint %}
 
 ## Testing

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-between-minor-versions-on-linux.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-between-minor-versions-on-linux.md
@@ -1,38 +1,299 @@
 ---
 description: >-
-  Steps for minor version upgrades (e.g., 10.5.8 to 10.5.9) on Linux, which
-  typically involve package manager updates and a service restart.
+  Step-by-step minor version upgrade (e.g., 11.4.4 to 11.4.5) for MariaDB
+  Community Server on Linux using YUM, APT, or ZYpp — backup, stop, upgrade
+  packages, restart, and run mariadb-upgrade.
 ---
 
 # Upgrading Between Minor MariaDB Versions
 
-For Windows, see [Upgrading MariaDB on Windows](upgrading-mariadb-on-windows.md) instead.
+These instructions detail a **minor release upgrade** of **MariaDB Community Server** on Linux. A minor release upgrade is a change from one release to a later release within the same release series — for example, from MariaDB 11.4.4 to MariaDB 11.4.5.
 
-Before you upgrade, it would be best to take a backup of your database. This is always a good idea to do before an upgrade. We would recommend [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/).
+For Windows, see [Upgrading MariaDB on Windows](upgrading-mariadb-on-windows.md) instead. For major version upgrades (e.g., MariaDB 10.11 to MariaDB 11.4), see [Upgrading Between Major MariaDB Versions](upgrading-between-major-mariadb-versions.md) and the per-version guides listed in [See Also](#see-also).
 
-To upgrade between minor versions of MariaDB on Linux/Unix (for example from [MariaDB 10.11.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.4) to [MariaDB 10.11.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.11/10.11.5)), the following procedure is suggested:
+{% hint style="info" %}
+The examples in this guide use MariaDB Community Server 11.4.4 → 11.4.5 as the worked scenario, but the same procedure applies to any supported minor-version upgrade within a release series.
+{% endhint %}
 
-1. Stop MariaDB.
-2. Uninstall the old version of MariaDB.
-3. Install the new version of MariaDB.
+## Data Backup
 
-* On Debian, Ubuntu, and other similar Linux distributions, see [Installing MariaDB Packages with APT](../installing-mariadb/binary-packages/installing-mariadb-deb-files.md#installing-mariadb-packages-with-apt) for more information.
-* On RHEL, CentOS, Fedora, and other similar Linux distributions, see [Installing MariaDB Packages with YUM](../installing-mariadb/binary-packages/rpm/yum.md#installing-mariadb-packages-with-yum) for more information.
-* On SLES, OpenSUSE, and other similar Linux distributions, see [Installing MariaDB Packages with ZYpp](../installing-mariadb/binary-packages/rpm/installing-mariadb-with-zypper.md#installing-mariadb-packages-with-zypp) for more information.
+Occasionally, issues can be encountered during upgrades. These issues can even potentially corrupt the database's data files, preventing you from easily reverting to the old installation. It is generally best to perform a backup prior to upgrading. If an issue is encountered during the upgrade, you can use the backup to restore your MariaDB Server database to the old version. If the upgrade finishes without issue, then the backup can be deleted.
 
-4. Make any desired changes to configuration options in [option files](../configuring-mariadb/configuring-mariadb-with-option-files.md), such as `my.cnf`.
-5. Start MariaDB.
+The instructions below show how to perform a backup using [MariaDB Backup](../../../server-usage/backup-and-restore/mariadb-backup/). For more information about backing up and restoring the database, see the [Recovery Guide](../../../server-usage/backup-and-restore/).
 
-To upgrade between major versions, see the following:
+1.  Take a full backup:
+
+    ```bash
+    sudo mariadb-backup --backup \
+          --user=mariadb-backup_user \
+          --password=mariadb-backup_passwd \
+          --target-dir=/data/backup/preupgrade_backup
+    ```
+
+    Confirm successful completion of the backup operation.
+2.  Prepare the backup so it is ready for immediate restoration if required:
+
+    ```bash
+    sudo mariadb-backup --prepare \
+          --target-dir=/data/backup/preupgrade_backup
+    ```
+
+    Confirm successful completion of the prepare operation.
+3. Backups should be tested before they are trusted. Restore the backup to a non-production instance and verify it before proceeding with the upgrade.
+
+## Stop the MariaDB Server Process
+
+Before the new packages are installed, stop the running server.
+
+1.  Set the [innodb\_fast\_shutdown](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_fast_shutdown) system variable to `1` so InnoDB closes cleanly:
+
+    ```sql
+    SET GLOBAL innodb_fast_shutdown = 1;
+    ```
+2.  Use [XA RECOVER](../../../reference/sql-statements/transactions/xa-transactions.md#xa-recover) to confirm that there are no external XA transactions in a prepared state:
+
+    ```sql
+    XA RECOVER;
+    ```
+
+    Commit or roll back any open XA transactions before stopping the server.
+3.  Stop the server process. On distributions that use `systemd` (most supported OSes), manage the server with `systemctl`:
+
+    ```bash
+    sudo systemctl stop mariadb
+    ```
+
+## Install the New Version
+
+Unlike a major-version upgrade, a minor-version upgrade does **not** require uninstalling the old packages first. The distribution's package manager handles the upgrade in place.
+
+MariaDB Community Server provides a setup script, [`mariadb_repo_setup`](../mariadb-package-repository-setup-and-usage.md), that configures the package repository for your distribution. To pin to a specific minor release, pass the full version number to `--mariadb-server-version`, prefixed with `mariadb-`. For example, to install MariaDB 11.4.5 instead of the latest 11.4.x release:
+
+```
+--mariadb-server-version="mariadb-11.4.5"
+```
+
+To track the latest release in a series rather than pinning to a specific minor, pass only the series:
+
+```
+--mariadb-server-version="mariadb-11.4"
+```
+
+{% tabs %}
+{% tab title="Upgrade via YUM" %}
+**Upgrade via YUM (RHEL, AlmaLinux, CentOS, Rocky Linux)**
+
+1.  Configure the YUM package repository for the target release. The example pins to MariaDB 11.4.5:
+
+    ```bash
+    sudo yum install curl
+    ```
+
+    ```bash
+    curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+    ```
+
+    ```bash
+    chmod +x mariadb_repo_setup
+    ```
+
+    ```bash
+    sudo ./mariadb_repo_setup --mariadb-server-version="mariadb-11.4.5"
+    ```
+
+    See [Pinning the Repository to a Specific Minor Release](../mariadb-package-repository-setup-and-usage.md#mariadb-community-server-2) for more on minor-release pinning.
+2.  Update MariaDB Community Server and package dependencies:
+
+    ```bash
+    sudo yum update "MariaDB-*" "galera*"
+    ```
+
+    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+{% endtab %}
+
+{% tab title="Upgrade via APT" %}
+**Upgrade via APT (Debian, Ubuntu)**
+
+1.  Configure the APT package repository for the target release. The example pins to MariaDB 11.4.5:
+
+    ```bash
+    sudo apt install curl
+    ```
+
+    ```bash
+    curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+    ```
+
+    ```bash
+    chmod +x mariadb_repo_setup
+    ```
+
+    ```bash
+    sudo ./mariadb_repo_setup --mariadb-server-version="mariadb-11.4.5"
+    ```
+
+    ```bash
+    sudo apt update
+    ```
+2.  Upgrade MariaDB Community Server and package dependencies. The `--only-upgrade` flag ensures `apt` does not install new packages, only updates existing ones:
+
+    ```bash
+    sudo apt install --only-upgrade "mariadb-*" "galera*"
+    ```
+
+    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+{% endtab %}
+
+{% tab title="Upgrade via ZYpp" %}
+**Upgrade via ZYpp (SLES, openSUSE)**
+
+1.  Configure the ZYpp package repository for the target release. The example pins to MariaDB 11.4.5:
+
+    ```bash
+    sudo zypper install curl
+    ```
+
+    ```bash
+    curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+    ```
+
+    ```bash
+    chmod +x mariadb_repo_setup
+    ```
+
+    ```bash
+    sudo ./mariadb_repo_setup --mariadb-server-version="mariadb-11.4.5"
+    ```
+2.  Update MariaDB Community Server and package dependencies:
+
+    ```bash
+    sudo zypper update "MariaDB-*" "galera*"
+    ```
+
+    Be sure to check that the wildcards do not unintentionally refer to any of your custom applications.
+{% endtab %}
+{% endtabs %}
+
+## Configuration
+
+For platforms that use YUM or ZYpp as a package manager, MariaDB Community Server's packages bundle several configuration files:
+
+* `/etc/my.cnf`
+* `/etc/my.cnf.d/client.cnf`
+* `/etc/my.cnf.d/mysql-clients.cnf`
+* `/etc/my.cnf.d/server.cnf`
+
+If your version of any of these configuration files contained custom edits, then the package manager may save your edited version with the `.rpmsave` extension during the upgrade. To continue using your version with the custom edits, restore it before starting the server. For example, to restore `server.cnf`:
+
+```bash
+sudo mv /etc/my.cnf.d/server.cnf /etc/my.cnf.d/server.cnf.original
+```
+
+```bash
+sudo mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
+```
+
+On APT-based systems (Debian, Ubuntu), preserved configuration files use the `.dpkg-old` extension instead. The principle is the same: rename and restore as needed.
+
+Now is also the time to make any desired changes to [option files](../configuring-mariadb/configuring-mariadb-with-option-files.md) such as `my.cnf`, before starting the new server.
+
+## Starting the Server
+
+MariaDB Community Server includes configuration to start, stop, restart, enable/disable on boot, and check the status of the server using the operating system's default process management system.
+
+For distributions that use `systemd`, manage the server process using `systemctl`:
+
+| Operation              | Command                          |
+| ---------------------- | -------------------------------- |
+| Start                  | `sudo systemctl start mariadb`   |
+| Stop                   | `sudo systemctl stop mariadb`    |
+| Restart                | `sudo systemctl restart mariadb` |
+| Enable during startup  | `sudo systemctl enable mariadb`  |
+| Disable during startup | `sudo systemctl disable mariadb` |
+| Status                 | `sudo systemctl status mariadb`  |
+
+## Upgrading the Data Directory
+
+MariaDB ships with a utility that identifies and corrects compatibility issues in the new version. After the server is upgraded and running, run [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) to upgrade the data directory:
+
+```bash
+sudo mariadb-upgrade
+```
+
+{% hint style="info" %}
+Minor-version upgrades typically do not change the data dictionary, and recent MariaDB versions detect this and exit quickly. Running `mariadb-upgrade` is still recommended as a safety check, and is harmless when no work is needed.
+{% endhint %}
+
+## Testing
+
+When the upgraded server is up and running, verify it is working and there were no issues during startup.
+
+1.  Connect to the server using the [mariadb](../../../clients-and-utilities/mariadb-client/) client as the `root@localhost` user:
+
+    ```bash
+    sudo mariadb
+    ```
+
+    ```
+    Welcome to the MariaDB monitor.  Commands end with ; or \g.
+    Your MariaDB connection id is 9
+    Server version: 11.4.5-MariaDB MariaDB Server
+
+    Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+    MariaDB [(none)]>
+    ```
+2.  Verify the server version by checking the [version](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#version) system variable:
+
+    ```sql
+    SHOW GLOBAL VARIABLES LIKE 'version';
+    ```
+
+    ```
+    +---------------+-----------------+
+    | Variable_name | Value           |
+    +---------------+-----------------+
+    | version       | 11.4.5-MariaDB  |
+    +---------------+-----------------+
+    ```
+3.  Verify by calling the [VERSION()](../../../reference/sql-functions/secondary-functions/information-functions/version.md) function:
+
+    ```sql
+    SELECT VERSION();
+    ```
+
+    ```
+    +-----------------+
+    | VERSION()       |
+    +-----------------+
+    | 11.4.5-MariaDB  |
+    +-----------------+
+    ```
+
+## See Also
+
+For major version upgrades (between release series), see:
 
 * [Upgrading Between Major MariaDB Versions](upgrading-between-major-mariadb-versions.md)
-* [Upgrading from MariaDB 11.1 to MariaDB 11.2](upgrading-from-to-specific-versions/upgrading-from-mariadb-11-1-to-mariadb-11-2.md)
-* [Upgrading from MariaDB 11.0 to MariaDB 11.1](upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-11-0-to-mariadb-11-1.md)
-* [Upgrading from MariaDB 10.11 to MariaDB 11.0](upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0.md)
+* [Upgrading from MariaDB 11.4 to MariaDB 11.8](upgrading-from-to-specific-versions/upgrading-from-mariadb-11-4-to-mariadb-11-8.md)
+* [Upgrading from MariaDB 10.11 to MariaDB 11.4](upgrading-from-to-specific-versions/upgrading-from-mariadb-10-11-to-mariadb-11-4.md)
 * [Upgrading from MariaDB 10.6 to MariaDB 10.11](upgrading-from-to-specific-versions/upgrading-from-mariadb-10-6-to-mariadb-10-11.md)
-* [Upgrading from MariaDB 10.5 to MariaDB 10.6](upgrading-from-to-specific-versions/upgrading-from-mariadb-10-5-to-mariadb-10-6.md)
-* [Upgrading from MariaDB 10.4 to MariaDB 10.5](upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5.md)
-* [Upgrading from MariaDB 10.3 to MariaDB 10.4](upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104.md)
+
+For the equivalent Enterprise Server minor-upgrade guides, see:
+
+* [Upgrade MariaDB Enterprise Server from 11.4.X to 11.4.Y](upgrade-paths/mariadb-enterprise-server-11.4/upgrade-mariadb-enterprise-server-from-11.4.x-to-11.4.y.md)
+* [Upgrade MariaDB Enterprise Server from 10.6.X to 10.6.Y](upgrade-paths/mariadb-enterprise-server-10.6/upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md)
+
+Related references:
+
+* [MariaDB Package Repository Setup and Usage](../mariadb-package-repository-setup-and-usage.md) — full reference for `mariadb_repo_setup` options, including `--mariadb-server-version` and minor-release pinning.
+* [Installing MariaDB Packages with YUM](../installing-mariadb/binary-packages/rpm/yum.md)
+* [Installing MariaDB .deb Files (APT)](../installing-mariadb/binary-packages/installing-mariadb-deb-files.md)
+* [Installing MariaDB with Zypper](../installing-mariadb/binary-packages/rpm/installing-mariadb-with-zypper.md)
+* [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) — the post-upgrade data-directory utility.
+* [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/) — the recommended pre-upgrade backup tool.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 


### PR DESCRIPTION
Addresses [DOCS-5615](https://mariadbcorp.atlassian.net/browse/DOCS-5615) — customer request for a step-by-step minor-version upgrade procedure (e.g., 11.4.4 → 11.4.5) for MariaDB Community Server on Linux.

**Note on review:** this is a starting draft for @uday-dubey to refine, per the conversation on the Jira ticket. Not ready to merge as-is. Uday, please pull, review, adapt anything that doesn't match how you'd like to write it, and either push follow-up commits or take over the branch.

## What's here

Expanded the existing 39-line `upgrading-between-minor-versions-on-linux.md` (which was a high-level outline that linked out to the install pages) into a full ~280-line how-to modeled on the equivalent Enterprise Server [Upgrade MariaDB Enterprise Server from 11.4.X to 11.4.Y](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-mariadb-enterprise-server-from-11.4.x-to-11.4.y) page.

Written generically so the procedure applies to any minor-version upgrade within a supported release series, with **11.4.4 → 11.4.5** as the worked example per the customer's original request.

## Section structure

- **Data Backup** — `mariadb-backup --backup` / `--prepare` with a test-restore reminder.
- **Stop the MariaDB Server Process** — `innodb_fast_shutdown=1`, `XA RECOVER`, `systemctl stop mariadb`.
- **Install the New Version** — explanation that minor upgrades use the package manager's `update` (not uninstall + install — that's for major upgrades), with the Community `mariadb_repo_setup` syntax including the `mariadb-` prefix required on `--mariadb-server-version`. `{% tabs %}` for **YUM / APT / ZYpp** with per-distro commands.
- **Configuration** — `.rpmsave` (YUM/ZYpp) and `.dpkg-old` (APT) handling.
- **Starting the Server** — `systemctl` operations table.
- **Upgrading the Data Directory** — `mariadb-upgrade` as a safety check, with a note that minor upgrades typically don't change the data dictionary.
- **Testing** — connect with `mariadb`, `SHOW GLOBAL VARIABLES LIKE 'version'`, `SELECT VERSION()`.
- **See Also** — major-upgrade guides, equivalent ES minor-upgrade pages, repo-setup reference, install guides per package manager.

## Things @uday-dubey should double-check

1. **`mariadb_repo_setup` URL and invocation.** I used `curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup` followed by `chmod +x` and `sudo ./mariadb_repo_setup …`. Some existing pages use the shorter `curl -sS … | sudo bash` pipe-to-bash form. I went with the explicit download because it lets the example pass `--mariadb-server-version=`, which the pipe form doesn't easily support. Either is fine; if you prefer the pipe form for consistency, let me know.
2. **Package wildcard for APT.** I used `sudo apt install --only-upgrade "mariadb-*" "galera*"` matching the ES page. Worth confirming this picks up `mariadb-server`, `mariadb-client`, `mariadb-backup`, etc. on Debian/Ubuntu Community packaging.
3. **`mariadb-upgrade` note.** I added an info-box stating that minor upgrades typically don't change the data dictionary and `mariadb-upgrade` exits quickly. If that's not accurate as written, remove or adjust.
4. **MaxScale / Galera mention.** The Community `mariadb_repo_setup` script also configures MaxScale and Tools repos by default. I didn't mention this — keeping the focus tight on the upgrade — but you could add a note if customers tend to be surprised by it.

## Customer-facing answer to the original ticket

Once this lands, the page will fully cover the customer's "MariaDB 11.4.4 → 11.4.5 via YUM" scenario, plus the equivalent APT and ZYpp paths.

[DOCS-5615]: https://mariadbcorp.atlassian.net/browse/DOCS-5615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ