### PR TITLE
Clarify Connector/Python 2.0 is an RC; 1.1 remains GA

### DIFF
--- a/connectors/connectors-quickstart-guides/connector-python-guide.md
+++ b/connectors/connectors-quickstart-guides/connector-python-guide.md
@@ -29,22 +29,37 @@ Before installing MariaDB Connector/Python, ensure you have:
 
 #### 2. Installation
 
-Choose the installation option that best fits your needs:
+{% hint style="info" %}
+**Version 1.1 is the latest stable (GA) release; version 2.0 is currently a Release Candidate (RC).** Choose the version that fits your needs below. Do not use non-stable (non-GA) releases in production.
+{% endhint %}
 
-**Pure Python (recommended for most users):**
+**Version 1.1 (stable / GA)**
+
+A plain `pip install` installs the latest stable release (1.1). It always installs the C extension and requires MariaDB Connector/C to be pre-installed; connection pooling is included by default.
+
 ```bash
 pip install mariadb
 ```
 
-**Pre-compiled binary wheels (best for production):**
+To pin to a specific 1.1 release:
+
 ```bash
-pip install mariadb[binary,pool]
+pip install mariadb==1.1.14
 ```
 
-**C extension from source (maximum performance):**
+**Version 2.0 (Release Candidate)**
+
+Version 2.0 is a pre-release, so the `--pre` flag is required — without it, pip installs the latest GA release (1.1). Choose the option that best fits your needs:
+
 ```bash
-# Requires MariaDB Connector/C installed
-pip install mariadb[c,pool]
+# Pure Python (recommended for most users)
+pip install --pre mariadb
+
+# Pre-compiled binary wheels (best for production)
+pip install --pre mariadb[binary,pool]
+
+# C extension from source (maximum performance, requires MariaDB Connector/C)
+pip install --pre mariadb[c,pool]
 ```
 
 #### 3. Basic Usage

--- a/connectors/mariadb-connector-python/README.md
+++ b/connectors/mariadb-connector-python/README.md
@@ -11,6 +11,10 @@ icon: link
 
 MariaDB Connector/Python enables python programs to access MariaDB and MySQL databases, using an API which is compliant with the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)).
 
+{% hint style="info" %}
+**Version 2.0 is currently a Release Candidate (RC); version 1.1 is the latest stable (GA) release.** Because 2.0 is not yet GA, install it with the `--pre` flag (for example `pip install --pre mariadb`); a plain `pip install mariadb` installs the latest stable release (1.1). See the [Installation](install.md) page for details. Do not use non-stable (non-GA) releases in production.
+{% endhint %}
+
 #### Contents
 
 ## Contents:

--- a/connectors/mariadb-connector-python/faq.md
+++ b/connectors/mariadb-connector-python/faq.md
@@ -68,20 +68,24 @@ of python3. If you are using python3.10 you may need to install python3.10-dev.
 
 ### Which installation option should I choose for version 2.0?
 
+{% hint style="info" %}
+Version 2.0 is currently a Release Candidate (RC); version 1.1 is the latest stable (GA) release. The 2.0 commands below use the `--pre` flag because pip otherwise installs the latest stable release (1.1). Do not use non-stable (non-GA) releases in production.
+{% endhint %}
+
 **Version 2.0** offers three installation options:
 
-1. **Pure Python (default)** - `pip install mariadb`
+1. **Pure Python (default)** - `pip install --pre mariadb`
    - Works everywhere, no compiler required
    - Good performance for most use cases
    - Recommended for development and testing
 
-2. **Pre-compiled binary wheels** - `pip install mariadb[binary]`
+2. **Pre-compiled binary wheels** - `pip install --pre mariadb[binary]`
    - Best for production
    - **MariaDB Connector/C is bundled** - no separate installation needed
    - Maximum performance without compilation
    - No compiler required
 
-3. **C extension from source** - `pip install mariadb[c]`
+3. **C extension from source** - `pip install --pre mariadb[c]`
    - **Requires MariaDB Connector/C 3.3.1+ to be pre-installed** on your system
    - Maximum performance
    - Requires C compiler for building
@@ -89,7 +93,7 @@ of python3. If you are using python3.10 you may need to install python3.10-dev.
 
 **For connection pooling**, add `[pool]` to any option:
 ```console
-pip install mariadb[binary,pool]
+pip install --pre mariadb[binary,pool]
 ```
 
 ### Do I need MariaDB Connector/C for version 2.0?
@@ -100,7 +104,7 @@ pip install mariadb[binary,pool]
 - **Binary wheels** (`mariadb[binary]`): No separate installation needed - MariaDB Connector/C is bundled inside the wheel
 - **C extension from source** (`mariadb[c]`): Yes, requires MariaDB Connector/C 3.3.1+ to be pre-installed on your system
 
-For most users, `pip install mariadb[binary,pool]` provides the best experience with no external dependencies.
+For most users, `pip install --pre mariadb[binary,pool]` provides the best experience with no external dependencies (the `--pre` flag is required while 2.0 is a Release Candidate).
 
 ### ModuleNotFoundError: No module named ‘packaging’
 
@@ -217,7 +221,7 @@ python3 -m pip install .
 
 See the comprehensive [Migration Guide](migration-from-1.1-to-2.0.md) for detailed instructions. Key changes:
 
-1. **Installation**: `pip install mariadb[binary,pool]` for best experience
+1. **Installation**: `pip install --pre mariadb[binary,pool]` for best experience (the `--pre` flag is required while 2.0 is a Release Candidate)
 2. **Remove deprecated parameters**: `reconnect`, `auto_reconnect`, `cursor_type`, `prepared`
 3. **Update cursor creation**: Use `binary=True` instead of `prepared=True`
 4. **Update pooling**: Install `mariadb[pool]` and use `create_pool()` instead of `ConnectionPool()`

--- a/connectors/mariadb-connector-python/install.md
+++ b/connectors/mariadb-connector-python/install.md
@@ -25,12 +25,24 @@ MariaDB Connector/Python 2.0 supports
 
 ## Installation Options
 
-### Installing Version 1.1
+{% hint style="info" %}
+**Version 2.0 is currently a Release Candidate (RC); version 1.1 is the latest stable (GA) release.**
 
-If you need to install the version 1.1:
+Because 2.0 is not yet GA, a plain `pip install mariadb` installs the latest stable release (1.1). To install the 2.0 release candidate you must pass the `--pre` flag, for example `pip install --pre mariadb`. Do not use non-stable (non-GA) releases in production.
+{% endhint %}
+
+### Installing Version 1.1 (Stable / GA)
+
+Version 1.1 is the current GA release. A plain `pip install` installs the latest stable version:
 
 ```console
-pip install mariadb==1.1.10
+pip install mariadb
+```
+
+To pin to a specific 1.1 release:
+
+```console
+pip install mariadb==1.1.14
 ```
 
 Version 1.1:
@@ -41,7 +53,11 @@ Version 1.1:
 
 For version 1.1 documentation, see the [1.1 branch documentation](https://mariadb-corporation.github.io/mariadb-connector-python/).
 
-### Installing Version 2.0
+### Installing Version 2.0 (Release Candidate)
+
+{% hint style="info" %}
+Version 2.0 is a Release Candidate. The `--pre` flag is required so that pip will select the pre-release; without it, pip installs the latest GA release (1.1).
+{% endhint %}
 
 MariaDB Connector/Python 2.0 offers three installation options:
 
@@ -50,10 +66,10 @@ MariaDB Connector/Python 2.0 offers three installation options:
 Works everywhere, no compiler or C dependencies required:
 
 ```console
-pip install mariadb
+pip install --pre mariadb
 ```
 
-This is the default installation method. The pure Python implementation:
+This is the default installation method for 2.0. The pure Python implementation:
 - Works on all Python interpreters (CPython, PyPy, etc.)
 - Requires no compilation or system dependencies
 - Provides good performance for most use cases
@@ -64,7 +80,7 @@ This is the default installation method. The pure Python implementation:
 For maximum performance, install the C extension:
 
 ```console
-pip install mariadb[c]
+pip install --pre mariadb[c]
 ```
 
 The C extension:
@@ -78,7 +94,7 @@ The C extension:
 Pre-compiled wheels with no local C connector required:
 
 ```console
-pip install mariadb[binary]
+pip install --pre mariadb[binary]
 ```
 
 Binary wheels:
@@ -92,13 +108,13 @@ Binary wheels:
 Connection pooling is now a separate optional package:
 
 ```console
-pip install mariadb[pool]
+pip install --pre mariadb[pool]
 ```
 
 Or combine with binary wheels:
 
 ```console
-pip install mariadb[binary,pool]
+pip install --pre mariadb[binary,pool]
 ```
 
 ### Microsoft Windows
@@ -106,13 +122,13 @@ pip install mariadb[binary,pool]
 **Option 1: Binary wheels (recommended)**
 
 ```console
-pip install mariadb[binary,pool]
+pip install --pre mariadb[binary,pool]
 ```
 
 **Option 2: Pure Python**
 
 ```console
-pip install mariadb[pool]
+pip install --pre mariadb[pool]
 ```
 
 **Option 3: C extension from source**
@@ -122,7 +138,7 @@ First install MariaDB Connector/C. MSI installers for both 32-bit and 64-bit ope
 Then install the C extension:
 
 ```console
-pip install mariadb[c,pool]
+pip install --pre mariadb[c,pool]
 ```
 
 On success, you should see a message at the end "Successfully installed mariadb-2.0.0rc2".

--- a/connectors/mariadb-connector-python/mariadb-connector-python-guide.md
+++ b/connectors/mariadb-connector-python/mariadb-connector-python-guide.md
@@ -18,20 +18,38 @@ MariaDB Connector/Python enables python programs to access MariaDB and MySQL dat
 
 All implementations support both synchronous and asynchronous operations.
 
-**Installation:**
+{% hint style="info" %}
+**Version 1.1 is the latest stable (GA) release; version 2.0 is currently a Release Candidate (RC).** Choose the version that fits your needs below. Do not use non-stable (non-GA) releases in production.
+{% endhint %}
+
+**Installation — version 1.1 (stable / GA):**
+
+A plain `pip3 install` installs the latest stable release (1.1). It always installs the C extension and requires MariaDB Connector/C to be pre-installed; connection pooling is included by default.
+
+```bash
+# Latest stable release (1.1)
+$ pip3 install mariadb
+
+# Pin to a specific 1.1 release
+$ pip3 install mariadb==1.1.14
+```
+
+**Installation — version 2.0 (Release Candidate):**
+
+Version 2.0 is a pre-release, so the `--pre` flag is required — without it, pip installs the latest GA release (1.1).
 
 ```bash
 # Pure Python (default)
-$ pip3 install mariadb
+$ pip3 install --pre mariadb
 
 # C extension for maximum performance
-$ pip3 install mariadb[c]
+$ pip3 install --pre mariadb[c]
 
 # Pre-compiled binary wheels
-$ pip3 install mariadb[binary]
+$ pip3 install --pre mariadb[binary]
 
 # With connection pooling
-$ pip3 install mariadb[binary,pool]
+$ pip3 install --pre mariadb[binary,pool]
 ```
 
 ### Links:

--- a/connectors/mariadb-connector-python/migration-from-1.1-to-2.0.md
+++ b/connectors/mariadb-connector-python/migration-from-1.1-to-2.0.md
@@ -9,6 +9,10 @@ description: >-
 
 This guide helps you migrate your applications from MariaDB Connector/Python 1.1 to version 2.0.0.
 
+{% hint style="info" %}
+**Version 2.0 is currently a Release Candidate (RC); version 1.1 is the latest stable (GA) release.** Until 2.0 reaches GA, install it with the `--pre` flag (for example `pip install --pre mariadb`); a plain `pip install mariadb` installs the latest stable release (1.1). Do not use non-stable (non-GA) releases in production.
+{% endhint %}
+
 ## API Reference
 
 - **[Connection API](connection.md)** - Connection parameters, methods, and attributes
@@ -38,28 +42,30 @@ This always installed the C extension and required MariaDB Connector/C to be pre
 
 ### Version 2.0 Installation Options
 
+Version 2.0 is still a Release Candidate, so the `--pre` flag is required; without it, pip installs the latest GA release (1.1).
+
 **Pure Python (default, works everywhere):**
 ```bash
-pip install mariadb
+pip install --pre mariadb
 ```
 
 **C extension (maximum performance):**
 ```bash
-pip install mariadb[c]
+pip install --pre mariadb[c]
 ```
 *Requires MariaDB Connector/C to be pre-installed on your system.*
 
 **Pre-compiled binary wheels (no local C connector required):**
 ```bash
-pip install mariadb[binary]
+pip install --pre mariadb[binary]
 ```
 *MariaDB Connector/C is bundled - no separate installation needed.*
 
 **With connection pooling:**
 ```bash
-pip install mariadb[pool]
+pip install --pre mariadb[pool]
 # or combined
-pip install mariadb[binary,pool]
+pip install --pre mariadb[binary,pool]
 ```
 
 ### Key Changes
@@ -181,8 +187,8 @@ pool = mariadb.ConnectionPool(
 
 **Version 2.0:**
 ```bash
-# First install pooling support
-pip install mariadb[pool]
+# First install pooling support (--pre is required while 2.0 is an RC)
+pip install --pre mariadb[pool]
 ```
 
 ```python
@@ -355,8 +361,8 @@ conn = mariadb.connect(
 ### Step 1: Update Installation
 
 ```bash
-# Choose your installation option
-pip install mariadb[binary,pool]
+# Choose your installation option (--pre is required while 2.0 is an RC)
+pip install --pre mariadb[binary,pool]
 ```
 
 ### Step 2: Update Cursor Creation

--- a/connectors/mariadb-connector-python/module.md
+++ b/connectors/mariadb-connector-python/module.md
@@ -166,10 +166,10 @@ For detailed async usage, see [Async/Await Support](async-usage.md).
 
 Creates a synchronous connection pool.
 
-**Note:** Connection pooling requires the `mariadb[pool]` package to be installed:
+**Note:** Connection pooling requires the `mariadb[pool]` package to be installed (the `--pre` flag is required while 2.0 is a Release Candidate):
 
 ```console
-pip install mariadb[pool]
+pip install --pre mariadb[pool]
 ```
 
 **Usage:**

--- a/connectors/mariadb-connector-python/pooling.md
+++ b/connectors/mariadb-connector-python/pooling.md
@@ -10,8 +10,12 @@ description: >-
 *Since version 2.0:* Connection pooling is now a separate optional package. Install with:
 
 ```console
-pip install mariadb[pool]
+pip install --pre mariadb[pool]
 ```
+
+{% hint style="info" %}
+Version 2.0 is currently a Release Candidate (RC), so the `--pre` flag is required. Version 1.1 (the latest stable/GA release) includes connection pooling by default.
+{% endhint %}
 
 A connection pool is a cache of connections to a database server where connections can be reused for future requests.
 Since establishing a connection is resource-expensive and time-consuming, especially when used inside a middle tier
@@ -197,8 +201,8 @@ conn = pool.get_connection()
 
 **Version 2.0:**
 ```python
-# Install pooling package first
-# pip install mariadb[pool]
+# Install pooling package first (--pre is required while 2.0 is an RC)
+# pip install --pre mariadb[pool]
 
 pool = mariadb.create_pool(
     host="localhost",


### PR DESCRIPTION
MariaDB Connector/Python 2.0 is currently a **Release Candidate (RC)**, while
**1.1 is the latest stable (GA) release**. Because 2.0 is a pre-release, a plain
`pip install mariadb` installs the latest GA (1.1) — to get 2.0 you must pass
`--pre`. The docs were written as though 2.0 were GA, so the install commands
(`pip install mariadb`, `pip install mariadb[binary,pool]`, etc.) would have
silently installed 1.1 instead of the intended 2.0.

This PR makes the version status explicit and corrects the install commands.
