### PR TITLE
MXS Remove comment on source from release notes

### DIFF
--- a/release-notes/maxscale/script/generate_release_notes.sh
+++ b/release-notes/maxscale/script/generate_release_notes.sh
@@ -69,15 +69,6 @@ document.
 RPM and Debian packages are provided for the supported Linux distributions.
 
 Packages can be downloaded [here](https://mariadb.com/downloads).
-
-## Source Code
-
-The source code of MaxScale is tagged at GitHub with a tag, which is identical
-with the version of MaxScale. For instance, the tag of version X.Y.Z of MaxScale
-is \`maxscale-X.Y.Z\`. Further, the default branch is always the latest GA version
-of MaxScale.
-
-The source code is available [here](https://github.com/mariadb-corporation/MaxScale).
 EOF
 
 echo Manually update the following files:


### PR DESCRIPTION
The script used for generating the release notes must not add a comment on the source code as it no longer is publicly available.