### PR TITLE
Remove CVE-2026-44169 from release notes

### DIFF
--- a/release-notes/community-server/10.11/10.11.17.md
+++ b/release-notes/community-server/10.11/10.11.17.md
@@ -243,7 +243,6 @@ Fixes for the following security vulnerabilities
 | [CVE-2026-44172](https://www.cve.org/CVERecord?id=CVE-2026-44172) | 5.0                    |
 | [CVE-2026-44171](https://www.cve.org/CVERecord?id=CVE-2026-44171) | 6.3                    |
 | [CVE-2026-44170](https://www.cve.org/CVERecord?id=CVE-2026-44170) | 5.0                    |
-| [CVE-2026-44169](https://www.cve.org/CVERecord?id=CVE-2026-44169) | 4.3                    |
 | [CVE-2026-44168](https://www.cve.org/CVERecord?id=CVE-2026-44168) | 8.0                    |
 
 ## Changelog


### PR DESCRIPTION
Removed CVE-2026-44169 entry from the security table.