### PR TITLE
DOCS-6158 Document PARTIAL_ROW_DATA_EVENT in replication protocol

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -4044,6 +4044,7 @@
       * [GTID\_LIST\_EVENT](reference/clientserver-protocol/replication-protocol/gtid_list_event.md)
       * [HEARTBEAT\_LOG\_EVENT](reference/clientserver-protocol/replication-protocol/heartbeat_log_event.md)
       * [INTVAR\_EVENT](reference/clientserver-protocol/replication-protocol/intvar_event.md)
+      * [PARTIAL\_ROW\_DATA\_EVENT](reference/clientserver-protocol/replication-protocol/partial_row_data_event.md)
       * [QUERY\_EVENT](reference/clientserver-protocol/replication-protocol/query_event.md)
       * [RAND\_EVENT](reference/clientserver-protocol/replication-protocol/rand_event.md)
       * [ROTATE\_EVENT](reference/clientserver-protocol/replication-protocol/rotate_event.md)

--- a/server/reference/clientserver-protocol/replication-protocol/partial_row_data_event.md
+++ b/server/reference/clientserver-protocol/replication-protocol/partial_row_data_event.md
@@ -1,0 +1,43 @@
+---
+description: >-
+  Carries a fragment of a Rows event that exceeded the replica's
+  slave_max_allowed_packet; reassembled on the replica before execution.
+---
+
+# PARTIAL\_ROW\_DATA\_EVENT
+
+When a [`ROWS_EVENT`](rows_event_v1v2-rows_compressed_event_v1.md) (for example `WRITE_ROWS_EVENT_V1`) is too large to be sent to a replica — that is, larger than the replica's `slave_max_allowed_packet` — the rows event is fragmented into sub-events of type `PARTIAL_ROW_DATA_EVENT` so that it can still be transmitted. The replica takes the content of each `PARTIAL_ROW_DATA_EVENT` in a group and joins them together into the original rows event, which is then executed as normal.
+
+`PARTIAL_ROW_DATA_EVENT`s are written to the binary log sequentially, and the replica assembles them in the order they were binlogged. The maximum size of each `PARTIAL_ROW_DATA_EVENT` is determined by the system variable `binlog_row_event_fragment_threshold`.
+
+The event is referred to as `Partial_rows_log_event` in the server source.
+
+Added in MariaDB 12.3 ([MDEV-32570](https://jira.mariadb.org/browse/MDEV-32570)).
+
+## Header
+
+* `PARTIAL_ROW_DATA_EVENT`: Event Type is 172 (0xAC).
+
+## Fields
+
+* [uint<4>](../protocol-data-types.md#fixed-length-integers) Sequence number of this fragment within the group (1-based).
+* [uint<4>](../protocol-data-types.md#fixed-length-integers) Total number of fragments in the group.
+* [uint<1>](../protocol-data-types.md#fixed-length-integers) Flags.
+* If (flags & `FL_ORIG_EVENT_SIZE`):
+  * [uint<8>](../protocol-data-types.md#fixed-length-integers) Size of the original underlying rows event when reassembled on the replica.
+* [string\<EOF>](../protocol-data-types.md#end-of-file-length-strings) Chunk of the original rows event data carried by this fragment. Runs to the end of the event body.
+
+### Flags
+
+| Flag                 | Value | Details                                                                                                                                              |
+| -------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FL_ORIG_EVENT_SIZE` | 0x01  | Set when the original rows-event size is included in this event. Set only for the first fragment in a group (i.e. the fragment with sequence number 1). |
+
+## Notes
+
+* The current binary log format supports a maximum rows-event size of 4 GB. Even if `slave_max_allowed_packet` is later raised above its present 1 GB cap, the per-fragment size of a `PARTIAL_ROW_DATA_EVENT` would not exceed 4 GB.
+* When `mariadb-binlog` replays a group of `PARTIAL_ROW_DATA_EVENT`s, the [`TABLE_MAP_EVENT`](table_map_event.md) from the start of the group is re-emitted before the last fragment. The server treats each `BINLOG` base64 statement as standalone and closes tables after each one, so the table-map context must be re-established immediately before the final fragment — that is the fragment whose execution reassembles and runs the original rows event.
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}

--- a/server/reference/clientserver-protocol/replication-protocol/partial_row_data_event.md
+++ b/server/reference/clientserver-protocol/replication-protocol/partial_row_data_event.md
@@ -20,8 +20,8 @@ Added in MariaDB 12.3 ([MDEV-32570](https://jira.mariadb.org/browse/MDEV-32570))
 
 ## Fields
 
-* [uint<4>](../protocol-data-types.md#fixed-length-integers) Sequence number of this fragment within the group (1-based).
 * [uint<4>](../protocol-data-types.md#fixed-length-integers) Total number of fragments in the group.
+* [uint<4>](../protocol-data-types.md#fixed-length-integers) Sequence number of this fragment within the group (1-based).
 * [uint<1>](../protocol-data-types.md#fixed-length-integers) Flags.
 * If (flags & `FL_ORIG_EVENT_SIZE`):
   * [uint<8>](../protocol-data-types.md#fixed-length-integers) Size of the original underlying rows event when reassembled on the replica.


### PR DESCRIPTION
## Summary

- New replication-protocol page at `reference/clientserver-protocol/replication-protocol/partial_row_data_event.md` documenting event type 172 (0xAC), added by [MDEV-32570](https://jira.mariadb.org/browse/MDEV-32570) in MariaDB 12.3.
- Linked from `server/SUMMARY.md` alphabetically between `INTVAR_EVENT` and `QUERY_EVENT`.
- Closes [DOCS-6158](https://mariadbcorp.atlassian.net/browse/DOCS-6158).

## What the event does

When a rows event is larger than the replica's `slave_max_allowed_packet`, the primary fragments it into `PARTIAL_ROW_DATA_EVENT`s sized by `binlog_row_event_fragment_threshold`. The replica reassembles the fragments in order and executes the original rows event.

## Grounding (and one deviation from the ticket draft)

The field layout is grounded in the Doxygen block on `class Partial_rows_log_event` at `sql/log_event.h:5624-5760` (and `PARTIAL_ROWS_HEADER_LEN (4 + 4 + 1)` at line 228). One deliberate departure from the ticket's draft:

| Field          | Ticket draft order | Source order   | This PR |
|----------------|--------------------|----------------|---------|
| 4-byte uint #1 | Total fragments    | Sequence number | Sequence number |
| 4-byte uint #2 | Sequence number    | Total fragments | Total fragments |

The source's Post-Header table lists Sequence Number first, then Total Fragments, and the class members are declared in that same order (`seq_no`, `total_fragments`). I followed the source.

## Naming note

The on-the-wire enum constant is `PARTIAL_ROW_DATA_EVENT` (singular ROW), while the C++ class is `Partial_rows_log_event` (plural rows). Other event pages on the site use the enum-constant form (`WRITE_ROWS_EVENT_V1`, `XID_EVENT`, etc.) so this page follows that convention; the alternate class name is mentioned in the intro so reviewers and readers searching for either find it.

## Test plan
- [ ] Verify the new page is reachable from the GitBook nav (added to SUMMARY).
- [ ] Verify the `string<EOF>` anchor link resolves to `protocol-data-types.md#end-of-file-length-strings`.
- [ ] Spot-check that codespell / lychee pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6158]: https://mariadbcorp.atlassian.net/browse/DOCS-6158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ