### PR TITLE
DOCS-6209 Enterprise Audit: fix upgrade guidance

### DIFF
--- a/server/reference/plugins/mariadb-enterprise-audit.md
+++ b/server/reference/plugins/mariadb-enterprise-audit.md
@@ -1269,6 +1269,10 @@ MariaDB Enterprise Audit is included with MariaDB Enterprise Server. Special con
 
 For details on how to upgrade from the MariaDB Audit Plugin to MariaDB Enterprise Audit, see the sections below.
 
+{% hint style="warning" %}
+**Before upgrading the package**: Remove the v1 plugin **and** every `server_audit_*` variable setting from your configuration files *before* running `apt upgrade` (or your platform's equivalent). The new Enterprise Server does not recognize the v1 variables and will fail to start if they remain. Follow the [pre-upgrade cleanup steps](mariadb-enterprise-audit.md#check-for-and-uninstall-the-v1-plugin) below.
+{% endhint %}
+
 {% hint style="danger" %}
 **Migrating from MariaDB Audit Plugin (v1)**
 
@@ -1442,11 +1446,28 @@ Remove or comment out the plugin\_load\_add option from the configuration file:
 {% endstep %}
 {% endstepper %}
 
+#### Remove v1 Variable Settings
+
+After uninstalling the plugin, also remove every `server_audit_*` system variable from your configuration files. If any of these settings remain, the new Enterprise Server will fail to start because it does not recognize them.
+
+```bash
+$ grep --extended-regexp --with-filename \
+   'server_audit[_a-z]*[[:blank:]]*=' \
+   /etc/mysql/my.cnf \
+   /etc/mysql/mariadb.conf.d/*
+```
+
+Comment out or delete every matching line. Common variables include `server_audit_events`, `server_audit_logging`, `server_audit_incl_users`, `server_audit_excl_users`, `server_audit_file_path`, `server_audit_output_type`, `server_audit_query_log_limit`, and `server_audit_file_rotate_size`.
+
 ### Migrate v1 Settings to Enterprise Audit (v2)
 
 #### Update System Tables
 
-After upgrading to MariaDB Enterprise Server, execute mariadb-upgrade to create the [System Tables for Audit Filters](mariadb-enterprise-audit.md#system-tables-for-audit-filters).
+After upgrading to MariaDB Enterprise Server, execute `mariadb-upgrade` to create the [System Tables for Audit Filters](mariadb-enterprise-audit.md#system-tables-for-audit-filters).
+
+{% hint style="info" %}
+If `mariadb-upgrade` reports that the installation is already up to date — for example, when upgrading from Community Server 10.6 to Enterprise Server 10.6 — the audit-filter system tables will not be created. In that case, run [`mariadb-upgrade --force`](../../clients-and-utilities/deployment-tools/mariadb-upgrade.md#f-force) to force the upgrade scripts to run anyway. See [mariadb-upgrade](../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) for the full behaviour.
+{% endhint %}
 
 #### Migrate Audit Filters
 


### PR DESCRIPTION
## Summary

Fixes [DOCS-6209](https://mariadbcorp.atlassian.net/browse/DOCS-6209) — two reported issues with the **Upgrades** section of the [MariaDB Enterprise Audit](https://mariadb.com/docs/server/reference/plugins/mariadb-enterprise-audit#upgrades) page. Both surfaced for a customer migrating Community Server 10.6 → Enterprise Server 10.6.

### Issue 1 — pre-upgrade cleanup was under-specified

Before the OS-level package upgrade (`apt upgrade` / `yum upgrade` / equivalent) runs, the user must remove **both**:

- the v1 `server_audit` plugin (already covered on the page), and
- **every `server_audit_*` system variable from configuration files** (was only covered post-upgrade as part of the v1→v2 settings migration).

If any of the variables remain in config, the new Enterprise Server refuses to start because it does not know about them.

**Fix**: Add a prominent `{% hint style="warning" %}` callout at the top of the **Upgrades** section, plus a new `#### Remove v1 Variable Settings` subsection inside **Check for and Uninstall the v1 Plugin** with a `grep` recipe and the list of common variables (`server_audit_events`, `server_audit_incl_users`, `server_audit_excl_users`, `server_audit_logging`, etc.).

### Issue 2 — `mariadb-upgrade` short-circuits on same major.minor

The page said:

> After upgrading to MariaDB Enterprise Server, execute mariadb-upgrade to create the System Tables for Audit Filters.

That's only true when source and target are on different major.minor versions. When they match (e.g. Community 10.6 → ES 10.6), `mariadb-upgrade` reports the install as already up to date and the audit-filter system tables are **not** created. The escape hatch is `mariadb-upgrade --force` (server source: `client/mysql_upgrade.c:888`; docs already cover it on the [mariadb-upgrade]({server}/clients-and-utilities/deployment-tools/mariadb-upgrade#f-force) page).

**Fix**: Add an `{% hint style="info" %}` callout under **Update System Tables** that names the same-major.minor case explicitly and links to the `--force` section of the `mariadb-upgrade` page.

## Out of scope

- The post-upgrade **Migrate Audit Filters** / **Migrate Users** subsections still walk the user through commenting out `server_audit_events`, `server_audit_incl_users`, and `server_audit_excl_users` from config. With the new pre-upgrade section, those steps are redundant for users who followed the warning, but they're still useful as a checklist for users who got there without it. Left intact unless reviewers want them stripped or cross-referenced.

## Related

- Upstream bug: [MENT-1712](https://jira.mariadb.org/browse/MENT-1712)

## Test plan

- [ ] Render in GitBook (PR preview) and confirm:
  - [ ] Warning callout appears at the top of the **Upgrades** section.
  - [ ] **Remove v1 Variable Settings** appears as the last subsection inside **Check for and Uninstall the v1 Plugin**.
  - [ ] The `--force` info callout appears under **Update System Tables** and the link to `mariadb-upgrade#f-force` resolves.
- [ ] codespell, lychee, and alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6209]: https://mariadbcorp.atlassian.net/browse/DOCS-6209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ