### PR TITLE
DOCS-6198 CVE pages: move CNA explanation to body paragraph

### DIFF
--- a/server/security/cve/community-server.md
+++ b/server/security/cve/community-server.md
@@ -1,14 +1,12 @@
 ---
 description: >-
   This page contains a full list of CVEs fixed in all versions and series of
-  MariaDB Community Server. The list is updated continuously. CVEs may be
-  added retroactively to already-released versions, as vulnerabilities can be
-  reported to and assigned by CVE Numbering Authorities (CNAs) after the
-  corresponding fix has been released. As a result, a release may receive
-  additional CVE entries over time even after it has been published.
+  MariaDB Community Server.
 ---
 
 # Security Vulnerabilities (CVE) Fixed in MariaDB Community Server
+
+The list is updated continuously. CVEs may be added retroactively to already-released versions, as vulnerabilities can be reported to and assigned by CVE Numbering Authorities (CNAs) after the corresponding fix has been released. As a result, a release may receive additional CVE entries over time even after it has been published.
 
 ## Table of Fixed Security Vulnerabilities
 

--- a/server/security/cve/enterprise-server.md
+++ b/server/security/cve/enterprise-server.md
@@ -1,14 +1,12 @@
 ---
 description: >-
   This page contains a full list of CVEs fixed in all versions and series of
-  MariaDB Enterprise Server. The list is updated continuously. CVEs may be
-  added retroactively to already-released versions, as vulnerabilities can be
-  reported to and assigned by CVE Numbering Authorities (CNAs) after the
-  corresponding fix has been released. As a result, a release may receive
-  additional CVE entries over time even after it has been published.
+  MariaDB Enterprise Server.
 ---
 
 # Security Vulnerabilities (CVE) Fixed in MariaDB Enterprise Server
+
+The list is updated continuously. CVEs may be added retroactively to already-released versions, as vulnerabilities can be reported to and assigned by CVE Numbering Authorities (CNAs) after the corresponding fix has been released. As a result, a release may receive additional CVE entries over time even after it has been published.
 
 ## Table of Fixed Security Vulnerabilities
 


### PR DESCRIPTION
## Summary

Fix-forward for [DOCS-6198](https://mariadbcorp.atlassian.net/browse/DOCS-6198). The previous PR ([#549](https://github.com/mariadb-corporation/mariadb-docs/pull/549)) put the long CNA explanation entirely into the YAML frontmatter `description`. GitBook truncates the rendered meta-description at ~200 characters, so on the live pages the explanation gets cut mid-sentence:

- https://mariadb.com/docs/server/security/cve/enterprise-server
- https://mariadb.com/docs/server/security/cve/community-server

This PR:

- Restores the `description` to just the first sentence (short enough to render in full).
- Moves the rest of the explanation to a body paragraph between the `# Security Vulnerabilities (CVE) Fixed in …` H1 and the `## Table of Fixed Security Vulnerabilities` heading, where it renders without truncation.

The wording itself is unchanged from the reporter's text in DOCS-6198.

## Test plan

- [ ] GitBook preview shows the full CNA paragraph in the body of each page.
- [ ] The page subtitle (rendered description) shows only the first sentence and is not truncated mid-word.
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6198]: https://mariadbcorp.atlassian.net/browse/DOCS-6198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ