### PR TITLE
DOCS-5978 Storage I/O background page (step 1)

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -979,6 +979,7 @@
       * [Multi Range Read Optimization](ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md)
     * [Operating System Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/README.md)
       * [Filesystem Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/filesystem-optimizations.md)
+      * [Storage I/O: Buffering and Persistence](ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md)
     * [Optimization and Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/README.md)
       * [Building the best INDEX for a given SELECT](ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select.md)
       * [Compound (Composite) Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md)

--- a/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md
+++ b/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md
@@ -1,0 +1,67 @@
+---
+description: >-
+  Defines the OS-agnostic terms MariaDB documentation uses for disk I/O —
+  unbuffered I/O, write-through, persist — and shows how each one maps to
+  Linux and Windows mechanisms.
+---
+
+# Storage I/O: Buffering and Persistence
+
+This page defines the I/O behavior terms that other MariaDB documentation pages use — *unbuffered I/O*, *write-through*, *persist to non-volatile storage* — and shows how each one maps to the underlying mechanism on Linux and Windows. Other pages refer here for the OS-level details rather than embedding Linux-specific flag names inline.
+
+## Why This Matters
+
+The MariaDB server, and especially the [InnoDB](../../../server-usage/storage-engines/innodb/) storage engine, needs precise control over when writes actually reach non-volatile storage. The operating system normally buffers writes in memory (the *page cache*) and flushes them to disk on its own schedule. That is fast, but unsafe for a transactional database: a power loss between the application write and the OS flush would lose committed data.
+
+MariaDB therefore exposes configuration that lets administrators choose between OS-buffered performance and database-controlled durability. The configuration uses general I/O terms — buffering, write-through, persistence — that describe the behavior independent of the operating system. This page is the reference for what those terms mean and how each OS implements them.
+
+## Unbuffered I/O
+
+**Behavior**: Reads and writes bypass the operating system's page cache. Each read fetches directly from the storage device; each write is handed to the device without keeping a copy in OS memory.
+
+**Trade-off**: Avoids "double buffering" — that is, caching the same data both in MariaDB's own buffer pool and in the OS page cache, which costs memory and CPU. The trade-off is the loss of the OS's read-ahead and write-coalescing optimizations. Unbuffered I/O is most appropriate when MariaDB itself manages most of the memory available for caching data (for example, when the InnoDB buffer pool is sized to most of system RAM).
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | File opened with `O_DIRECT` |
+| Windows          | File opened with `FILE_FLAG_NO_BUFFERING` |
+
+## Write-Through
+
+**Behavior**: Every individual write call returns only after the storage layer has accepted the data for non-volatile storage. Equivalent to issuing a write followed by an immediate persist, on every single write.
+
+**Trade-off**: Maximum durability per write, at the cost of write latency. The application does not need to issue a separate persist call to know that data is safe.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | File opened with `O_DSYNC` |
+| Windows          | File opened with `FILE_FLAG_WRITE_THROUGH` |
+
+## Persist to Non-Volatile Storage
+
+**Behavior**: After one or more buffered writes, force any data still in the OS page cache or the storage device's own write cache out to non-volatile media. The call returns only once the data is durable.
+
+**Trade-off**: Lets the application batch many writes cheaply and persist them with a single explicit call, instead of paying the durability cost on every write (as write-through does). This is the foundation of MariaDB's group-commit and binary-log durability behavior.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | `fsync()` |
+| Windows          | `FlushFileBuffers()` |
+
+## Persist Data Without Metadata Sync
+
+**Behavior**: Like *persist to non-volatile storage*, but skips synchronization of non-essential file metadata such as the last-modified timestamp. The file contents and any metadata required to read them back are durable; bookkeeping metadata may still be in cache.
+
+**Trade-off**: Cheaper than a full persist on filesystems where metadata updates would otherwise trigger an additional disk write. Used in performance-critical paths where MariaDB does not care about timestamp durability.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | `fdatasync()` |
+| Windows          | `NtFlushBuffersFileEx()` with the `FLUSH_FLAGS_FILE_DATA_SYNC_ONLY` flag, with `FlushFileBuffers()` as a fallback on older Windows versions or non-NTFS filesystems |
+
+## See Also
+
+* [`innodb_flush_method`](../../../server-usage/storage-engines/innodb/innodb-flush-method.md) — selects InnoDB's combination of buffering and persistence strategies.
+* [`sync_binlog`](../../standard-replication/replication-and-binary-log-system-variables.md#sync_binlog) — controls how often the binary log is persisted.
+* [`innodb_doublewrite`](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_doublewrite) — InnoDB's protection against torn writes.
+* [Filesystem Optimizations](filesystem-optimizations.md) — choosing and tuning the filesystem MariaDB writes to.


### PR DESCRIPTION
## Summary

Draft PR for [DOCS-5978](https://mariadbcorp.atlassian.net/browse/DOCS-5978), **step 1**: a new background page that defines disk-I/O behavior in OS-agnostic English (unbuffered I/O, write-through, persist) and maps each term to its Linux and Windows mechanism.

Motivation comes from Vlad Vaintroub's comment on DOCS-5520:

> ...generally to get rid of [the] habit to put various Linux open() flags directly into documentation and describe what happens in generic terms, applicable to all OSes. e.g. do not use O_DIRECT, use "unbuffered IO", do not use O_DSYNC, use "write-through", do not use fsync(), use "persist to non-volatile storage". In a single place, it can be clarified what all those terms mean, on various OSes...

This PR is **just the new page**. The sweep that replaces inline `O_DIRECT` / `O_DSYNC` / `fsync` mentions on other pages with English + a link here is **step 2**, will be a follow-up PR.

### New file

`server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md`

Sections:

- **Why This Matters** — short framing on the page-cache vs database-durability tradeoff.
- **Unbuffered I/O** — Linux `O_DIRECT` ↔ Windows `FILE_FLAG_NO_BUFFERING`.
- **Write-Through** — Linux `O_DSYNC` ↔ Windows `FILE_FLAG_WRITE_THROUGH`.
- **Persist to Non-Volatile Storage** — Linux `fsync()` ↔ Windows `FlushFileBuffers()`.
- **Persist Data Without Metadata Sync** — Linux `fdatasync()` ↔ Windows `NtFlushBuffersFileEx(..., FLUSH_FLAGS_FILE_DATA_SYNC_ONLY)` with `FlushFileBuffers` as fallback on older Windows / non-NTFS.
- **See Also** — `innodb_flush_method`, `sync_binlog`, `innodb_doublewrite`, Filesystem Optimizations.

Added under **Operating System Optimizations** alongside Filesystem Optimizations; wired into `server/SUMMARY.md`.

### Cross-check against `mariadb-server`

OS mappings are not just from Vlad's comment — they were verified against the server source:

- `storage/innobase/os/os0file.cc` — Windows uses `FILE_FLAG_NO_BUFFERING`, `FILE_FLAG_WRITE_THROUGH`, `FlushFileBuffers`, and `NtFlushBuffersFileEx` with `FLUSH_FLAGS_FILE_DATA_SYNC_ONLY` (one small correction vs Vlad's draft: it's `_SYNC_ONLY`, not `_FILE_DATA_ONLY`).
- `handler/ha_innodb.cc` — the `innodb_flush_method` value names (`fsync`, `O_DSYNC`, `O_DIRECT`, plus Windows-only `unbuffered`, `async_unbuffered`, `normal`) confirm the mixed-OS-flavored vocabulary the page is designed to displace.

## Reviewers

Marked **draft** until reviewed. Per the ticket, requesting:

- @vaintroub — original author of the suggestion and authoritative on the Windows-side mappings
- @svoj-mariadb and @markot-mariadb (if applicable) — server / InnoDB durability context

(@-mentions in this body are illustrative; actual reviewer assignment goes through the GitHub UI.)

## Out of scope (= step 2, follow-up PR)

Sweep of the existing docs to replace inline `O_DIRECT` / `O_DSYNC` / `fsync()` prose mentions with English plus a link here. Quick scope estimate from `grep`:

| Term | Files (prose + config-value uses) |
|------|----------------------------------:|
| `O_DIRECT` | 16 |
| `O_DSYNC` | 4 |
| `fsync` | 53 |
| `fdatasync` | 11 |

The 53 `fsync` hits include legitimate ones where `fsync` is the value of `innodb_flush_method=fsync` — those stay; only prose mentions get rewritten.

## Test plan

- [ ] GitBook preview renders the new page with intact section structure.
- [ ] SUMMARY entry shows "Storage I/O: Buffering and Persistence" under Operating System Optimizations.
- [ ] All `See Also` links resolve.
- [ ] codespell, lychee, and alias-expand CI checks pass.
- [ ] Vlad / Serg / Marko sign off on the technical content before this is marked ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5978]: https://mariadbcorp.atlassian.net/browse/DOCS-5978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ