### PR TITLE
Restore Railroad diagram references that were lost in GitBook sync conflict

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -980,6 +980,7 @@
       * [Multi Range Read Optimization](ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md)
     * [Operating System Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/README.md)
       * [Filesystem Optimizations](ha-and-performance/optimization-and-tuning/operating-system-optimizations/filesystem-optimizations.md)
+      [Storage I/O: Buffering and Persistence](ha-and-performance/optimization-and-tuning/operating-system-optimizations/storage-io-buffering-and-persistence.md)
     * [Optimization and Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/README.md)
       * [Building the best INDEX for a given SELECT](ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select.md)
       * [Compound (Composite) Indexes](ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md)

--- a/server/reference/sql-statements/data-definition/create/create-database.md
+++ b/server/reference/sql-statements/data-definition/create/create-database.md
@@ -18,6 +18,10 @@ create_specification:
   | COMMENT [=] 'comment'
 ```
 
+![Railroad diagram of CREATE DATABASE — equivalent to the BNF above](../../../../.gitbook/assets/create-database-railroad.svg)
+
+![Railroad diagram of create_specification](../../../../.gitbook/assets/create-database-specification-railroad.svg)
+
 ## Description
 
 `CREATE DATABASE` creates a database with the given name. To use this statement, you need the [CREATE privilege](../../account-management-sql-statements/grant.md#database-privileges) for the database. `CREATE SCHEMA` is a synonym for `CREATE DATABASE`.

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
@@ -27,6 +27,10 @@ DELETE [LOW_PRIORITY] [QUICK] [IGNORE]
     [, select_expr ...]]
 ```
 
+![Railroad diagram of single-table DELETE — equivalent to the BNF above](../../../../.gitbook/assets/delete-railroad.svg)
+
+The `AS alias` clause is available from MariaDB 11.6. `order_by_specification` stands in for the abbreviated `ORDER BY ...` in the source BNF; see [ORDER BY](../selecting-data/order-by.md) for its full form.
+
 Multiple-table syntax:
 
 ```sql

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
@@ -23,8 +23,16 @@ UPDATE [LOW_PRIORITY] [IGNORE] table_reference
   [WHERE where_condition]
   [ORDER BY ...]
   [LIMIT row_count]
+  [RETURNING select_expr 
+    [, select_expr ...]]
   RETURNING OLD_VALUE(val) AS old [, val as new]
 ```
+
+![Railroad diagram of single-table UPDATE — equivalent to the BNF above](../../../../.gitbook/assets/update-railroad.svg)
+
+![Railroad diagram of set_value](../../../../.gitbook/assets/update-set-value-railroad.svg)
+
+`order_by_specification` stands in for the abbreviated `ORDER BY ...` in the source BNF; see [ORDER BY](../selecting-data/order-by.md) for its full form.
 
 {% hint style="info" %}
 The `RETURNING` clause is available from MariaDB 13.0.

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert.md
@@ -18,6 +18,10 @@ INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE]
       [, select_expr ...]]
 ```
 
+![Railroad diagram of INSERT ... VALUES — equivalent to the BNF above](../../../../.gitbook/assets/insert-railroad.svg)
+
+![Railroad diagram of value_list](../../../../.gitbook/assets/insert-value-list-railroad.svg)
+
 Or:
 
 ```sql

--- a/server/server-usage/views/create-view.md
+++ b/server/server-usage/views/create-view.md
@@ -20,6 +20,8 @@ CREATE
     [WITH [CASCADED | LOCAL] CHECK OPTION]
 ```
 
+![Railroad diagram of CREATE VIEW — equivalent to the BNF above](../../.gitbook/assets/create-view-railroad.svg)
+
 ## Description
 
 The `CREATE VIEW` statement creates a new [view](./), or replaces an existing one if the `OR REPLACE` clause is given. If the view does not exist, `CREATE OR REPLACE VIEW` is the same as `CREATE VIEW`. If the view does exist, `CREATE OR REPLACE VIEW` is the same as [ALTER VIEW](alter-view.md).


### PR DESCRIPTION
GitBook sync conflict caused a8c2fa64a commit to overwrite Railroad diagram additions. This commit restores the deleted lines across 5 .md files and 1 SUMMARY.md entry.