### PR TITLE
DOCS-6184 Document UPDATE behavior on system-versioned tables

### DIFF
--- a/server/reference/sql-structure/temporal-tables/system-versioned-tables.md
+++ b/server/reference/sql-structure/temporal-tables/system-versioned-tables.md
@@ -174,6 +174,27 @@ SELECT a,row_start,row_end FROM t;
 +------+----------------------------+----------------------------+
 ```
 
+### Updating Data
+
+When an `UPDATE` statement modifies a row in a system-versioned table, the server writes a new history row capturing the previous state of the row.
+
+**A history row is created for every `UPDATE` statement that includes a versioned column in its `SET` list, regardless of whether any column value actually changes.** Running `UPDATE t SET x = x` against an existing row of a versioned table still produces a new history row — what determines history-row creation is the presence of a versioned column in the `SET` list, not whether the supplied values differ from the stored values. `UPDATE` statements whose `SET` list references only columns declared `WITHOUT SYSTEM VERSIONING` do not produce a history row.
+
+```sql
+CREATE OR REPLACE TABLE t (x INT) WITH SYSTEM VERSIONING;
+INSERT INTO t VALUES (1);
+
+-- This UPDATE changes nothing about the stored value of x,
+-- but still produces a new history row:
+UPDATE t SET x = 1;
+
+SELECT x, ROW_START, ROW_END FROM t FOR SYSTEM_TIME ALL;
+```
+
+This statement-level behavior applies to the default timestamp-based versioning. For [transaction-precise versioning](system-versioned-tables.md#transaction-precise-history-in-innodb), history generation is handled at the storage-engine level by InnoDB's MVCC and is tied to actual row-level changes.
+
+See [MDEV-39727](https://jira.mariadb.org/browse/MDEV-39727) for related discussion (duplicates [MDEV-31944](https://jira.mariadb.org/browse/MDEV-31944)).
+
 ### Querying Historical Data
 
 #### `SELECT`


### PR DESCRIPTION
## Summary

- New `### Updating Data` subsection on the system-versioned tables page clarifying that a history row is written for every `UPDATE` that touches a versioned column, even when no column value actually changes.
- Calls out the contrast with transaction-precise (VERS_TRX_ID) versioning, where history generation is delegated to InnoDB's MVCC and tied to actual row-level changes.
- Cross-links [MDEV-39727](https://jira.mariadb.org/browse/MDEV-39727) (and the older duplicate, [MDEV-31944](https://jira.mariadb.org/browse/MDEV-31944)) so readers can follow any upstream change in behavior.
- Closes [DOCS-6184](https://mariadbcorp.atlassian.net/browse/DOCS-6184).

## Why this is correct (grounded in server source)

`sql/sql_update.cc`:

- `TABLE::vers_check_update()` (line 213) determines `has_vers_fields` from whether the `UPDATE`'s `SET` list contains a versioned column — it does **not** inspect whether the supplied values differ from the stored values.
- In the per-row update loop, `need_update= !can_compare_record || compare_record(table)` (line 1021) controls whether `ha_update_row()` is called. When the new row equals the old one, `need_update` is `false` and the actual storage-engine update is skipped.
- The history-row insertion at line 1123 — `if (likely(!error) && has_vers_fields && table->versioned(VERS_TIMESTAMP))` — sits **outside** the `if (need_update)` block. So for timestamp-based versioning, the history row is written whenever a versioned column appears in `SET`, regardless of whether the row was actually changed. For `VERS_TRX_ID` (transaction-precise) versioning, the history is generated inside InnoDB and is tied to the engine's row-difference check — hence the carve-out in the new section.

## Notes for reviewer

The wording avoids labeling the current behavior as a bug or as intended-and-fixed: MDEV-39727 is open and marked as duplicating MDEV-31944, so the upstream disposition is not yet settled. The doc just describes what the server does today and points readers to the ticket.

## Test plan
- [ ] Render the page in GitBook preview after \`expand-gitbook-aliases\` runs.
- [ ] Confirm \`codespell\` and \`lychee\` pass on the changed file.
- [ ] Sanity-check that the \`## See Also\` heading is still in place (the help-tables extractor depends on \`# Title\` / \`## Syntax\` / \`## Description\` / \`## Examples\` / \`## See Also\` structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6184]: https://mariadbcorp.atlassian.net/browse/DOCS-6184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ