### PR TITLE
DOCS-6198 CVE pages: explain retroactive CVE additions

### DIFF
--- a/server/security/cve/community-server.md
+++ b/server/security/cve/community-server.md
@@ -1,5 +1,11 @@
 ---
-description: Full list of CVE fixed in all versions and series of MariaDB Community Server.
+description: >-
+  This page contains a full list of CVEs fixed in all versions and series of
+  MariaDB Community Server. The list is updated continuously. CVEs may be
+  added retroactively to already-released versions, as vulnerabilities can be
+  reported to and assigned by CVE Numbering Authorities (CNAs) after the
+  corresponding fix has been released. As a result, a release may receive
+  additional CVE entries over time even after it has been published.
 ---
 
 # Security Vulnerabilities (CVE) Fixed in MariaDB Community Server

--- a/server/security/cve/enterprise-server.md
+++ b/server/security/cve/enterprise-server.md
@@ -1,7 +1,11 @@
 ---
 description: >-
-  This page contains a full list of CVE fixed in all versions and series of
-  MariaDB Enterprise Server.
+  This page contains a full list of CVEs fixed in all versions and series of
+  MariaDB Enterprise Server. The list is updated continuously. CVEs may be
+  added retroactively to already-released versions, as vulnerabilities can be
+  reported to and assigned by CVE Numbering Authorities (CNAs) after the
+  corresponding fix has been released. As a result, a release may receive
+  additional CVE entries over time even after it has been published.
 ---
 
 # Security Vulnerabilities (CVE) Fixed in MariaDB Enterprise Server


### PR DESCRIPTION
## Summary

Fixes [DOCS-6198](https://mariadbcorp.atlassian.net/browse/DOCS-6198). DBS asked why we add CVEs to already-published releases. The description on both Vulnerability Pages now explains that CVE Numbering Authorities (CNAs) can assign CVE IDs *after* the corresponding fix has shipped, so a release may pick up additional CVE entries over time.

Pages touched:

- [`server/security/cve/enterprise-server.md`]({server}/security/cve/enterprise-server)
- [`server/security/cve/community-server.md`]({server}/security/cve/community-server)

The wording is taken verbatim from the ticket's recommendation on the ES page, and adapted for the Community page (only `Enterprise Server` → `Community Server`).

The Community page's description was previously a single-line scalar; it's now a YAML folded block (`>-`) to match the Enterprise page, since the description is multi-line.

## Out of scope

The reporter noted that they're unsure whether the same explanation belongs in the **Fixed Security Vulnerabilities** tables on individual release notes pages (since not all release notes include CVEs). Left untouched. Happy to follow up if you want a small note added to those CVE tables too.

## Test plan

- [ ] Render in GitBook preview and confirm both pages show the new description.
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6198]: https://mariadbcorp.atlassian.net/browse/DOCS-6198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ