### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more high-traffic SQL pages

### DIFF
--- a/server/.gitbook/assets/create-trigger-event-railroad.svg
+++ b/server/.gitbook/assets/create-trigger-event-railroad.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="439" height="191">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="70" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">INSERT</text>
+   <rect x="51" y="91" width="74" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">UPDATE</text>
+   <rect x="165" y="91" width="38" height="32" rx="10"/>
+   <rect x="163"
+         y="89"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="173" y="109">OF</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_name"
+      xlink:title="column_name">
+      <rect x="243" y="91" width="108" height="32"/>
+      <rect x="241" y="89" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="251" y="109">column_name</text>
+   </a>
+   <rect x="243" y="47" width="24" height="32" rx="10"/>
+   <rect x="241"
+         y="45"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="251" y="65">,</text>
+   <rect x="51" y="157" width="70" height="32" rx="10"/>
+   <rect x="49"
+         y="155"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="175">DELETE</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m70 0 h10 m0 0 h270 m-380 0 h20 m360 0 h20 m-400 0 q10 0 10 10 m380 0 q0 -10 10 -10 m-390 10 v68 m380 0 v-68 m-380 68 q0 10 10 10 m360 0 q10 0 10 -10 m-370 10 h10 m74 0 h10 m20 0 h10 m38 0 h10 m20 0 h10 m108 0 h10 m-148 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m128 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-128 0 h10 m24 0 h10 m0 0 h84 m-226 44 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v14 m246 0 v-14 m-246 14 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m0 0 h216 m-350 -44 v20 m380 0 v-20 m-380 20 v46 m380 0 v-46 m-380 46 q0 10 10 10 m360 0 q10 0 10 -10 m-370 10 h10 m70 0 h10 m0 0 h270 m23 -154 h-3"/>
+   <polygon points="429 17 437 13 437 21"/>
+   <polygon points="429 17 421 13 421 21"/>
+</svg>

--- a/server/.gitbook/assets/create-trigger-railroad.svg
+++ b/server/.gitbook/assets/create-trigger-railroad.svg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="993" height="485">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="80" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">DEFINER</text>
+   <rect x="443" y="35" width="30" height="32" rx="10"/>
+   <rect x="441"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="513" y="35" width="48" height="32"/>
+      <rect x="511" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="53">user</text>
+   </a>
+   <rect x="513" y="79" width="128" height="32" rx="10"/>
+   <rect x="511"
+         y="77"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="97">CURRENT_USER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="513" y="123" width="44" height="32"/>
+      <rect x="511" y="121" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="141">role</text>
+   </a>
+   <rect x="513" y="167" width="130" height="32" rx="10"/>
+   <rect x="511"
+         y="165"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="185">CURRENT_ROLE</text>
+   <rect x="703" y="3" width="80" height="32" rx="10"/>
+   <rect x="701"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="711" y="21">TRIGGER</text>
+   <rect x="45" y="309" width="34" height="32" rx="10"/>
+   <rect x="43"
+         y="307"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="327">IF</text>
+   <rect x="99" y="309" width="48" height="32" rx="10"/>
+   <rect x="97"
+         y="307"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="107" y="327">NOT</text>
+   <rect x="167" y="309" width="70" height="32" rx="10"/>
+   <rect x="165"
+         y="307"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="175" y="327">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#trigger_name"
+      xlink:title="trigger_name">
+      <rect x="277" y="277" width="106" height="32"/>
+      <rect x="275" y="275" width="106" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="285" y="295">trigger_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#trigger_time"
+      xlink:title="trigger_time">
+      <rect x="403" y="277" width="98" height="32"/>
+      <rect x="401" y="275" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="411" y="295">trigger_time</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#trigger_event"
+      xlink:title="trigger_event">
+      <rect x="541" y="277" width="106" height="32"/>
+      <rect x="539" y="275" width="106" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="549" y="295">trigger_event</text>
+   </a>
+   <rect x="541" y="233" width="40" height="32" rx="10"/>
+   <rect x="539"
+         y="231"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="549" y="251">OR</text>
+   <rect x="687" y="277" width="40" height="32" rx="10"/>
+   <rect x="685"
+         y="275"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="695" y="295">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="747" y="277" width="80" height="32"/>
+      <rect x="745" y="275" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="755" y="295">tbl_name</text>
+   </a>
+   <rect x="847" y="277" width="48" height="32" rx="10"/>
+   <rect x="845"
+         y="275"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="855" y="295">FOR</text>
+   <rect x="915" y="277" width="56" height="32" rx="10"/>
+   <rect x="913"
+         y="275"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="923" y="295">EACH</text>
+   <rect x="435" y="375" width="54" height="32" rx="10"/>
+   <rect x="433"
+         y="373"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="443" y="393">ROW</text>
+   <rect x="549" y="407" width="88" height="32" rx="10"/>
+   <rect x="547"
+         y="405"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="557" y="425">FOLLOWS</text>
+   <rect x="549" y="451" width="90" height="32" rx="10"/>
+   <rect x="547"
+         y="449"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="557" y="469">PRECEDES</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#other_trigger_name"
+      xlink:title="other_trigger_name">
+      <rect x="679" y="407" width="148" height="32"/>
+      <rect x="677" y="405" width="148" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="687" y="425">other_trigger_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#trigger_stmt"
+      xlink:title="trigger_stmt">
+      <rect x="867" y="375" width="98" height="32"/>
+      <rect x="865" y="373" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="875" y="393">trigger_stmt</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h330 m-360 0 h20 m340 0 h20 m-380 0 q10 0 10 10 m360 0 q0 -10 10 -10 m-370 10 v12 m360 0 v-12 m-360 12 q0 10 10 10 m340 0 q10 0 10 -10 m-350 10 h10 m80 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m48 0 h10 m0 0 h82 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -164 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-802 274 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m106 0 h10 m0 0 h10 m98 0 h10 m20 0 h10 m106 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m40 0 h10 m0 0 h66 m20 44 h10 m40 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m54 0 h10 m20 0 h10 m0 0 h308 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v12 m338 0 v-12 m-338 12 q0 10 10 10 m318 0 q10 0 10 -10 m-308 10 h10 m88 0 h10 m0 0 h2 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m20 -44 h10 m148 0 h10 m20 -32 h10 m98 0 h10 m3 0 h-3"/>
+   <polygon points="983 389 991 385 991 393"/>
+   <polygon points="983 389 975 385 975 393"/>
+</svg>

--- a/server/.gitbook/assets/create-trigger-time-railroad.svg
+++ b/server/.gitbook/assets/create-trigger-time-railroad.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="173" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="74" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">BEFORE</text>
+   <rect x="51" y="47" width="62" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">AFTER</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m74 0 h10 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m62 0 h10 m0 0 h12 m23 -44 h-3"/>
+   <polygon points="163 17 171 13 171 21"/>
+   <polygon points="163 17 155 13 155 21"/>
+</svg>

--- a/server/.gitbook/assets/load-data-infile-railroad.svg
+++ b/server/.gitbook/assets/load-data-infile-railroad.svg
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1229" height="783">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="58" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">LOAD</text>
+   <rect x="109" y="3" width="56" height="32" rx="10"/>
+   <rect x="107"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="117" y="21">DATA</text>
+   <rect x="205" y="35" width="130" height="32" rx="10"/>
+   <rect x="203"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="213" y="53">LOW_PRIORITY</text>
+   <rect x="205" y="79" width="114" height="32" rx="10"/>
+   <rect x="203"
+         y="77"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="213" y="97">CONCURRENT</text>
+   <rect x="395" y="35" width="64" height="32" rx="10"/>
+   <rect x="393"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="403" y="53">LOCAL</text>
+   <rect x="499" y="3" width="66" height="32" rx="10"/>
+   <rect x="497"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="507" y="21">INFILE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#file_name"
+      xlink:title="file_name">
+      <rect x="585" y="3" width="82" height="32"/>
+      <rect x="583" y="1" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="593" y="21">file_name</text>
+   </a>
+   <rect x="707" y="35" width="80" height="32" rx="10"/>
+   <rect x="705"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="53">REPLACE</text>
+   <rect x="707" y="79" width="74" height="32" rx="10"/>
+   <rect x="705"
+         y="77"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="97">IGNORE</text>
+   <rect x="827" y="3" width="56" height="32" rx="10"/>
+   <rect x="825"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="835" y="21">INTO</text>
+   <rect x="903" y="3" width="62" height="32" rx="10"/>
+   <rect x="901"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="911" y="21">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="398" y="145" width="80" height="32"/>
+      <rect x="396" y="143" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="406" y="163">tbl_name</text>
+   </a>
+   <rect x="518" y="177" width="102" height="32" rx="10"/>
+   <rect x="516"
+         y="175"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="526" y="195">CHARACTER</text>
+   <rect x="640" y="177" width="44" height="32" rx="10"/>
+   <rect x="638"
+         y="175"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="648" y="195">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#charset_name"
+      xlink:title="charset_name">
+      <rect x="704" y="177" width="110" height="32"/>
+      <rect x="702" y="175" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="712" y="195">charset_name</text>
+   </a>
+   <rect x="65" y="259" width="70" height="32" rx="10"/>
+   <rect x="63"
+         y="257"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="277">FIELDS</text>
+   <rect x="65" y="303" width="88" height="32" rx="10"/>
+   <rect x="63"
+         y="301"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="321">COLUMNS</text>
+   <rect x="213" y="291" width="108" height="32" rx="10"/>
+   <rect x="211"
+         y="289"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="309">TERMINATED</text>
+   <rect x="341" y="291" width="38" height="32" rx="10"/>
+   <rect x="339"
+         y="289"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="309">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="399" y="291" width="56" height="32"/>
+      <rect x="397" y="289" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="407" y="309">string</text>
+   </a>
+   <rect x="535" y="323" width="110" height="32" rx="10"/>
+   <rect x="533"
+         y="321"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="543" y="341">OPTIONALLY</text>
+   <rect x="685" y="291" width="92" height="32" rx="10"/>
+   <rect x="683"
+         y="289"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="693" y="309">ENCLOSED</text>
+   <rect x="797" y="291" width="38" height="32" rx="10"/>
+   <rect x="795"
+         y="289"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="805" y="309">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="855" y="291" width="46" height="32"/>
+      <rect x="853" y="289" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="863" y="309">char</text>
+   </a>
+   <rect x="961" y="291" width="82" height="32" rx="10"/>
+   <rect x="959"
+         y="289"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="969" y="309">ESCAPED</text>
+   <rect x="1063" y="291" width="38" height="32" rx="10"/>
+   <rect x="1061"
+         y="289"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1071" y="309">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="1121" y="291" width="46" height="32"/>
+      <rect x="1119" y="289" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1129" y="309">char</text>
+   </a>
+   <rect x="292" y="405" width="62" height="32" rx="10"/>
+   <rect x="290"
+         y="403"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="300" y="423">LINES</text>
+   <rect x="394" y="437" width="90" height="32" rx="10"/>
+   <rect x="392"
+         y="435"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="402" y="455">STARTING</text>
+   <rect x="504" y="437" width="38" height="32" rx="10"/>
+   <rect x="502"
+         y="435"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="512" y="455">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="562" y="437" width="56" height="32"/>
+      <rect x="560" y="435" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="570" y="455">string</text>
+   </a>
+   <rect x="678" y="437" width="108" height="32" rx="10"/>
+   <rect x="676"
+         y="435"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="686" y="455">TERMINATED</text>
+   <rect x="806" y="437" width="38" height="32" rx="10"/>
+   <rect x="804"
+         y="435"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="814" y="455">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="864" y="437" width="56" height="32"/>
+      <rect x="862" y="435" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="872" y="455">string</text>
+   </a>
+   <rect x="295" y="579" width="74" height="32" rx="10"/>
+   <rect x="293"
+         y="577"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="597">IGNORE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="389" y="579" width="68" height="32"/>
+      <rect x="387" y="577" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="397" y="597">number</text>
+   </a>
+   <rect x="497" y="579" width="62" height="32" rx="10"/>
+   <rect x="495"
+         y="577"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="597">LINES</text>
+   <rect x="497" y="623" width="62" height="32" rx="10"/>
+   <rect x="495"
+         y="621"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="641">ROWS</text>
+   <rect x="639" y="547" width="26" height="32" rx="10"/>
+   <rect x="637"
+         y="545"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="565">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name_or_user_var"
+      xlink:title="col_name_or_user_var">
+      <rect x="705" y="547" width="166" height="32"/>
+      <rect x="703" y="545" width="166" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="713" y="565">col_name_or_user_var</text>
+   </a>
+   <rect x="705" y="503" width="24" height="32" rx="10"/>
+   <rect x="703"
+         y="501"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="713" y="521">,</text>
+   <rect x="911" y="547" width="26" height="32" rx="10"/>
+   <rect x="909"
+         y="545"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="919" y="565">)</text>
+   <rect x="879" y="733" width="44" height="32" rx="10"/>
+   <rect x="877"
+         y="731"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="887" y="751">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="963" y="733" width="80" height="32"/>
+      <rect x="961" y="731" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="971" y="751">col_name</text>
+   </a>
+   <rect x="1063" y="733" width="30" height="32" rx="10"/>
+   <rect x="1061"
+         y="731"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1071" y="751">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="1113" y="733" width="48" height="32"/>
+      <rect x="1111" y="731" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1121" y="751">expr</text>
+   </a>
+   <rect x="963" y="689" width="24" height="32" rx="10"/>
+   <rect x="961"
+         y="687"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="971" y="707">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m114 0 h10 m0 0 h16 m40 -76 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m66 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m74 0 h10 m0 0 h6 m20 -76 h10 m56 0 h10 m0 0 h10 m62 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-611 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m0 0 h306 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v12 m336 0 v-12 m-336 12 q0 10 10 10 m316 0 q10 0 10 -10 m-326 10 h10 m102 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m110 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-853 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1152 m-1182 0 h20 m1162 0 h20 m-1202 0 q10 0 10 10 m1182 0 q0 -10 10 -10 m-1192 10 v12 m1182 0 v-12 m-1182 12 q0 10 10 10 m1162 0 q10 0 10 -10 m-1152 10 h10 m70 0 h10 m0 0 h18 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h396 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v12 m426 0 v-12 m-426 12 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -32 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m82 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-979 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m62 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-729 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-314 10 h10 m74 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m62 0 h10 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -76 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m44 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-238 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m218 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-218 0 h10 m24 0 h10 m0 0 h174 m-322 44 h20 m322 0 h20 m-362 0 q10 0 10 10 m342 0 q0 -10 10 -10 m-352 10 v14 m342 0 v-14 m-342 14 q0 10 10 10 m322 0 q10 0 10 -10 m-332 10 h10 m0 0 h312 m23 -34 h-3"/>
+   <polygon points="1219 747 1227 743 1227 751"/>
+   <polygon points="1219 747 1211 743 1211 751"/>
+</svg>

--- a/server/.gitbook/assets/select-into-outfile-export-options-railroad.svg
+++ b/server/.gitbook/assets/select-into-outfile-export-options-railroad.svg
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1235" height="239">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 5 1 1 1 9"/>
+   <polygon points="17 5 9 1 9 9"/>
+   <rect x="71" y="23" width="70" height="32" rx="10"/>
+   <rect x="69"
+         y="21"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="41">FIELDS</text>
+   <rect x="71" y="67" width="88" height="32" rx="10"/>
+   <rect x="69"
+         y="65"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="85">COLUMNS</text>
+   <rect x="219" y="55" width="108" height="32" rx="10"/>
+   <rect x="217"
+         y="53"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="227" y="73">TERMINATED</text>
+   <rect x="347" y="55" width="38" height="32" rx="10"/>
+   <rect x="345"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="405" y="55" width="56" height="32"/>
+      <rect x="403" y="53" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="413" y="73">string</text>
+   </a>
+   <rect x="541" y="87" width="110" height="32" rx="10"/>
+   <rect x="539"
+         y="85"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="549" y="105">OPTIONALLY</text>
+   <rect x="691" y="55" width="92" height="32" rx="10"/>
+   <rect x="689"
+         y="53"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="699" y="73">ENCLOSED</text>
+   <rect x="803" y="55" width="38" height="32" rx="10"/>
+   <rect x="801"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="811" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="861" y="55" width="46" height="32"/>
+      <rect x="859" y="53" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="869" y="73">char</text>
+   </a>
+   <rect x="967" y="55" width="82" height="32" rx="10"/>
+   <rect x="965"
+         y="53"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="975" y="73">ESCAPED</text>
+   <rect x="1069" y="55" width="38" height="32" rx="10"/>
+   <rect x="1067"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1077" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="1127" y="55" width="46" height="32"/>
+      <rect x="1125" y="53" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1135" y="73">char</text>
+   </a>
+   <rect x="539" y="173" width="62" height="32" rx="10"/>
+   <rect x="537"
+         y="171"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="547" y="191">LINES</text>
+   <rect x="641" y="205" width="90" height="32" rx="10"/>
+   <rect x="639"
+         y="203"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="649" y="223">STARTING</text>
+   <rect x="751" y="205" width="38" height="32" rx="10"/>
+   <rect x="749"
+         y="203"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="759" y="223">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="809" y="205" width="56" height="32"/>
+      <rect x="807" y="203" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="817" y="223">string</text>
+   </a>
+   <rect x="925" y="205" width="108" height="32" rx="10"/>
+   <rect x="923"
+         y="203"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="933" y="223">TERMINATED</text>
+   <rect x="1053" y="205" width="38" height="32" rx="10"/>
+   <rect x="1051"
+         y="203"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1061" y="223">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="1111" y="205" width="56" height="32"/>
+      <rect x="1109" y="203" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1119" y="223">string</text>
+   </a>
+   <path class="line"
+         d="m17 5 h2 m20 0 h10 m0 0 h1152 m-1182 0 h20 m1162 0 h20 m-1202 0 q10 0 10 10 m1182 0 q0 -10 10 -10 m-1192 10 v12 m1182 0 v-12 m-1182 12 q0 10 10 10 m1162 0 q10 0 10 -10 m-1152 10 h10 m70 0 h10 m0 0 h18 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h396 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v12 m426 0 v-12 m-426 12 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -32 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m82 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-738 150 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m62 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m43 -64 h-3"/>
+   <polygon points="1225 155 1233 151 1233 159"/>
+   <polygon points="1225 155 1217 151 1217 159"/>
+</svg>

--- a/server/.gitbook/assets/select-into-outfile-railroad.svg
+++ b/server/.gitbook/assets/select-into-outfile-railroad.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="817" height="155">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_statement"
+      xlink:title="select_statement">
+      <rect x="31" y="3" width="130" height="32"/>
+      <rect x="29" y="1" width="130" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">select_statement</text>
+   </a>
+   <rect x="181" y="3" width="56" height="32" rx="10"/>
+   <rect x="179"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="189" y="21">INTO</text>
+   <rect x="257" y="3" width="80" height="32" rx="10"/>
+   <rect x="255"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="21">OUTFILE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#file_name"
+      xlink:title="file_name">
+      <rect x="357" y="3" width="82" height="32"/>
+      <rect x="355" y="1" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="365" y="21">file_name</text>
+   </a>
+   <rect x="479" y="35" width="102" height="32" rx="10"/>
+   <rect x="477"
+         y="33"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="487" y="53">CHARACTER</text>
+   <rect x="601" y="35" width="44" height="32" rx="10"/>
+   <rect x="599"
+         y="33"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="609" y="53">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#charset_name"
+      xlink:title="charset_name">
+      <rect x="665" y="35" width="110" height="32"/>
+      <rect x="663" y="33" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="673" y="53">charset_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#export_options"
+      xlink:title="export_options">
+      <rect x="653" y="121" width="116" height="32"/>
+      <rect x="651" y="119" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="661" y="139">export_options</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m130 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h306 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v12 m336 0 v-12 m-336 12 q0 10 10 10 m316 0 q10 0 10 -10 m-326 10 h10 m102 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m110 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-206 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m23 -32 h-3"/>
+   <polygon points="807 103 815 99 815 107"/>
+   <polygon points="807 103 799 99 799 107"/>
+</svg>

--- a/server/.gitbook/assets/set-password-railroad.svg
+++ b/server/.gitbook/assets/set-password-railroad.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="879" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="44" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SET</text>
+   <rect x="95" y="3" width="100" height="32" rx="10"/>
+   <rect x="93"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="103" y="21">PASSWORD</text>
+   <rect x="235" y="35" width="48" height="32" rx="10"/>
+   <rect x="233"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="53">FOR</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="303" y="35" width="48" height="32"/>
+      <rect x="301" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="311" y="53">user</text>
+   </a>
+   <rect x="391" y="3" width="30" height="32" rx="10"/>
+   <rect x="389"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="399" y="21">=</text>
+   <rect x="481" y="3" width="100" height="32" rx="10"/>
+   <rect x="479"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="21">PASSWORD</text>
+   <rect x="481" y="47" width="138" height="32" rx="10"/>
+   <rect x="479"
+         y="45"
+         width="138"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="65">OLD_PASSWORD</text>
+   <rect x="659" y="3" width="26" height="32" rx="10"/>
+   <rect x="657"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="667" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="705" y="3" width="80" height="32"/>
+      <rect x="703" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="713" y="21">password</text>
+   </a>
+   <rect x="805" y="3" width="26" height="32" rx="10"/>
+   <rect x="803"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="813" y="21">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#encrypted_password"
+      xlink:title="encrypted_password">
+      <rect x="461" y="91" width="152" height="32"/>
+      <rect x="459" y="89" width="152" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="469" y="109">encrypted_password</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m48 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m30 0 h10 m40 0 h10 m100 0 h10 m0 0 h38 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m20 -44 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m-410 0 h20 m390 0 h20 m-430 0 q10 0 10 10 m410 0 q0 -10 10 -10 m-420 10 v68 m410 0 v-68 m-410 68 q0 10 10 10 m390 0 q10 0 10 -10 m-400 10 h10 m152 0 h10 m0 0 h218 m23 -88 h-3"/>
+   <polygon points="869 17 877 13 877 21"/>
+   <polygon points="869 17 861 13 861 21"/>
+</svg>

--- a/server/reference/sql-statements/account-management-sql-statements/set-password.md
+++ b/server/reference/sql-statements/account-management-sql-statements/set-password.md
@@ -17,6 +17,8 @@ SET PASSWORD [FOR user] =
     }
 ```
 
+![Railroad diagram of SET PASSWORD — equivalent to the BNF above](../../../.gitbook/assets/set-password-railroad.svg)
+
 ## Description
 
 The `SET PASSWORD` statement assigns a password to an existing MariaDB user account.

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update.md
@@ -17,6 +17,8 @@ INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE]
       [, col=expr] ... ]
 ```
 
+For a Railroad diagram of this form (without the `RETURNING` clause that is also valid on plain `INSERT`), see the diagram on the [INSERT](insert.md#syntax) page.
+
 Or:
 
 ```sql

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md
@@ -27,6 +27,8 @@ LOAD DATA [LOW_PRIORITY | CONCURRENT] [LOCAL] INFILE 'file_name'
     [SET col_name = expr,...]
 ```
 
+![Railroad diagram of LOAD DATA INFILE — equivalent to the BNF above](../../../../../.gitbook/assets/load-data-infile-railroad.svg)
+
 ## Description
 
 `LOAD DATA INFILE` is [unsafe](../../../../../ha-and-performance/standard-replication/unsafe-statements-for-statement-based-replication.md) for statement-based replication.

--- a/server/reference/sql-statements/data-manipulation/selecting-data/select-into-outfile.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/select-into-outfile.md
@@ -25,6 +25,10 @@ export_options:
     ]
 ```
 
+![Railroad diagram of SELECT INTO OUTFILE — equivalent to the BNF above](../../../../.gitbook/assets/select-into-outfile-railroad.svg)
+
+![Railroad diagram of export_options](../../../../.gitbook/assets/select-into-outfile-export-options-railroad.svg)
+
 ## Description
 
 `SELECT INTO OUTFILE` writes the resulting rows to a file, and allows the use of column and row terminators to specify a particular output format. The default is to terminate fields with tabs () and lines with newlines ().

--- a/server/server-usage/triggers-events/triggers/create-trigger.md
+++ b/server/server-usage/triggers-events/triggers/create-trigger.md
@@ -12,21 +12,27 @@ description: >-
 ```bnf
 CREATE [OR REPLACE]
     [DEFINER = { user | CURRENT_USER | role | CURRENT_ROLE }]
-    TRIGGER [IF NOT EXISTS] 
-            trigger_name trigger_time {trigger_event [ OR trigger_event] [...]}
+    TRIGGER [IF NOT EXISTS]
+            trigger_name trigger_time {trigger_event [OR trigger_event] ...}
     ON tbl_name FOR EACH ROW
-   [{ FOLLOWS | PRECEDES } other_trigger_name ]
-   trigger_stmt;
+    [{ FOLLOWS | PRECEDES } other_trigger_name]
+    trigger_stmt
 
-trigger time:
+trigger_time:
     BEFORE
   | AFTER
 
 trigger_event:
     INSERT
-  | UPDATE [ OF column_name [, colunm_name [, ...]]
+  | UPDATE [OF column_name [, column_name] ...]
   | DELETE
 ```
+
+![Railroad diagram of CREATE TRIGGER — equivalent to the BNF above](../../../.gitbook/assets/create-trigger-railroad.svg)
+
+![Railroad diagram of trigger_time](../../../.gitbook/assets/create-trigger-time-railroad.svg)
+
+![Railroad diagram of trigger_event](../../../.gitbook/assets/create-trigger-event-railroad.svg)
 
 ## Description
 


### PR DESCRIPTION
## Summary

Batch 2 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continues from the ALTER TABLE prototype (#545) and the first multi-page batch (#552, which covered CREATE DATABASE / INSERT / UPDATE / DELETE / CREATE VIEW). Five more pages from the top-50 list.

## Pages

| Page | Rank | Views | Diagrams added |
|---|---:|---:|---|
| [SET PASSWORD](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/set-password) | 10 | 555 | top-level |
| [LOAD DATA INFILE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) | 14 | 511 | top-level |
| [INSERT … ON DUPLICATE KEY UPDATE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update) | 18 | 435 | **(cross-reference only — see below)** |
| [CREATE TRIGGER](https://mariadb.com/docs/server/server-usage/triggers-events/triggers/create-trigger) | 28 | 356 | top-level + `trigger_time` + `trigger_event` |
| [SELECT INTO OUTFILE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select-into-outfile) | 36 | 325 | top-level + `export_options` |

7 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## INSERT … ON DUPLICATE KEY UPDATE: no new diagram

The page's source BNF is the INSERT BNF *minus* the trailing `RETURNING` clause. A new diagram would visually duplicate the one already on the INSERT page from PR #552. Instead, the page gets a one-line pointer to that diagram:

> For a Railroad diagram of this form (without the `RETURNING` clause that is also valid on plain `INSERT`), see the diagram on the [INSERT](insert.md#syntax) page.

This keeps the rendered docs honest (no spurious duplicate SVGs) without leaving the page diagram-less in the navigation.

## Source-BNF cleanup folded in (CREATE TRIGGER)

The CREATE TRIGGER page's source BNF had three bugs the diagram could not faithfully reproduce. Fixed in the same edit so the BNF and the diagram agree:

1. The `trigger_event` production read
   ```
   UPDATE [ OF column_name [, colunm_name [, ...]]
   ```
   with a typo (`colunm_name`) and unbalanced brackets (three opening `[`, one closing `]`). Replaced with the proper `UPDATE [OF column_name [, column_name] ...]` form.
2. The top-level rule ended with a stray `;` that does not belong in BNF. Removed.
3. The sub-rule heading was `trigger time:` (with a missing underscore) while the top-level rule referred to `trigger_time`. Made the two agree on `trigger_time:`.

## Reversibility

If any diagram looks off in the GitBook preview, the embed line for it is a single `![...](...)` markdown image — easy to comment out without touching anything else. The SVG file can stay in place for the next attempt.

## Test plan

- [ ] GitBook preview renders each diagram inline under its `bnf` block.
- [ ] CREATE TRIGGER's corrected BNF reads cleanly and matches the diagram.
- [ ] INSERT … ON DUPLICATE KEY UPDATE shows the cross-reference text and its link resolves.
- [ ] All 7 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ