### PR TITLE
DOCS-5614 add Railroad diagrams to 5 high-traffic SQL pages

### DIFF
--- a/server/.gitbook/assets/create-database-railroad.svg
+++ b/server/.gitbook/assets/create-database-railroad.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="829" height="167">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="3" width="92" height="32" rx="10"/>
+   <rect x="341"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="21">DATABASE</text>
+   <rect x="343" y="47" width="76" height="32" rx="10"/>
+   <rect x="341"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="65">SCHEMA</text>
+   <rect x="495" y="35" width="34" height="32" rx="10"/>
+   <rect x="493"
+         y="33"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="53">IF</text>
+   <rect x="549" y="35" width="48" height="32" rx="10"/>
+   <rect x="547"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="557" y="53">NOT</text>
+   <rect x="617" y="35" width="70" height="32" rx="10"/>
+   <rect x="615"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="625" y="53">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#db_name"
+      xlink:title="db_name">
+      <rect x="727" y="3" width="80" height="32"/>
+      <rect x="725" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="735" y="21">db_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#create_specification"
+      xlink:title="create_specification">
+      <rect x="635" y="113" width="146" height="32"/>
+      <rect x="633" y="111" width="146" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="643" y="131">create_specification</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m40 -44 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-236 144 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h156 m-186 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m166 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-166 0 h10 m146 0 h10 m23 34 h-3"/>
+   <polygon points="819 161 827 157 827 165"/>
+   <polygon points="819 161 811 157 811 165"/>
+</svg>

--- a/server/.gitbook/assets/create-database-specification-railroad.svg
+++ b/server/.gitbook/assets/create-database-specification-railroad.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="665" height="221">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="35" width="80" height="32" rx="10"/>
+   <rect x="69"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="53">DEFAULT</text>
+   <rect x="211" y="3" width="102" height="32" rx="10"/>
+   <rect x="209"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="21">CHARACTER</text>
+   <rect x="333" y="3" width="44" height="32" rx="10"/>
+   <rect x="331"
+         y="1"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="21">SET</text>
+   <rect x="417" y="35" width="30" height="32" rx="10"/>
+   <rect x="415"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#charset_name"
+      xlink:title="charset_name">
+      <rect x="487" y="3" width="110" height="32"/>
+      <rect x="485" y="1" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="495" y="21">charset_name</text>
+   </a>
+   <rect x="211" y="79" width="82" height="32" rx="10"/>
+   <rect x="209"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="97">COLLATE</text>
+   <rect x="333" y="111" width="30" height="32" rx="10"/>
+   <rect x="331"
+         y="109"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="129">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#collation_name"
+      xlink:title="collation_name">
+      <rect x="403" y="79" width="116" height="32"/>
+      <rect x="401" y="77" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="411" y="97">collation_name</text>
+   </a>
+   <rect x="51" y="155" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="153"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="173">COMMENT</text>
+   <rect x="179" y="187" width="30" height="32" rx="10"/>
+   <rect x="177"
+         y="185"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="205">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#comment"
+      xlink:title="comment">
+      <rect x="249" y="155" width="78" height="32"/>
+      <rect x="247" y="153" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="257" y="173">comment</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -32 h10 m102 0 h10 m0 0 h10 m44 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m110 0 h10 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v56 m426 0 v-56 m-426 56 q0 10 10 10 m406 0 q10 0 10 -10 m-416 10 h10 m82 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m116 0 h10 m0 0 h78 m-586 -76 h20 m586 0 h20 m-626 0 q10 0 10 10 m606 0 q0 -10 10 -10 m-616 10 v132 m606 0 v-132 m-606 132 q0 10 10 10 m586 0 q10 0 10 -10 m-596 10 h10 m88 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m78 0 h10 m0 0 h290 m23 -152 h-3"/>
+   <polygon points="655 17 663 13 663 21"/>
+   <polygon points="655 17 647 13 647 21"/>
+</svg>

--- a/server/.gitbook/assets/create-view-railroad.svg
+++ b/server/.gitbook/assets/create-view-railroad.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="845" height="647">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="104" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">ALGORITHM</text>
+   <rect x="467" y="35" width="30" height="32" rx="10"/>
+   <rect x="465"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="475" y="53">=</text>
+   <rect x="537" y="35" width="100" height="32" rx="10"/>
+   <rect x="535"
+         y="33"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="545" y="53">UNDEFINED</text>
+   <rect x="537" y="79" width="66" height="32" rx="10"/>
+   <rect x="535"
+         y="77"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="545" y="97">MERGE</text>
+   <rect x="537" y="123" width="100" height="32" rx="10"/>
+   <rect x="535"
+         y="121"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="545" y="141">TEMPTABLE</text>
+   <rect x="45" y="221" width="80" height="32" rx="10"/>
+   <rect x="43"
+         y="219"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="239">DEFINER</text>
+   <rect x="145" y="221" width="30" height="32" rx="10"/>
+   <rect x="143"
+         y="219"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="153" y="239">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="215" y="221" width="48" height="32"/>
+      <rect x="213" y="219" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="223" y="239">user</text>
+   </a>
+   <rect x="215" y="265" width="128" height="32" rx="10"/>
+   <rect x="213"
+         y="263"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="283">CURRENT_USER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="215" y="309" width="44" height="32"/>
+      <rect x="213" y="307" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="223" y="327">role</text>
+   </a>
+   <rect x="215" y="353" width="130" height="32" rx="10"/>
+   <rect x="213"
+         y="351"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="371">CURRENT_ROLE</text>
+   <rect x="425" y="221" width="48" height="32" rx="10"/>
+   <rect x="423"
+         y="219"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="433" y="239">SQL</text>
+   <rect x="493" y="221" width="88" height="32" rx="10"/>
+   <rect x="491"
+         y="219"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="501" y="239">SECURITY</text>
+   <rect x="621" y="221" width="80" height="32" rx="10"/>
+   <rect x="619"
+         y="219"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="629" y="239">DEFINER</text>
+   <rect x="621" y="265" width="84" height="32" rx="10"/>
+   <rect x="619"
+         y="263"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="629" y="283">INVOKER</text>
+   <rect x="765" y="189" width="58" height="32" rx="10"/>
+   <rect x="763"
+         y="187"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="773" y="207">VIEW</text>
+   <rect x="46" y="451" width="34" height="32" rx="10"/>
+   <rect x="44"
+         y="449"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="54" y="469">IF</text>
+   <rect x="100" y="451" width="48" height="32" rx="10"/>
+   <rect x="98"
+         y="449"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="108" y="469">NOT</text>
+   <rect x="168" y="451" width="70" height="32" rx="10"/>
+   <rect x="166"
+         y="449"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="176" y="469">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#view_name"
+      xlink:title="view_name">
+      <rect x="278" y="419" width="92" height="32"/>
+      <rect x="276" y="417" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="286" y="437">view_name</text>
+   </a>
+   <rect x="410" y="451" width="26" height="32" rx="10"/>
+   <rect x="408"
+         y="449"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="418" y="469">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_list"
+      xlink:title="column_list">
+      <rect x="456" y="451" width="92" height="32"/>
+      <rect x="454" y="449" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="464" y="469">column_list</text>
+   </a>
+   <rect x="568" y="451" width="26" height="32" rx="10"/>
+   <rect x="566"
+         y="449"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="576" y="469">)</text>
+   <rect x="634" y="419" width="38" height="32" rx="10"/>
+   <rect x="632"
+         y="417"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="642" y="437">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_statement"
+      xlink:title="select_statement">
+      <rect x="692" y="419" width="130" height="32"/>
+      <rect x="690" y="417" width="130" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="700" y="437">select_statement</text>
+   </a>
+   <rect x="405" y="537" width="58" height="32" rx="10"/>
+   <rect x="403"
+         y="535"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="413" y="555">WITH</text>
+   <rect x="503" y="569" width="94" height="32" rx="10"/>
+   <rect x="501"
+         y="567"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="587">CASCADED</text>
+   <rect x="503" y="613" width="64" height="32" rx="10"/>
+   <rect x="501"
+         y="611"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="631">LOCAL</text>
+   <rect x="637" y="537" width="64" height="32" rx="10"/>
+   <rect x="635"
+         y="535"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="645" y="555">CHECK</text>
+   <rect x="721" y="537" width="76" height="32" rx="10"/>
+   <rect x="719"
+         y="535"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="729" y="555">OPTION</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h324 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v12 m354 0 v-12 m-354 12 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m104 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m66 0 h10 m0 0 h34 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-696 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h330 m-360 0 h20 m340 0 h20 m-380 0 q10 0 10 10 m360 0 q0 -10 10 -10 m-370 10 v12 m360 0 v-12 m-360 12 q0 10 10 10 m340 0 q10 0 10 -10 m-350 10 h10 m80 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m48 0 h10 m0 0 h82 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m60 -164 h10 m0 0 h310 m-340 0 h20 m320 0 h20 m-360 0 q10 0 10 10 m340 0 q0 -10 10 -10 m-350 10 v12 m340 0 v-12 m-340 12 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m48 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m80 0 h10 m0 0 h4 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m40 -76 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-841 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m92 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m38 0 h10 m0 0 h10 m130 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-481 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h402 m-432 0 h20 m412 0 h20 m-452 0 q10 0 10 10 m432 0 q0 -10 10 -10 m-442 10 v12 m432 0 v-12 m-432 12 q0 10 10 10 m412 0 q10 0 10 -10 m-422 10 h10 m58 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m64 0 h10 m0 0 h30 m20 -76 h10 m64 0 h10 m0 0 h10 m76 0 h10 m23 -32 h-3"/>
+   <polygon points="835 519 843 515 843 523"/>
+   <polygon points="835 519 827 515 827 523"/>
+</svg>

--- a/server/.gitbook/assets/delete-railroad.svg
+++ b/server/.gitbook/assets/delete-railroad.svg
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="897" height="441">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="70" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">DELETE</text>
+   <rect x="141" y="35" width="130" height="32" rx="10"/>
+   <rect x="139"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="53">LOW_PRIORITY</text>
+   <rect x="331" y="35" width="64" height="32" rx="10"/>
+   <rect x="329"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="339" y="53">QUICK</text>
+   <rect x="455" y="35" width="74" height="32" rx="10"/>
+   <rect x="453"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="53">IGNORE</text>
+   <rect x="569" y="3" width="60" height="32" rx="10"/>
+   <rect x="567"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="21">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="649" y="3" width="80" height="32"/>
+      <rect x="647" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="657" y="21">tbl_name</text>
+   </a>
+   <rect x="295" y="117" width="98" height="32" rx="10"/>
+   <rect x="293"
+         y="115"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="135">PARTITION</text>
+   <rect x="413" y="117" width="26" height="32" rx="10"/>
+   <rect x="411"
+         y="115"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="421" y="135">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_list"
+      xlink:title="partition_list">
+      <rect x="459" y="117" width="100" height="32"/>
+      <rect x="457" y="115" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="467" y="135">partition_list</text>
+   </a>
+   <rect x="579" y="117" width="26" height="32" rx="10"/>
+   <rect x="577"
+         y="115"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="587" y="135">)</text>
+   <rect x="69" y="199" width="48" height="32" rx="10"/>
+   <rect x="67"
+         y="197"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="77" y="217">FOR</text>
+   <rect x="137" y="199" width="84" height="32" rx="10"/>
+   <rect x="135"
+         y="197"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="217">PORTION</text>
+   <rect x="241" y="199" width="38" height="32" rx="10"/>
+   <rect x="239"
+         y="197"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="249" y="217">OF</text>
+   <rect x="299" y="199" width="74" height="32" rx="10"/>
+   <rect x="297"
+         y="197"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="217">PERIOD</text>
+   <rect x="393" y="199" width="60" height="32" rx="10"/>
+   <rect x="391"
+         y="197"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="401" y="217">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr1"
+      xlink:title="expr1">
+      <rect x="473" y="199" width="56" height="32"/>
+      <rect x="471" y="197" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="481" y="217">expr1</text>
+   </a>
+   <rect x="549" y="199" width="38" height="32" rx="10"/>
+   <rect x="547"
+         y="197"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="557" y="217">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr2"
+      xlink:title="expr2">
+      <rect x="607" y="199" width="56" height="32"/>
+      <rect x="605" y="197" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="615" y="217">expr2</text>
+   </a>
+   <rect x="723" y="199" width="38" height="32" rx="10"/>
+   <rect x="721"
+         y="197"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="731" y="217">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#alias"
+      xlink:title="alias">
+      <rect x="781" y="199" width="50" height="32"/>
+      <rect x="779" y="197" width="50" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="789" y="217">alias</text>
+   </a>
+   <rect x="45" y="281" width="70" height="32" rx="10"/>
+   <rect x="43"
+         y="279"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="299">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#where_condition"
+      xlink:title="where_condition">
+      <rect x="135" y="281" width="124" height="32"/>
+      <rect x="133" y="279" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="143" y="299">where_condition</text>
+   </a>
+   <rect x="319" y="281" width="68" height="32" rx="10"/>
+   <rect x="317"
+         y="279"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="327" y="299">ORDER</text>
+   <rect x="407" y="281" width="38" height="32" rx="10"/>
+   <rect x="405"
+         y="279"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="415" y="299">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_by_specification"
+      xlink:title="order_by_specification">
+      <rect x="465" y="281" width="164" height="32"/>
+      <rect x="463" y="279" width="164" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="473" y="299">order_by_specification</text>
+   </a>
+   <rect x="689" y="281" width="60" height="32" rx="10"/>
+   <rect x="687"
+         y="279"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="697" y="299">LIMIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#row_count"
+      xlink:title="row_count">
+      <rect x="769" y="281" width="86" height="32"/>
+      <rect x="767" y="279" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="777" y="299">row_count</text>
+   </a>
+   <rect x="595" y="391" width="100" height="32" rx="10"/>
+   <rect x="593"
+         y="389"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="603" y="409">RETURNING</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_expr"
+      xlink:title="select_expr">
+      <rect x="735" y="391" width="94" height="32"/>
+      <rect x="733" y="389" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="743" y="409">select_expr</text>
+   </a>
+   <rect x="735" y="347" width="24" height="32" rx="10"/>
+   <rect x="733"
+         y="345"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="743" y="365">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -32 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-498 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-620 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h604 m-634 0 h20 m614 0 h20 m-654 0 q10 0 10 10 m634 0 q0 -10 10 -10 m-644 10 v12 m634 0 v-12 m-634 12 q0 10 10 10 m614 0 q10 0 10 -10 m-624 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h118 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v12 m148 0 v-12 m-148 12 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m38 0 h10 m0 0 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-870 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m70 0 h10 m0 0 h10 m124 0 h10 m40 -32 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m164 0 h10 m40 -32 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m60 0 h10 m0 0 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-344 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
+   <polygon points="887 405 895 401 895 409"/>
+   <polygon points="887 405 879 401 879 409"/>
+</svg>

--- a/server/.gitbook/assets/insert-railroad.svg
+++ b/server/.gitbook/assets/insert-railroad.svg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="941" height="437">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="70" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">INSERT</text>
+   <rect x="143" y="35" width="130" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">LOW_PRIORITY</text>
+   <rect x="143" y="79" width="82" height="32" rx="10"/>
+   <rect x="141"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="97">DELAYED</text>
+   <rect x="143" y="123" width="134" height="32" rx="10"/>
+   <rect x="141"
+         y="121"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="141">HIGH_PRIORITY</text>
+   <rect x="337" y="35" width="74" height="32" rx="10"/>
+   <rect x="335"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="53">IGNORE</text>
+   <rect x="471" y="35" width="56" height="32" rx="10"/>
+   <rect x="469"
+         y="33"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="479" y="53">INTO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="567" y="3" width="80" height="32"/>
+      <rect x="565" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="575" y="21">tbl_name</text>
+   </a>
+   <rect x="67" y="265" width="98" height="32" rx="10"/>
+   <rect x="65"
+         y="263"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="75" y="283">PARTITION</text>
+   <rect x="185" y="265" width="26" height="32" rx="10"/>
+   <rect x="183"
+         y="263"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="193" y="283">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_list"
+      xlink:title="partition_list">
+      <rect x="231" y="265" width="100" height="32"/>
+      <rect x="229" y="263" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="239" y="283">partition_list</text>
+   </a>
+   <rect x="351" y="265" width="26" height="32" rx="10"/>
+   <rect x="349"
+         y="263"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="359" y="283">)</text>
+   <rect x="437" y="233" width="26" height="32" rx="10"/>
+   <rect x="435"
+         y="231"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="445" y="251">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="503" y="233" width="38" height="32"/>
+      <rect x="501" y="231" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="511" y="251">col</text>
+   </a>
+   <rect x="503" y="189" width="24" height="32" rx="10"/>
+   <rect x="501"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="207">,</text>
+   <rect x="581" y="233" width="26" height="32" rx="10"/>
+   <rect x="579"
+         y="231"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="589" y="251">)</text>
+   <rect x="667" y="233" width="72" height="32" rx="10"/>
+   <rect x="665"
+         y="231"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="675" y="251">VALUES</text>
+   <rect x="667" y="277" width="64" height="32" rx="10"/>
+   <rect x="665"
+         y="275"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="675" y="295">VALUE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value_list"
+      xlink:title="value_list">
+      <rect x="799" y="233" width="80" height="32"/>
+      <rect x="797" y="231" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="251">value_list</text>
+   </a>
+   <rect x="799" y="189" width="24" height="32" rx="10"/>
+   <rect x="797"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="807" y="207">,</text>
+   <rect x="45" y="387" width="40" height="32" rx="10"/>
+   <rect x="43"
+         y="385"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="405">ON</text>
+   <rect x="105" y="387" width="98" height="32" rx="10"/>
+   <rect x="103"
+         y="385"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="405">DUPLICATE</text>
+   <rect x="223" y="387" width="46" height="32" rx="10"/>
+   <rect x="221"
+         y="385"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="231" y="405">KEY</text>
+   <rect x="289" y="387" width="74" height="32" rx="10"/>
+   <rect x="287"
+         y="385"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="297" y="405">UPDATE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="403" y="387" width="38" height="32"/>
+      <rect x="401" y="385" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="411" y="405">col</text>
+   </a>
+   <rect x="461" y="387" width="30" height="32" rx="10"/>
+   <rect x="459"
+         y="385"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="469" y="405">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="511" y="387" width="48" height="32"/>
+      <rect x="509" y="385" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="519" y="405">expr</text>
+   </a>
+   <rect x="403" y="343" width="24" height="32" rx="10"/>
+   <rect x="401"
+         y="341"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="411" y="361">,</text>
+   <rect x="639" y="387" width="100" height="32" rx="10"/>
+   <rect x="637"
+         y="385"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="405">RETURNING</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_expr"
+      xlink:title="select_expr">
+      <rect x="779" y="387" width="94" height="32"/>
+      <rect x="777" y="385" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="787" y="405">select_expr</text>
+   </a>
+   <rect x="779" y="343" width="24" height="32" rx="10"/>
+   <rect x="777"
+         y="341"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="787" y="361">,</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m130 0 h10 m0 0 h4 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m82 0 h10 m0 0 h52 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m40 -120 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -32 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-644 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v14 m210 0 v-14 m-210 14 q0 10 10 10 m190 0 q10 0 10 -10 m-200 10 h10 m0 0 h180 m40 -34 h10 m72 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m64 0 h10 m0 0 h8 m40 -44 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-918 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m40 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m24 0 h10 m0 0 h132 m-554 44 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v14 m574 0 v-14 m-574 14 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m0 0 h544 m40 -34 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
+   <polygon points="931 401 939 397 939 405"/>
+   <polygon points="931 401 923 397 923 405"/>
+</svg>

--- a/server/.gitbook/assets/insert-value-list-railroad.svg
+++ b/server/.gitbook/assets/insert-value-list-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="311" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="26" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="117" y="47" width="48" height="32"/>
+      <rect x="115" y="45" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="125" y="65">expr</text>
+   </a>
+   <rect x="117" y="91" width="80" height="32" rx="10"/>
+   <rect x="115"
+         y="89"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="109">DEFAULT</text>
+   <rect x="97" y="3" width="24" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">,</text>
+   <rect x="257" y="47" width="26" height="32" rx="10"/>
+   <rect x="255"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="65">)</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m26 0 h10 m40 0 h10 m48 0 h10 m0 0 h32 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-140 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m20 44 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="301 61 309 57 309 65"/>
+   <polygon points="301 61 293 57 293 65"/>
+</svg>

--- a/server/.gitbook/assets/update-railroad.svg
+++ b/server/.gitbook/assets/update-railroad.svg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="981" height="419">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="74" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">UPDATE</text>
+   <rect x="145" y="35" width="130" height="32" rx="10"/>
+   <rect x="143"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="153" y="53">LOW_PRIORITY</text>
+   <rect x="335" y="35" width="74" height="32" rx="10"/>
+   <rect x="333"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="53">IGNORE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#table_reference"
+      xlink:title="table_reference">
+      <rect x="449" y="3" width="120" height="32"/>
+      <rect x="447" y="1" width="120" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="457" y="21">table_reference</text>
+   </a>
+   <rect x="609" y="35" width="98" height="32" rx="10"/>
+   <rect x="607"
+         y="33"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="617" y="53">PARTITION</text>
+   <rect x="727" y="35" width="26" height="32" rx="10"/>
+   <rect x="725"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="735" y="53">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_list"
+      xlink:title="partition_list">
+      <rect x="773" y="35" width="100" height="32"/>
+      <rect x="771" y="33" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="781" y="53">partition_list</text>
+   </a>
+   <rect x="893" y="35" width="26" height="32" rx="10"/>
+   <rect x="891"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="901" y="53">)</text>
+   <rect x="45" y="177" width="48" height="32" rx="10"/>
+   <rect x="43"
+         y="175"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="195">FOR</text>
+   <rect x="113" y="177" width="84" height="32" rx="10"/>
+   <rect x="111"
+         y="175"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="121" y="195">PORTION</text>
+   <rect x="217" y="177" width="38" height="32" rx="10"/>
+   <rect x="215"
+         y="175"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="195">OF</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#period"
+      xlink:title="period">
+      <rect x="275" y="177" width="60" height="32"/>
+      <rect x="273" y="175" width="60" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="283" y="195">period</text>
+   </a>
+   <rect x="355" y="177" width="60" height="32" rx="10"/>
+   <rect x="353"
+         y="175"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="363" y="195">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr1"
+      xlink:title="expr1">
+      <rect x="435" y="177" width="56" height="32"/>
+      <rect x="433" y="175" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="443" y="195">expr1</text>
+   </a>
+   <rect x="511" y="177" width="38" height="32" rx="10"/>
+   <rect x="509"
+         y="175"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="519" y="195">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr2"
+      xlink:title="expr2">
+      <rect x="569" y="177" width="56" height="32"/>
+      <rect x="567" y="175" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="577" y="195">expr2</text>
+   </a>
+   <rect x="665" y="145" width="44" height="32" rx="10"/>
+   <rect x="663"
+         y="143"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="673" y="163">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="749" y="145" width="38" height="32"/>
+      <rect x="747" y="143" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="757" y="163">col</text>
+   </a>
+   <rect x="807" y="145" width="30" height="32" rx="10"/>
+   <rect x="805"
+         y="143"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="815" y="163">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#set_value"
+      xlink:title="set_value">
+      <rect x="857" y="145" width="82" height="32"/>
+      <rect x="855" y="143" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="865" y="163">set_value</text>
+   </a>
+   <rect x="749" y="101" width="24" height="32" rx="10"/>
+   <rect x="747"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="757" y="119">,</text>
+   <rect x="87" y="259" width="70" height="32" rx="10"/>
+   <rect x="85"
+         y="257"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="95" y="277">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#where_condition"
+      xlink:title="where_condition">
+      <rect x="177" y="259" width="124" height="32"/>
+      <rect x="175" y="257" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="185" y="277">where_condition</text>
+   </a>
+   <rect x="361" y="259" width="68" height="32" rx="10"/>
+   <rect x="359"
+         y="257"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="369" y="277">ORDER</text>
+   <rect x="449" y="259" width="38" height="32" rx="10"/>
+   <rect x="447"
+         y="257"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="457" y="277">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_by_specification"
+      xlink:title="order_by_specification">
+      <rect x="507" y="259" width="164" height="32"/>
+      <rect x="505" y="257" width="164" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="515" y="277">order_by_specification</text>
+   </a>
+   <rect x="731" y="259" width="60" height="32" rx="10"/>
+   <rect x="729"
+         y="257"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="739" y="277">LIMIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#row_count"
+      xlink:title="row_count">
+      <rect x="811" y="259" width="86" height="32"/>
+      <rect x="809" y="257" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="819" y="277">row_count</text>
+   </a>
+   <rect x="679" y="369" width="100" height="32" rx="10"/>
+   <rect x="677"
+         y="367"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="687" y="387">RETURNING</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_expr"
+      xlink:title="select_expr">
+      <rect x="819" y="369" width="94" height="32"/>
+      <rect x="817" y="367" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="827" y="387">select_expr</text>
+   </a>
+   <rect x="819" y="325" width="24" height="32" rx="10"/>
+   <rect x="817"
+         y="323"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="827" y="343">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -32 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m120 0 h10 m20 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-958 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h590 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v12 m620 0 v-12 m-620 12 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m44 0 h10 m20 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m82 0 h10 m-230 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m210 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-210 0 h10 m24 0 h10 m0 0 h166 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-936 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m70 0 h10 m0 0 h10 m124 0 h10 m40 -32 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m164 0 h10 m40 -32 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m60 0 h10 m0 0 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
+   <polygon points="971 383 979 379 979 387"/>
+   <polygon points="971 383 963 379 963 387"/>
+</svg>

--- a/server/.gitbook/assets/update-set-value-railroad.svg
+++ b/server/.gitbook/assets/update-set-value-railroad.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="179" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="51" y="3" width="48" height="32"/>
+      <rect x="49" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="21">expr</text>
+   </a>
+   <rect x="51" y="47" width="80" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">DEFAULT</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m48 0 h10 m0 0 h32 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m23 -44 h-3"/>
+   <polygon points="169 17 177 13 177 21"/>
+   <polygon points="169 17 161 13 161 21"/>
+</svg>

--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -979,6 +979,7 @@
       * [Multi Range Read Optimization](ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md)
     * [Operating System Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/README.md)
       * [Filesystem Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/filesystem-optimizations.md)
+      * [Storage I/O: Buffering and Persistence](ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md)
     * [Optimization and Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/README.md)
       * [Building the best INDEX for a given SELECT](ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select.md)
       * [Compound (Composite) Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md)

--- a/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md
+++ b/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md
@@ -1,0 +1,67 @@
+---
+description: >-
+  Defines the OS-agnostic terms MariaDB documentation uses for disk I/O —
+  unbuffered I/O, write-through, persist — and shows how each one maps to
+  Linux and Windows mechanisms.
+---
+
+# Storage I/O: Buffering and Persistence
+
+This page defines the I/O behavior terms that other MariaDB documentation pages use — *unbuffered I/O*, *write-through*, *persist to non-volatile storage* — and shows how each one maps to the underlying mechanism on Linux and Windows. Other pages refer here for the OS-level details rather than embedding Linux-specific flag names inline.
+
+## Why This Matters
+
+The MariaDB server, and especially the [InnoDB](../../../server-usage/storage-engines/innodb/) storage engine, needs precise control over when writes actually reach non-volatile storage. The operating system normally buffers writes in memory (the *page cache*) and flushes them to disk on its own schedule. That is fast, but unsafe for a transactional database: a power loss between the application write and the OS flush would lose committed data.
+
+MariaDB therefore exposes configuration that lets administrators choose between OS-buffered performance and database-controlled durability. The configuration uses general I/O terms — buffering, write-through, persistence — that describe the behavior independent of the operating system. This page is the reference for what those terms mean and how each OS implements them.
+
+## Unbuffered I/O
+
+**Behavior**: Reads and writes bypass the operating system's page cache. Each read fetches directly from the storage device; each write is handed to the device without keeping a copy in OS memory.
+
+**Trade-off**: Avoids "double buffering" — that is, caching the same data both in MariaDB's own buffer pool and in the OS page cache, which costs memory and CPU. The trade-off is the loss of the OS's read-ahead and write-coalescing optimizations. Unbuffered I/O is most appropriate when MariaDB itself manages most of the memory available for caching data (for example, when the InnoDB buffer pool is sized to most of system RAM).
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | File opened with `O_DIRECT` |
+| Windows          | File opened with `FILE_FLAG_NO_BUFFERING` |
+
+## Write-Through
+
+**Behavior**: Every individual write call returns only after the storage layer has accepted the data for non-volatile storage. Equivalent to issuing a write followed by an immediate persist, on every single write.
+
+**Trade-off**: Maximum durability per write, at the cost of write latency. The application does not need to issue a separate persist call to know that data is safe.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | File opened with `O_DSYNC` |
+| Windows          | File opened with `FILE_FLAG_WRITE_THROUGH` |
+
+## Persist to Non-Volatile Storage
+
+**Behavior**: After one or more buffered writes, force any data still in the OS page cache or the storage device's own write cache out to non-volatile media. The call returns only once the data is durable.
+
+**Trade-off**: Lets the application batch many writes cheaply and persist them with a single explicit call, instead of paying the durability cost on every write (as write-through does). This is the foundation of MariaDB's group-commit and binary-log durability behavior.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | `fsync()` |
+| Windows          | `FlushFileBuffers()` |
+
+## Persist Data Without Metadata Sync
+
+**Behavior**: Like *persist to non-volatile storage*, but skips synchronization of non-essential file metadata such as the last-modified timestamp. The file contents and any metadata required to read them back are durable; bookkeeping metadata may still be in cache.
+
+**Trade-off**: Cheaper than a full persist on filesystems where metadata updates would otherwise trigger an additional disk write. Used in performance-critical paths where MariaDB does not care about timestamp durability.
+
+| Operating system | Underlying mechanism |
+|------------------|----------------------|
+| Linux            | `fdatasync()` |
+| Windows          | `NtFlushBuffersFileEx()` with the `FLUSH_FLAGS_FILE_DATA_SYNC_ONLY` flag, with `FlushFileBuffers()` as a fallback on older Windows versions or non-NTFS filesystems |
+
+## See Also
+
+* [`innodb_flush_method`](../../../server-usage/storage-engines/innodb/innodb-flush-method.md) — selects InnoDB's combination of buffering and persistence strategies.
+* [`sync_binlog`](../../standard-replication/replication-and-binary-log-system-variables.md#sync_binlog) — controls how often the binary log is persisted.
+* [`innodb_doublewrite`](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_doublewrite) — InnoDB's protection against torn writes.
+* [Filesystem Optimizations](filesystem-optimizations.md) — choosing and tuning the filesystem MariaDB writes to.

--- a/server/reference/sql-statements/data-definition/create/create-database.md
+++ b/server/reference/sql-statements/data-definition/create/create-database.md
@@ -18,6 +18,10 @@ create_specification:
   | COMMENT [=] 'comment'
 ```
 
+![Railroad diagram of CREATE DATABASE — equivalent to the BNF above](../../../../.gitbook/assets/create-database-railroad.svg)
+
+![Railroad diagram of create_specification](../../../../.gitbook/assets/create-database-specification-railroad.svg)
+
 ## Description
 
 `CREATE DATABASE` creates a database with the given name. To use this statement, you need the [CREATE privilege](../../account-management-sql-statements/grant.md#database-privileges) for the database. `CREATE SCHEMA` is a synonym for `CREATE DATABASE`.

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
@@ -27,6 +27,10 @@ DELETE [LOW_PRIORITY] [QUICK] [IGNORE]
     [, select_expr ...]]
 ```
 
+![Railroad diagram of single-table DELETE — equivalent to the BNF above](../../../../.gitbook/assets/delete-railroad.svg)
+
+The `AS alias` clause is available from MariaDB 11.6. `order_by_specification` stands in for the abbreviated `ORDER BY ...` in the source BNF; see [ORDER BY](../selecting-data/order-by.md) for its full form.
+
 Multiple-table syntax:
 
 ```sql

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
@@ -23,8 +23,15 @@ UPDATE [LOW_PRIORITY] [IGNORE] table_reference
   [WHERE where_condition]
   [ORDER BY ...]
   [LIMIT row_count]
-  RETURNING OLD_VALUE(val) AS old [, val as new]
+  [RETURNING select_expr 
+    [, select_expr ...]]
 ```
+
+![Railroad diagram of single-table UPDATE — equivalent to the BNF above](../../../../.gitbook/assets/update-railroad.svg)
+
+![Railroad diagram of set_value](../../../../.gitbook/assets/update-set-value-railroad.svg)
+
+`order_by_specification` stands in for the abbreviated `ORDER BY ...` in the source BNF; see [ORDER BY](../selecting-data/order-by.md) for its full form.
 
 {% hint style="info" %}
 The `RETURNING` clause is available from MariaDB 13.0.

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert.md
@@ -18,6 +18,10 @@ INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE]
       [, select_expr ...]]
 ```
 
+![Railroad diagram of INSERT ... VALUES — equivalent to the BNF above](../../../../.gitbook/assets/insert-railroad.svg)
+
+![Railroad diagram of value_list](../../../../.gitbook/assets/insert-value-list-railroad.svg)
+
 Or:
 
 ```sql

--- a/server/server-usage/views/create-view.md
+++ b/server/server-usage/views/create-view.md
@@ -20,6 +20,8 @@ CREATE
     [WITH [CASCADED | LOCAL] CHECK OPTION]
 ```
 
+![Railroad diagram of CREATE VIEW — equivalent to the BNF above](../../.gitbook/assets/create-view-railroad.svg)
+
 ## Description
 
 The `CREATE VIEW` statement creates a new [view](./), or replaces an existing one if the `OR REPLACE` clause is given. If the view does not exist, `CREATE OR REPLACE VIEW` is the same as `CREATE VIEW`. If the view does exist, `CREATE OR REPLACE VIEW` is the same as [ALTER VIEW](alter-view.md).


### PR DESCRIPTION
## Summary

Second batch of Railroad-diagram work under [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614), following reviewer feedback on the ALTER TABLE prototype ([#545](https://github.com/mariadb-corporation/mariadb-docs/pull/545)) that complete RR diagrams are most useful on pages where they don't dominate the page.

Pages with complete diagrams added directly under the existing ```bnf block:

| Page | Top-50 rank | Views | Diagrams added |
|---|---:|---:|---|
| [CREATE DATABASE](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-database) | 5 | 746 | top-level + `create_specification` |
| [INSERT](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert) | 6 | 745 | top-level + `value_list` |
| [UPDATE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/update) (single-table) | 7 | 741 | top-level + `set_value` |
| [DELETE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete) (single-table) | 15 | 495 | top-level |
| [CREATE VIEW](https://mariadb.com/docs/server/server-usage/views/create-view) | 16 | 484 | top-level |

8 SVGs total under `server/.gitbook/assets/`. EBNF sources are kept locally under `/Users/stefanhinz/maria/railroad-draft/` for future re-renders.

## Editorial notes added in prose next to the diagrams

- **DELETE**: the `AS alias` clause carries a "from MariaDB 11.6" note. The source BNF had this as an inline `--` comment that the diagram itself cannot render.
- **DELETE, UPDATE**: `order_by_specification` is identified in prose as the stand-in for the abbreviated `[ORDER BY ...]` in the source BNF.

## Source-BNF cleanup folded in

The UPDATE page's BNF previously ended with:

```
RETURNING OLD_VALUE(val) AS old [, val as new]
```

That mixed a concrete example with syntax brackets and was missing the optionality brackets around RETURNING. Replaced with the canonical form used on INSERT and DELETE:

```
[RETURNING select_expr 
  [, select_expr ...]]
```

The `OLD_VALUE()` / `NEW_VALUE()` semantics remain documented in the existing hint immediately below the BNF, which already links to the function reference.

## Out of scope

- Multi-table UPDATE / DELETE syntax blocks were left without diagrams (they're tagged `sql`, not `bnf`, and were not in the DOCS-5614 retag pass; can be added later if reviewers want).
- Pages where the BNF is one trivial line (data-type pages, function pages) — the diagram would not add value beyond the BNF itself.
- Pages where a complete diagram would dominate the layout (GRANT, CREATE USER, CREATE TABLE, SELECT) — they remain candidates for top-level-only diagrams in a future batch if reviewers want that pattern.

## Reversibility

If any diagram looks off in GitBook preview, the embed line for that one is a single `![...](...)` markdown image that's safe to comment out without touching anything else. The SVG file can stay in place for the next attempt.

## Test plan

- [ ] GitBook preview renders each diagram inline under its `bnf` block.
- [ ] All 8 SVG references resolve (verified locally with `find -f`).
- [ ] The UPDATE page's revised BNF reads `[RETURNING select_expr [, select_expr ...]]`.
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ