### PR TITLE
DOCS-6180 Add Plugin Support and Maintenance section to Plugin Maturity page

### DIFF
--- a/server/reference/plugins/information-on-plugins/list-of-plugins.md
+++ b/server/reference/plugins/information-on-plugins/list-of-plugins.md
@@ -88,6 +88,14 @@ FROM information_schema.plugins
 ORDER BY plugin_name;
 ```
 
+## Plugin Support and Maintenance
+
+Plugin maturity is not the same as plugin support and maintenance.
+
+Currently, the plugins maintained and supported by MariaDB plc for a given release series are the ones included in the corresponding MariaDB Enterprise Server release. Plugins that are not supported by MariaDB plc are either placed in a separate **unsupported repository** (reached by passing the `--include-unsupported` flag to the `mariadb_es_repo_setup` script) or omitted from the build entirely.
+
+For the authoritative statement of which plugins are supported in which release series, see the [MariaDB Engineering Policies](https://mariadb.com/engineering-policies/) and the relevant MariaDB Enterprise Server release notes.
+
 ## See Also
 
 * [Plugin Overview](../plugin-overview.md)


### PR DESCRIPTION
Addresses [DOCS-6180](https://mariadbcorp.atlassian.net/browse/DOCS-6180).

Adds a **"Plugin Support and Maintenance"** section between the maturity table and "See Also" on `server/reference/plugins/information-on-plugins/list-of-plugins.md` (the "Plugin Maturity" page). Closely follows the wording proposed in the ticket description, with two minor adjustments noted below.

## What the new section says

- Plugin **maturity** is not the same as plugin **support and maintenance**.
- The plugins currently maintained and supported by MariaDB plc for a given release series are the ones included in the corresponding MariaDB Enterprise Server release.
- Plugins not supported by MariaDB plc are either placed in a separate **unsupported repository** (reached by passing `--include-unsupported` to `mariadb_es_repo_setup`) or omitted from the build entirely.
- Points readers at the [MariaDB Engineering Policies](https://mariadb.com/engineering-policies/) and the relevant ES release notes for the authoritative statement.

## Two small adjustments to the ticket's suggested text

1. **"unsupported directory" → "unsupported repository."** The ticket text said "in the /unsupported directory." After checking, that concept doesn't exist as a source-tree directory in the upstream mariadb-server (there is no `plugin/unsupported/` or `/unsupported/`). The actual mechanism is a separate **repository** reached via `--include-unsupported` on `mariadb_es_repo_setup` — confirmed by the recently-added [Differences in Available Plugins for Enterprise Server](https://github.com/mariadb-corporation/mariadb-docs/blob/main/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-available-plugins-for-enterprise-server.md) page (which calls this out for the CONNECT engine in ES 10.5). I went with the accurate phrasing.
2. **Light grammar tightening** ("Plugins are not supported by MariaDB plc will be" → "Plugins that are not supported by MariaDB plc are…").

## About "similar pages"

The ticket mentions "the plugin maturity page and similar pages." The Plugin Maturity page is the canonical maturity reference and the natural home for this content. Of the related pages I checked:

- **`plugin-overview.md`** is about plugins in general (loading, querying, `SHOW PLUGINS`), not maturity. A support/maintenance note there would be off-topic for that page's scope.
- **Other plugin landing READMEs** (authentication-plugins, password-validation-plugins, etc.) are scoped to specific plugin categories; adding the support note to all of them would create drift.

If you'd rather have a brief cross-reference from `plugin-overview.md` to the new section here, easy follow-up — say the word and I'll add it.

[DOCS-6180]: https://mariadbcorp.atlassian.net/browse/DOCS-6180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ