### PR TITLE
enabling-core-dump: ASAN with core dumps is possible

### DIFF
--- a/server/reference/product-development/debugging-mariadb/enabling-core-dumps.md
+++ b/server/reference/product-development/debugging-mariadb/enabling-core-dumps.md
@@ -274,7 +274,7 @@ See the IBM [Core Dump Handler](https://github.com/IBM/core-dump-handler) projec
 
 ## Core Files and Address Sanitizer (ASAN)
 
-If your `mariadbd` binary is built with [Address Sanitizer (ASAN)](../../../server-management/install-and-upgrade-mariadb/compiling-mariadb-from-source/legacy-guides/compile-and-using-mariadb-with-sanitizers-asan-ubsan-tsan-msan.md) then it will not be able to generate a core file.
+If your `mariadbd` binary is built with [Address Sanitizer (ASAN)](../../../server-management/install-and-upgrade-mariadb/compiling-mariadb-from-source/legacy-guides/compile-and-using-mariadb-with-sanitizers-asan-ubsan-tsan-msan.md) then it will disable core dumps by default. A core dump can be created if `mariadbd` is started with the environment variable `ASAN_OPTIONS` set with `disable_coredump=0`.
 
 ## What's Included in Core Files
 


### PR DESCRIPTION
This just requires ASAN_OPTIONS=disable_coredump=0 to be set. 


Proof:
```
$ ASAN_OPTIONS=disable_coredump=0  sql/mariadbd --no-defaults --datadir=/tmp/${PWD##*/}-datadir --socket=/tmp/${PWD##*/}.sock --plugin-dir=${PWD}/mysql-test/var/plugins/ --verbose --skip-networking 2026-06-04 15:03:18 0 [Note] Starting MariaDB 10.11.19-MariaDB-asan-debug source revision 8ec0acbe41e733a130874d39cc5a271a205ce8c6 server_uid enNnnQxEDTHTmtOjZVL8QXFFEN0= as process 120842 2026-06-04 15:03:18 0 [Note] InnoDB: !!!!!!!! UNIV_DEBUG switched on !!!!!!!!! 2026-06-04 15:03:18 0 [Note] InnoDB: Compressed tables use zlib 1.3.2 2026-06-04 15:03:18 0 [Note] InnoDB: Number of transaction pools: 1 2026-06-04 15:03:18 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions 2026-06-04 15:03:18 0 [Note] InnoDB: Using io_uring 2026-06-04 15:03:18 0 [Note] InnoDB: innodb_buffer_pool_size_max=8388614m, innodb_buffer_pool_size=128m 2026-06-04 15:03:18 0 [Note] InnoDB: Initialized memory pressure event listener 2026-06-04 15:03:18 0 [Note] InnoDB: Completed initialization of buffer pool 2026-06-04 15:03:18 0 [Note] InnoDB: Buffered log writes (block size=512 bytes) 2026-06-04 15:03:18 0 [Note] InnoDB: End of log at LSN=51576 2026-06-04 15:03:18 0 [Note] InnoDB: 128 rollback segments are active. 2026-06-04 15:03:18 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ... 2026-06-04 15:03:18 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB. 2026-06-04 15:03:18 0 [Note] InnoDB: log sequence number 51576; transaction id 14 2026-06-04 15:03:18 0 [Note] InnoDB: Loading buffer pool(s) from /tmp/build-mariadb-server-10.11-debug-datadir/ib_buffer_pool 2026-06-04 15:03:18 0 [Note] InnoDB: Buffer pool(s) load completed at 260604 15:03:18 2026-06-04 15:03:18 0 [Note] Plugin 'FEEDBACK' is disabled. 2026-06-04 15:03:18 0 [Note] sql/mariadbd: ready for connections. Version: '10.11.19-MariaDB-asan-debug'  socket: '/tmp/build-mariadb-server-10.11-debug.sock'  port: 0  Source distribution 260604 15:03:51 [ERROR] sql/mariadbd got signal 11 ; Sorry, we probably made a mistake, and this is a bug.

Your assistance in bug reporting will enable us to fix this for the next release. To report this bug, see https://mariadb.com/docs/general-resources/community/community/bug-tracking/reporting-bugs about how to report a bug on https://jira.mariadb.org/.

Please include the information from the server start above, to the end of the information below.

Server version: 10.11.19-MariaDB-asan-debug source revision: 8ec0acbe41e733a130874d39cc5a271a205ce8c6

The information page at https://mariadb.com/docs/server/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbdcontains instructions to obtain a better version of the backtrace below. Following these instructions will help MariaDB developers provide a fix quicker.

Attempting backtrace. Include this in the bug report. (note: Retrieving this information may fail)

Thread pointer: 0x0
stack_bottom = 0x0 thread_stack 0xb00000
addr2line: 'sql/mariadbd': No such file
Printing to addr2line failed
sql/mariadbd(___interceptor_backtrace+0x4a) [0x58656a] sql/mariadbd(my_print_stacktrace+0x10c) [0x27ff004] sql/mariadbd(handle_fatal_signal+0x321) [0x13e13d9] /lib64/libc.so.6(+0x1a5b0) [0x7f36f69f25b0]
/lib64/libc.so.6(+0x7be32) [0x7f36f6a53e32]
/lib64/libc.so.6(+0x7006c) [0x7f36f6a4806c]
/lib64/libc.so.6(+0x700b4) [0x7f36f6a480b4]
/lib64/libc.so.6(poll+0x1e) [0x7f36f6ac213e]
addr2line: 'sql/mariadbd': No such file
sql/mariadbd(__interceptor_poll+0x57) [0x582ef7]
sql/mariadbd(_Z26handle_connections_socketsv+0x3dc) [0x639474] sql/mariadbd() [0x637b38]
sql/mariadbd(_Z11mysqld_mainiPPc+0xfcb) [0x62df83] /lib64/libc.so.6(+0x3681) [0x7f36f69db681]
/lib64/libc.so.6(__libc_start_main+0x88) [0x7f36f69db798] addr2line: 'sql/mariadbd': No such file
sql/mariadbd(_start+0x25) [0x53c4f5]
Writing a core file...
Working directory at /tmp/build-mariadb-server-10.11-debug-datadir Resource Limits (excludes unlimited resources):
Limit                     Soft Limit           Hard Limit           Units
Max stack size            8388608              unlimited            bytes
Max processes             62725                62725                processes
Max open files            32190                524288               files
Max locked memory         8388608              8388608              bytes
Max pending signals       62725                62725                signals
Max msgqueue size         819200               819200               bytes
Max nice priority         0                    0
Max realtime priority     0                    0
Core pattern: |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %d %F

Kernel version: Linux version 7.0.10-201.fc44.x86_64 (mockbuild@cf28cc868f4b4f2890e464030f9a1614) (gcc (GCC) 16.1.1 20260515 (Red Hat 16.1.1-2), GNU ld version 2.46-3.fc44) #1 SMP PREEMPT_DYNAMIC Wed May 27 13:57:41 UTC 2026

Segmentation fault         (core dumped) ASAN_OPTIONS=disable_coredump=0 sql/mariadbd --no-defaults --datadir=/tmp/${PWD##*/}-datadir --socket=/tmp/${PWD##*/}.sock --plugin-dir=${PWD}/mysql-test/var/plugins/ --verbose --skip-networking
(base)

$ coredumpctl debug mariadbd
           PID: 120842 (mariadbd)
           UID: 1000 (dan)
           GID: 1000 (dan)
        Signal: 11 (SEGV)
     Timestamp: Thu 2026-06-04 15:03:51 AEST (56s ago)
  Command Line: sql/mariadbd --no-defaults --datadir=/tmp/build-mariadb-server-10.11-debug-datadir --socket=/tmp/build-mariadb-server-10.11-debug.sock --plugin-dir=/home/dan/repos/build-mariadb-server-10.11-debug/mysql-test/var/plugins/ --verbose --skip-networking
    Executable: /home/dan/repos/build-mariadb-server-10.11-debug/sql/mariadbd
 Control Group: /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-8093984a-999f-4026-8eb2-cc5ec0038e99.scope
          Unit: user@1000.service
     User Unit: vte-spawn-8093984a-999f-4026-8eb2-cc5ec0038e99.scope
         Slice: user-1000.slice
     Owner UID: 1000 (dan)
       Boot ID: 40545d6ac09644a3a979a938d8b649a1
    Machine ID: f92b0c4cdca64582a4d2b3171560f8ae
      Hostname: bark
       Storage: /var/lib/systemd/coredump/core.mariadbd.1000.40545d6ac09644a3a979a938d8b649a1.120842.1780549431000000.zst (present)
  Size on Disk: 3.1M
       Message: Process 120842 (mariadbd) of user 1000 dumped core.
```