### PR TITLE
fix group_concat_max_len max

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -773,7 +773,7 @@ The suffix can be upper or lower-case.
 * Data Type: `numeric`
 * Default Value:
   * `1048576` (1M)
-* Range: `4` to `4294967295`
+* Range: `4` to `1073741824`
 
 .
 


### PR DESCRIPTION
group_concat_max_len max was changed by the latest minor releases