### PR TITLE
DOCS-6182 Reconcile connector/python connect() parameter docs

### DIFF
--- a/connectors/mariadb-connector-python/connection.md
+++ b/connectors/mariadb-connector-python/connection.md
@@ -22,20 +22,26 @@ The `mariadb.connect()` function accepts the following parameters:
 
 ### Basic Connection Parameters
 
-- **`host`** (`str`) - Hostname or IP address of the database server. Can be a comma-separated list for failover support. Default: `'localhost'`
+- **`host`** (`str`) - Hostname or IP address of the database server. Can be a comma-separated list for failover support (requires `libmariadb` 3.3 or later when used with the C extension). Default: `'localhost'`
 - **`port`** (`int`) - Port number of the database server. Default: `3306`
 - **`user`**, **`username`** (`str`) - Username for authentication. Default: `None`
 - **`password`**, **`passwd`** (`str`) - Password for authentication. Default: `None`
 - **`database`**, **`db`** (`str`) - Database (schema) name to use. Default: `None`
-- **`unix_socket`** (`str`) - Path to Unix socket file for local connections. Default: `None`
+- **`unix_socket`** (`str`) - Path to the Unix socket file for local connections. When `host` is `localhost` and this parameter is not set, the connector auto-detects the Linux distribution (via `/etc/os-release`) and uses the same default socket path that `libmariadb` is compiled with on that distro: `/run/mysqld/mysqld.sock` on Debian, Ubuntu, Arch, and Alpine; `/var/lib/mysql/mysql.sock` on Fedora, RHEL, and CentOS; `/run/mysql/mysql.sock` on openSUSE and SLES. On non-Linux platforms (Windows, macOS) or unknown distributions no auto-detection happens and the connection falls back to TCP. `/tmp/mysql.sock` is intentionally not probed (the `/tmp` directory is world-writable, which would allow a non-privileged attacker to plant a fake socket); pass `unix_socket='/tmp/mysql.sock'` explicitly if that path is required. Default: `None`
+- **`protocol`** - Force a specific transport protocol. Accepted values are a case-insensitive string or an integer:
+  - `'DEFAULT'` / `0` - connector chooses automatically (Unix socket for `localhost` when available, otherwise TCP)
+  - `'TCP'` / `1` - force TCP/IP even when `host` is `localhost`
+  - `'SOCKET'` / `2` - force Unix socket (requires `unix_socket` to be set or auto-detected)
+
+  Default: `'DEFAULT'`
 
 ### Timeout Parameters
 
-- **`connect_timeout`** (`float`) - Timeout in seconds for establishing connection. Default: `10.0`
-- **`socket_timeout`** (`float`) - Timeout in seconds for socket operations. Default: `30.0`
-- **`read_timeout`** (`float`) - Alias for `socket_timeout`. Default: `30.0`
-- **`write_timeout`** (`float`) - Alias for `socket_timeout`. Default: `30.0`
-- **`query_timeout`** (`int`) - Maximum query execution time in seconds (0 = no timeout). Default: `0`
+- **`connect_timeout`** (`float`) - Timeout in seconds for establishing the initial connection to the server. Default: `10.0`
+- **`socket_timeout`** (`float`) - I/O timeout in seconds for socket operations (read and write). Primary timeout parameter for the pure-Python connector. Default: `30.0`
+- **`query_timeout`** (`int`) - Maximum query execution time in seconds (0 means no timeout). Default: `0`
+- **`read_timeout`** *(C extension only)* (`float`) - Read (receive) timeout in seconds, passed directly to `libmariadb`. On the pure-Python connector this value is accepted but mapped to `socket_timeout`. Default: same as `socket_timeout`
+- **`write_timeout`** *(C extension only)* (`float`) - Write (send) timeout in seconds, passed directly to `libmariadb`. On the pure-Python connector this value is accepted but mapped to `socket_timeout`. Default: same as `socket_timeout`
 
 ### SSL/TLS Parameters
 
@@ -48,7 +54,16 @@ The `mariadb.connect()` function accepts the following parameters:
 - **`ssl_crl`** (`str`) - Path to certificate revocation list file. Default: `None`
 - **`ssl_crlpath`** (`str`) - Path to directory containing CRL files. Default: `None`
 - **`ssl_verify_cert`** (`bool`) - Enable server certificate verification. Default: `False`
-- **`tls_version`** (`str`) - TLS version(s) to use (e.g., 'TLSv1.2', 'TLSv1.3', 'TLSv1.2,TLSv1.3'). Automatically enables SSL. Default: `None`
+- **`tls_version`** (`str`) - TLS version(s) to use (e.g., `'TLSv1.2'`, `'TLSv1.3'`, `'TLSv1.2,TLSv1.3'`). Automatically enables SSL. Default: `None`
+- **`tls_fp`** *(C extension only)* (`str`) - SHA-256 fingerprint of the expected server certificate, used for certificate pinning. Default: `None`
+- **`tls_fp_list`** *(C extension only)* (`str`) - Path to a file containing a list of accepted server certificate SHA-256 fingerprints. Default: `None`
+
+### Configuration File Parameters
+
+- **`default_file`** (`str`) - Read connection options from the specified MariaDB option file. On Windows the file must be a `.ini` file. If an empty string is passed, the connector reads from the default configuration files. Default: `None`
+- **`default_group`** (`str`) - Read connection options from the specified group within the option file. If not given, the default group name is the connection type. Default: `None`
+
+For a description of configuration file handling and accepted settings, see the [Configuration files](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/config_files#configuration-options) chapter of the MariaDB Connector/C documentation.
 
 ### Connection Behavior Parameters
 
@@ -56,7 +71,8 @@ The `mariadb.connect()` function accepts the following parameters:
 - **`read_only`** (`bool`) - Set connection to read-only mode. Default: `False`
 - **`compress`** (`bool`) - Enable protocol compression. Default: `False`
 - **`local_infile`** (`bool`) - Enable LOAD DATA LOCAL INFILE statements. Default: `None`
-- **`init_command`** (`str`) - SQL command to execute when connecting/reconnecting. Default: `None`
+- **`init_command`** (`str`) - SQL command to execute when connecting and reconnecting. Default: `None`
+- **`plugin_dir`** *(C extension only)* (`str`) - Directory containing MariaDB client plugins. Not applicable to the pure-Python connector. Default: `None`
 
 ### Protocol and Performance Parameters
 
@@ -80,6 +96,21 @@ The `mariadb.connect()` function accepts the following parameters:
 ### Type Conversion Parameters
 
 - **`converter`** (`dict`) - Custom type converter dictionary mapping field types to conversion functions. Default: `None`
+
+## Implementation Selection
+
+*Since version 2.0*
+
+The connector ships in three packaging variants — pure-Python, a binary wheel, and the C extension — and selects an implementation automatically at import time. Override the choice with the `MARIADB_PYTHON_CONNECTOR` environment variable:
+
+| Value | Implementation |
+|---|---|
+| `c` / `mariadb_c` | C extension (requires compilation, full feature set) |
+| `binary` / `mariadb_binary` | Binary wheel (precompiled, bundled dependencies) |
+| `python` / `mariadb` | Pure-Python implementation |
+| _unset_ | Default: try the C extension, then the binary wheel, fall back to pure-Python |
+
+Parameters tagged *(C extension only)* in the lists above are honored only when the C extension implementation is in use. On the pure-Python path those parameters are accepted but ignored, with the exception of `read_timeout` and `write_timeout` which are mapped to `socket_timeout`.
 
 ### Connection Examples
 

--- a/connectors/mariadb-connector-python/connection.md
+++ b/connectors/mariadb-connector-python/connection.md
@@ -60,8 +60,11 @@ The `mariadb.connect()` function accepts the following parameters:
 
 ### Configuration File Parameters
 
-- **`default_file`** (`str`) - Read connection options from the specified MariaDB option file. On Windows the file must be a `.ini` file. If an empty string is passed, the connector reads from the default configuration files. Default: `None`
-- **`default_group`** (`str`) - Read connection options from the specified group within the option file. If not given, the default group name is the connection type. Default: `None`
+- **`default_file`** (`str`) - Read connection options from a MariaDB/MySQL option file. Option files are read only if this parameter or `default_group` is set. Explicit connection arguments take precedence over option-file values. On Windows the file must be an `.ini` file. Default: `None`
+  - `None` (the default) reads no option file.
+  - A path reads only that file.
+  - An empty string (`""`) reads the default option files instead: `/etc`, `/etc/mysql`, `$MARIADB_HOME`/`$MYSQL_HOME`, and `~/.my.cnf`.
+- **`default_group`** (`str`) - An additional option-file group to read, on top of the always-read `[client]`, `[client-server]`, and `[client-mariadb]` groups. Setting it without `default_file` triggers reading of the default option files. Default: `None`
 
 For a description of configuration file handling and accepted settings, see the [Configuration files](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/config_files#configuration-options) chapter of the MariaDB Connector/C documentation.
 

--- a/connectors/mariadb-connector-python/module.md
+++ b/connectors/mariadb-connector-python/module.md
@@ -49,51 +49,28 @@ conn = mariadb.connect("mariadb://user:password@localhost/mydb", database="other
 
 **Keyword Arguments:**
 
-Connection parameters can also be provided as keyword arguments:
+Connection parameters can also be provided as keyword arguments. The most common ones are:
 
-- **\`host\`** - The host name or IP address of the database server. If MariaDB Connector/Python was built with MariaDB Connector/C 3.3, it is also possible to provide a comma separated list of hosts for simple fail over in case of one or more hosts are not available.
-- **\`user\`, \`username\`** - The username used to authenticate with the database server
-- **\`password\`, \`passwd\`** - The password of the given user
-- **\`database\`, \`db\`** - Database (schema) name to use when connecting with the database server
-- **\`unix_socket\`** - The location of the unix socket file to use instead of using an IP port to connect. If socket authentication is enabled, this can also be used in place of a password.
-- **\`port\`** - Port number of the database server. If not specified, the default value of 3306 will be used.
-- **\`connect_timeout\`** - Connect timeout in seconds
-- **\`read_timeout\`** - Read timeout in seconds
-- **\`write_timeout\`** - Write timeout in seconds
-- **\`local_infile\`** - Enables or disables the use of LOAD DATA LOCAL INFILE statements.
-- **\`compress\`** (default: False) - Uses the compressed protocol for client server communication. If the server doesn’t support compressed protocol, the default protocol will be used.
-- **\`init_command\`** - Command(s) which will be executed when connecting and reconnecting to the database server
-- **\`default_file\`** - Read options from the specified option file. If the file is an empty string, default configuration file(s) will be used
-- **\`default_group\`** - Read options from the specified group
-- **\`plugin_dir\`** - Directory which contains MariaDB client plugins (C extension only, not available in pure Python)
-- **\`binary\`** (default: False) - *Since version 2.0* - When enabled at connection level, all cursors default to binary protocol (prepared statements). Can be overridden per cursor.
-- **\`cache_prep_stmts\`** (default: True) - *Since version 2.0* - Enables or disables prepared statement caching. When enabled, prepared statements are reused across executions.
-- **\`prep_stmt_cache_size\`** (default: 100) - *Since version 2.0* - Maximum number of cached prepared statements per connection. When the cache is full, the least recently used statement is evicted.
-- **\`pipeline\`** (default: False) - *Since version 2.0* - Enables pipelining for batch operations
-- **\`ssl_key\`** - Defines a path to a private key file to use for TLS. This option requires that you use the absolute path, not a relative path. The specified key must be in PEM format
-- **\`ssl_cert\`** - Defines a path to the X509 certificate file to use for TLS. This option requires that you use the absolute path, not a relative path. The X609 certificate must be in PEM format.
-- **\`ssl_ca\`** - Defines a path to a PEM file that should contain one or more X509 certificates for trusted Certificate Authorities (CAs) to use for TLS. This option requires that you use the absolute path, not a relative path.
-- **\`ssl_capath\`** - Defines a path to a directory that contains one or more PEM files that contains one X509 certificate for a trusted Certificate Authority (CA)
-- **\`ssl_cipher\`** - Defines a list of permitted cipher suites to use for TLS
-- **\`ssl_crlpath\`** - Defines a path to a PEM file that should contain one or more revoked X509 certificates to use for TLS. This option requires that you use the absolute path, not a relative path.
-- **\`ssl_verify_cert\`** - Enables server certificate verification.
-- **\`ssl\`** - The connection must use TLS security, or it will fail.
-- **\`tls_version\`** - A comma-separated list (without whitespaces) of TLS versions. Valid versions are TLSv1.0, TLSv1.1,TLSv1.2 and TLSv1.3. Added in version 1.1.7.
-- **\`autocommit\`** (default: False) - Specifies the autocommit settings. True will enable autocommit, False will disable it (default).
-- **\`converter\`** - Specifies a conversion dictionary, where keys are FIELD_TYPE values and values are conversion functions
+- **`host`** - Host name or IP address of the database server. Can be a comma-separated list of hosts for simple failover. Default: `'localhost'`
+- **`port`** - Port number of the database server. Default: `3306`
+- **`user`**, **`username`** - Username for authentication
+- **`password`**, **`passwd`** - Password for authentication
+- **`database`**, **`db`** - Default database (schema) to select when connecting
+- **`unix_socket`** - Path to a Unix socket file for local connections (used in place of TCP)
+- **`autocommit`** - Enable autocommit mode. Default: `False`
+- **`converter`** - Conversion dictionary mapping `FIELD_TYPE` values to conversion functions
+
+For the full list of accepted parameters — including SSL/TLS options, timeouts, prepared-statement caching, configuration file loading, the result format options (`dictionary`, `named_tuple`, `native_object`), and the parameters that only apply to the C extension — see [The connection class](connection.md).
 
 #### Removed Parameters in Version 2.0
 
 The following parameters have been removed:
 
-- **\`reconnect\`** / **\`auto_reconnect\`** - Automatic reconnection is no longer supported. Use connection pools or call `conn.reconnect()` manually.
-- **\`cursor_type\`** - Replaced by `buffered=False` parameter in cursor creation.
-- **\`prepared\`** - Replaced by `binary=True` parameter.
+- **`reconnect`** / **`auto_reconnect`** - Automatic reconnection is no longer supported. Use connection pools or call `conn.reconnect()` manually.
+- **`cursor_type`** - Replaced by `buffered=False` parameter in cursor creation.
+- **`prepared`** - Replaced by `binary=True` parameter.
 
 For migration guidance, see the [Migration Guide](migration-from-1.1-to-2.0.md).
-
-#### NOTE
-For a description of configuration file handling and settings please read the chapter [Configuration files](https://github.com/mariadb-corporation/mariadb-connector-c/wiki/config_files#configuration-options) of the MariaDB Connector/C documentation.
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

- `connection.md` is now the single authoritative reference for `mariadb.connect()` keyword parameters, grounded against the 2.0 connector source (`mariadb/__init__.py` `connect()` docstring and `mariadb/impl/configuration.py`).
- `module.md` is slimmed to a short common-parameters list plus a cross-link to `connection.md`, so the two pages can no longer drift.
- Closes [DOCS-6182](https://mariadbcorp.atlassian.net/browse/DOCS-6182).

## Changes

**`connection.md`:**
- Added `default_file`, `default_group`, `plugin_dir`, `protocol`, `tls_fp`, `tls_fp_list`.
- Expanded `unix_socket` with Linux-distro auto-detection behaviour and the deliberate exclusion of `/tmp/mysql.sock`.
- Rewrote `read_timeout` / `write_timeout` as *(C extension only)*, with their pure-Python `socket_timeout` fallback documented.
- New `## Implementation Selection` section covering the `MARIADB_PYTHON_CONNECTOR` environment variable.
- C-extension-only parameters now tagged consistently.

**`module.md`:**
- Replaced the inline 30-bullet kwargs list with an 8-bullet common-parameters block plus a link to `connection.md`.
- Removed the orphaned configuration-file NOTE (now lives next to `default_file` / `default_group` on `connection.md`).
- Removed `default` for `pipeline` — previously contradicted `connection.md`.
- Examples and the "Removed in 2.0" subsection are unchanged.

## Notes for reviewer

The original ticket only mentioned `default_file` and `default_group` missing from `connection.md`. While grounding against the 2.0 source the discrepancy turned out to be broader (~12 parameters out of sync and a few contradictory defaults), so the PR is a full reconcile rather than a two-line fix.

While doing the grounding I also noticed two connector-side inconsistencies worth filing as separate tickets (they are *not* fixed in this PR):

1. `Configuration.from_dict()` lists `passwd` in its `valid_params` set but never reads it, so passing `passwd=` to the pure-Python path silently drops the value. The canonical `connect()` docstring documents `passwd` as a valid `password` alias.
2. Same shape for `hostname`, `server`, `schema`, `socket`, `named_pipe`, `pipe_name`.

## Test plan
- [ ] Render both pages in GitBook preview after \`expand-gitbook-aliases\` has run.
- [ ] Verify the \`module.md\` → \`connection.md\` cross-link resolves.
- [ ] Confirm \`codespell\` and \`lychee\` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6182]: https://mariadbcorp.atlassian.net/browse/DOCS-6182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ