### PR TITLE
DOCS-5614 Add Railroad diagram for ALTER TABLE (pilot)

### DIFF
--- a/server/.gitbook/assets/alter-table-railroad.svg
+++ b/server/.gitbook/assets/alter-table-railroad.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="915" height="223">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="62" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="133" y="35" width="74" height="32" rx="10"/>
+   <rect x="131"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="53">ONLINE</text>
+   <rect x="267" y="35" width="74" height="32" rx="10"/>
+   <rect x="265"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="275" y="53">IGNORE</text>
+   <rect x="381" y="3" width="62" height="32" rx="10"/>
+   <rect x="379"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="389" y="21">TABLE</text>
+   <rect x="483" y="35" width="34" height="32" rx="10"/>
+   <rect x="481"
+         y="33"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="491" y="53">IF</text>
+   <rect x="537" y="35" width="70" height="32" rx="10"/>
+   <rect x="535"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="545" y="53">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="647" y="3" width="80" height="32"/>
+      <rect x="645" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="655" y="21">tbl_name</text>
+   </a>
+   <rect x="767" y="35" width="58" height="32" rx="10"/>
+   <rect x="765"
+         y="33"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="775" y="53">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="845" y="35" width="28" height="32"/>
+      <rect x="843" y="33" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="853" y="53">n</text>
+   </a>
+   <rect x="767" y="79" width="78" height="32" rx="10"/>
+   <rect x="765"
+         y="77"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="775" y="97">NOWAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#alter_specification"
+      xlink:title="alter_specification">
+      <rect x="731" y="189" width="136" height="32"/>
+      <rect x="729" y="187" width="136" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="739" y="207">alter_specification</text>
+   </a>
+   <rect x="731" y="145" width="24" height="32" rx="10"/>
+   <rect x="729"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="739" y="163">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -32 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m80 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-226 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m136 0 h10 m-176 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m156 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-156 0 h10 m24 0 h10 m0 0 h112 m23 44 h-3"/>
+   <polygon points="905 203 913 199 913 207"/>
+   <polygon points="905 203 897 199 897 207"/>
+</svg>

--- a/server/reference/sql-statements/data-definition/alter/alter-table/README.md
+++ b/server/reference/sql-statements/data-definition/alter/alter-table/README.md
@@ -109,6 +109,8 @@ index_option:
 
 ```
 
+![This Railroad diagram is described in the preceding BNF diagram](../../../../../.gitbook/assets/alter-table-railroad.svg)
+
 ## Description
 
 `ALTER TABLE` enables you to change the structure of an existing table. For example, you can add or delete columns, create or destroy indexes, change the type of existing columns, or rename columns or the table itself. You can also change the comment for the table and the storage engine of the table.


### PR DESCRIPTION
## Summary

- First Railroad-diagram pilot for [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614).
- Adds `server/.gitbook/assets/alter-table-railroad.svg` (~5.9 KB, 915 × 223 px), generated from the existing BNF block on the ALTER TABLE reference page via [bottlecaps.de/rr/ui](https://bottlecaps.de/rr/ui).
- Embeds the SVG in `server/reference/sql-statements/data-definition/alter/alter-table/README.md` right after the existing `bnf` code block, before the `## Description` heading.

## Why ALTER TABLE first

ALTER TABLE is the **#1 highest-traffic BNF-containing page** under `/docs/server/` according to the Jan–Jun 2026 GA report (2,118 views — more than 2× the next-most-trafficked BNF page). Highest-impact place to validate the workflow.

## Scope of this diagram

Only the **top-level production** is rendered:

```
ALTER [ONLINE] [IGNORE] TABLE [IF EXISTS] tbl_name
    [WAIT n | NOWAIT]
    alter_specification [, alter_specification] ...
```

The `alter_specification` sub-production has 50+ variants and would produce an overlong diagram (test render was 1309 × 1351 px). The existing BNF block continues to be the canonical source for those sub-productions, and editorial judgment said one good diagram beats two overwhelming ones.

## Accessibility

The image's ALT text matches the wording the ticket prescribes:

> This Railroad diagram is described in the preceding BNF diagram

Screen-reader users get pointed at the BNF block as the canonical, machine-readable description of the same syntax.

## How the SVG was generated

1. The EBNF source (a bottlecaps-flavored translation of the BNF block) lives at `/Users/stefanhinz/maria/railroad-draft/alter-table.ebnf` (not committed — staging artifact).
2. Pasted into `https://bottlecaps.de/rr/ui`, rendered, downloaded as SVG.
3. Renamed `AlterTable.svg` → `alter-table-railroad.svg` to match repo asset-naming convention (`spider-federated.svg`, `loosescan-diagram-no-where.png`, etc.).

If this pilot is acceptable in GitBook preview, the same workflow scales to the remaining 49 entries in the Tier-1 candidate list (saved at `/Users/stefanhinz/maria/docs-5614-railroad-candidates.md`).

## Test plan
- [ ] Render the ALTER TABLE page in GitBook preview, verify the SVG renders inline and at a reasonable size on a normal desktop viewport.
- [ ] Spot-check that the page still renders cleanly on a narrow viewport (mobile width). The SVG has a fixed width of 915 px — if it overflows, we may need a `max-width: 100%` styling note.
- [ ] Confirm screen-reader behavior on the image's ALT text matches the ticket's intent.
- [ ] Confirm `codespell` and `lychee` pass (changes are an image add + one Markdown line — no prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ