### PR TITLE
DOCS-5614 add Railroad diagrams to 6 more pages

### DIFF
--- a/server/.gitbook/assets/case-statement-railroad.svg
+++ b/server/.gitbook/assets/case-statement-railroad.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="979" height="151">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 33 1 29 1 37"/>
+   <polygon points="17 33 9 29 9 37"/>
+   <rect x="31" y="19" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="37">CASE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#case_value"
+      xlink:title="case_value">
+      <rect x="107" y="19" width="92" height="32"/>
+      <rect x="105" y="17" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="115" y="37">case_value</text>
+   </a>
+   <rect x="239" y="19" width="62" height="32" rx="10"/>
+   <rect x="237"
+         y="17"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="247" y="37">WHEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#when_value"
+      xlink:title="when_value">
+      <rect x="321" y="19" width="96" height="32"/>
+      <rect x="319" y="17" width="96" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="329" y="37">when_value</text>
+   </a>
+   <rect x="437" y="19" width="56" height="32" rx="10"/>
+   <rect x="435"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="445" y="37">THEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#statement_list"
+      xlink:title="statement_list">
+      <rect x="513" y="19" width="112" height="32"/>
+      <rect x="511" y="17" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="37">statement_list</text>
+   </a>
+   <rect x="685" y="51" width="52" height="32" rx="10"/>
+   <rect x="683"
+         y="49"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="693" y="69">ELSE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#statement_list"
+      xlink:title="statement_list">
+      <rect x="757" y="51" width="112" height="32"/>
+      <rect x="755" y="49" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="765" y="69">statement_list</text>
+   </a>
+   <rect x="909" y="19" width="48" height="32" rx="10"/>
+   <rect x="907"
+         y="17"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="917" y="37">END</text>
+   <rect x="895" y="117" width="56" height="32" rx="10"/>
+   <rect x="893"
+         y="115"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="903" y="135">CASE</text>
+   <path class="line"
+         d="m17 33 h2 m0 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m112 0 h10 m-426 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m406 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-406 0 h10 m0 0 h396 m40 32 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m52 0 h10 m0 0 h10 m112 0 h10 m20 -32 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-106 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m3 0 h-3"/>
+   <polygon points="969 131 977 127 977 135"/>
+   <polygon points="969 131 961 127 961 135"/>
+</svg>

--- a/server/.gitbook/assets/flush-railroad.svg
+++ b/server/.gitbook/assets/flush-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="529" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">FLUSH</text>
+   <rect x="135" y="79" width="188" height="32" rx="10"/>
+   <rect x="133"
+         y="77"
+         width="188"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="97">NO_WRITE_TO_BINLOG</text>
+   <rect x="135" y="123" width="64" height="32" rx="10"/>
+   <rect x="133"
+         y="121"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="141">LOCAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#flush_option"
+      xlink:title="flush_option">
+      <rect x="383" y="47" width="98" height="32"/>
+      <rect x="381" y="45" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="391" y="65">flush_option</text>
+   </a>
+   <rect x="383" y="3" width="24" height="32" rx="10"/>
+   <rect x="381"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="391" y="21">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h198 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v12 m228 0 v-12 m-228 12 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m-218 -10 v20 m228 0 v-20 m-228 20 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m64 0 h10 m0 0 h124 m40 -76 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m23 44 h-3"/>
+   <polygon points="519 61 527 57 527 65"/>
+   <polygon points="519 61 511 57 511 65"/>
+</svg>

--- a/server/.gitbook/assets/generated-columns-railroad.svg
+++ b/server/.gitbook/assets/generated-columns-railroad.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="785" height="275">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="31" y="3" width="48" height="32"/>
+      <rect x="29" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">type</text>
+   </a>
+   <rect x="119" y="35" width="100" height="32" rx="10"/>
+   <rect x="117"
+         y="33"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="53">GENERATED</text>
+   <rect x="239" y="35" width="78" height="32" rx="10"/>
+   <rect x="237"
+         y="33"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="247" y="53">ALWAYS</text>
+   <rect x="357" y="3" width="38" height="32" rx="10"/>
+   <rect x="355"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="365" y="21">AS</text>
+   <rect x="415" y="3" width="26" height="32" rx="10"/>
+   <rect x="413"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expression"
+      xlink:title="expression">
+      <rect x="461" y="3" width="90" height="32"/>
+      <rect x="459" y="1" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="469" y="21">expression</text>
+   </a>
+   <rect x="571" y="3" width="26" height="32" rx="10"/>
+   <rect x="569"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="579" y="21">)</text>
+   <rect x="637" y="35" width="80" height="32" rx="10"/>
+   <rect x="635"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="645" y="53">VIRTUAL</text>
+   <rect x="637" y="79" width="106" height="32" rx="10"/>
+   <rect x="635"
+         y="77"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="645" y="97">PERSISTENT</text>
+   <rect x="637" y="123" width="76" height="32" rx="10"/>
+   <rect x="635"
+         y="121"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="645" y="141">STORED</text>
+   <rect x="345" y="209" width="74" height="32" rx="10"/>
+   <rect x="343"
+         y="207"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="227">UNIQUE</text>
+   <rect x="459" y="241" width="46" height="32" rx="10"/>
+   <rect x="457"
+         y="239"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="467" y="259">KEY</text>
+   <rect x="585" y="209" width="88" height="32" rx="10"/>
+   <rect x="583"
+         y="207"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="593" y="227">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#text"
+      xlink:title="text">
+      <rect x="693" y="209" width="44" height="32"/>
+      <rect x="691" y="207" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="701" y="227">text</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h208 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v12 m238 0 v-12 m-238 12 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m100 0 h10 m0 0 h10 m78 0 h10 m20 -32 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m80 0 h10 m0 0 h26 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m76 0 h10 m0 0 h30 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m74 0 h10 m20 0 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m60 -64 h10 m0 0 h162 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v12 m192 0 v-12 m-192 12 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m88 0 h10 m0 0 h10 m44 0 h10 m23 -32 h-3"/>
+   <polygon points="775 191 783 187 783 195"/>
+   <polygon points="775 191 767 187 767 195"/>
+</svg>

--- a/server/.gitbook/assets/insert-on-duplicate-key-update-railroad.svg
+++ b/server/.gitbook/assets/insert-on-duplicate-key-update-railroad.svg
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="899" height="437">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="70" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">INSERT</text>
+   <rect x="141" y="35" width="130" height="32" rx="10"/>
+   <rect x="139"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="53">LOW_PRIORITY</text>
+   <rect x="141" y="79" width="82" height="32" rx="10"/>
+   <rect x="139"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="97">DELAYED</text>
+   <rect x="141" y="123" width="134" height="32" rx="10"/>
+   <rect x="139"
+         y="121"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="141">HIGH_PRIORITY</text>
+   <rect x="335" y="35" width="74" height="32" rx="10"/>
+   <rect x="333"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="53">IGNORE</text>
+   <rect x="469" y="35" width="56" height="32" rx="10"/>
+   <rect x="467"
+         y="33"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="477" y="53">INTO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="565" y="3" width="80" height="32"/>
+      <rect x="563" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="573" y="21">tbl_name</text>
+   </a>
+   <rect x="45" y="265" width="98" height="32" rx="10"/>
+   <rect x="43"
+         y="263"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="283">PARTITION</text>
+   <rect x="163" y="265" width="26" height="32" rx="10"/>
+   <rect x="161"
+         y="263"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="171" y="283">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_list"
+      xlink:title="partition_list">
+      <rect x="209" y="265" width="100" height="32"/>
+      <rect x="207" y="263" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="217" y="283">partition_list</text>
+   </a>
+   <rect x="329" y="265" width="26" height="32" rx="10"/>
+   <rect x="327"
+         y="263"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="337" y="283">)</text>
+   <rect x="415" y="233" width="26" height="32" rx="10"/>
+   <rect x="413"
+         y="231"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="251">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="481" y="233" width="38" height="32"/>
+      <rect x="479" y="231" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="489" y="251">col</text>
+   </a>
+   <rect x="481" y="189" width="24" height="32" rx="10"/>
+   <rect x="479"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="207">,</text>
+   <rect x="559" y="233" width="26" height="32" rx="10"/>
+   <rect x="557"
+         y="231"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="567" y="251">)</text>
+   <rect x="645" y="233" width="72" height="32" rx="10"/>
+   <rect x="643"
+         y="231"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="251">VALUES</text>
+   <rect x="645" y="277" width="64" height="32" rx="10"/>
+   <rect x="643"
+         y="275"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="295">VALUE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value_list"
+      xlink:title="value_list">
+      <rect x="777" y="233" width="80" height="32"/>
+      <rect x="775" y="231" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="785" y="251">value_list</text>
+   </a>
+   <rect x="777" y="189" width="24" height="32" rx="10"/>
+   <rect x="775"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="785" y="207">,</text>
+   <rect x="317" y="387" width="40" height="32" rx="10"/>
+   <rect x="315"
+         y="385"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="405">ON</text>
+   <rect x="377" y="387" width="98" height="32" rx="10"/>
+   <rect x="375"
+         y="385"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="385" y="405">DUPLICATE</text>
+   <rect x="495" y="387" width="46" height="32" rx="10"/>
+   <rect x="493"
+         y="385"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="405">KEY</text>
+   <rect x="561" y="387" width="74" height="32" rx="10"/>
+   <rect x="559"
+         y="385"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="569" y="405">UPDATE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="675" y="387" width="38" height="32"/>
+      <rect x="673" y="385" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="683" y="405">col</text>
+   </a>
+   <rect x="733" y="387" width="30" height="32" rx="10"/>
+   <rect x="731"
+         y="385"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="741" y="405">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="783" y="387" width="48" height="32"/>
+      <rect x="781" y="385" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="791" y="405">expr</text>
+   </a>
+   <rect x="675" y="343" width="24" height="32" rx="10"/>
+   <rect x="673"
+         y="341"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="683" y="361">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m130 0 h10 m0 0 h4 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m82 0 h10 m0 0 h52 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m40 -120 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -32 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-664 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v14 m210 0 v-14 m-210 14 q0 10 10 10 m190 0 q10 0 10 -10 m-200 10 h10 m0 0 h180 m40 -34 h10 m72 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m64 0 h10 m0 0 h8 m40 -44 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-624 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m40 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-196 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m176 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-176 0 h10 m24 0 h10 m0 0 h132 m-554 44 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v14 m574 0 v-14 m-574 14 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m0 0 h544 m23 -34 h-3"/>
+   <polygon points="889 401 897 397 897 405"/>
+   <polygon points="889 401 881 397 881 405"/>
+</svg>

--- a/server/.gitbook/assets/insert-on-duplicate-key-update-value-list-railroad.svg
+++ b/server/.gitbook/assets/insert-on-duplicate-key-update-value-list-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="311" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="26" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="117" y="47" width="48" height="32"/>
+      <rect x="115" y="45" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="125" y="65">expr</text>
+   </a>
+   <rect x="117" y="91" width="80" height="32" rx="10"/>
+   <rect x="115"
+         y="89"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="109">DEFAULT</text>
+   <rect x="97" y="3" width="24" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">,</text>
+   <rect x="257" y="47" width="26" height="32" rx="10"/>
+   <rect x="255"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="65">)</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m26 0 h10 m40 0 h10 m48 0 h10 m0 0 h32 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-140 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m20 44 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="301 61 309 57 309 65"/>
+   <polygon points="301 61 293 57 293 65"/>
+</svg>

--- a/server/.gitbook/assets/optimize-table-railroad.svg
+++ b/server/.gitbook/assets/optimize-table-railroad.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="783" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="88" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">OPTIMIZE</text>
+   <rect x="159" y="79" width="188" height="32" rx="10"/>
+   <rect x="157"
+         y="77"
+         width="188"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="97">NO_WRITE_TO_BINLOG</text>
+   <rect x="159" y="123" width="64" height="32" rx="10"/>
+   <rect x="157"
+         y="121"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="141">LOCAL</text>
+   <rect x="387" y="47" width="62" height="32" rx="10"/>
+   <rect x="385"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="395" y="65">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="489" y="47" width="80" height="32"/>
+      <rect x="487" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="497" y="65">tbl_name</text>
+   </a>
+   <rect x="489" y="3" width="24" height="32" rx="10"/>
+   <rect x="487"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="497" y="21">,</text>
+   <rect x="629" y="79" width="58" height="32" rx="10"/>
+   <rect x="627"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="637" y="97">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="707" y="79" width="28" height="32"/>
+      <rect x="705" y="77" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="715" y="97">n</text>
+   </a>
+   <rect x="629" y="123" width="78" height="32" rx="10"/>
+   <rect x="627"
+         y="121"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="637" y="141">NOWAIT</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h198 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v12 m228 0 v-12 m-228 12 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m-218 -10 v20 m228 0 v-20 m-228 20 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m64 0 h10 m0 0 h124 m20 -76 h10 m62 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m23 -76 h-3"/>
+   <polygon points="773 61 781 57 781 65"/>
+   <polygon points="773 61 765 57 765 65"/>
+</svg>

--- a/server/.gitbook/assets/purge-binary-logs-railroad.svg
+++ b/server/.gitbook/assets/purge-binary-logs-railroad.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="605" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">PURGE</text>
+   <rect x="137" y="3" width="72" height="32" rx="10"/>
+   <rect x="135"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="21">BINARY</text>
+   <rect x="137" y="47" width="76" height="32" rx="10"/>
+   <rect x="135"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="65">MASTER</text>
+   <rect x="253" y="3" width="58" height="32" rx="10"/>
+   <rect x="251"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="21">LOGS</text>
+   <rect x="351" y="3" width="38" height="32" rx="10"/>
+   <rect x="349"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="359" y="21">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#log_name"
+      xlink:title="log_name">
+      <rect x="409" y="3" width="82" height="32"/>
+      <rect x="407" y="1" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="417" y="21">log_name</text>
+   </a>
+   <rect x="351" y="47" width="74" height="32" rx="10"/>
+   <rect x="349"
+         y="45"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="359" y="65">BEFORE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#datetime_expr"
+      xlink:title="datetime_expr">
+      <rect x="445" y="47" width="112" height="32"/>
+      <rect x="443" y="45" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="453" y="65">datetime_expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m72 0 h10 m0 0 h4 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m20 -44 h10 m58 0 h10 m20 0 h10 m38 0 h10 m0 0 h10 m82 0 h10 m0 0 h66 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m74 0 h10 m0 0 h10 m112 0 h10 m23 -44 h-3"/>
+   <polygon points="595 17 603 13 603 21"/>
+   <polygon points="595 17 587 13 587 21"/>
+</svg>

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table.md
@@ -15,6 +15,8 @@ OPTIMIZE [NO_WRITE_TO_BINLOG | LOCAL] TABLE
     [WAIT n | NOWAIT]
 ```
 
+![Railroad diagram of OPTIMIZE TABLE — equivalent to the BNF above](../../../.gitbook/assets/optimize-table-railroad.svg)
+
 ## Description
 
 `OPTIMIZE TABLE` has two main functions. It can either be used to defragment tables, or to update the InnoDB fulltext index.

--- a/server/reference/sql-statements/administrative-sql-statements/flush-commands/flush.md
+++ b/server/reference/sql-statements/administrative-sql-statements/flush-commands/flush.md
@@ -14,6 +14,8 @@ FLUSH [NO_WRITE_TO_BINLOG | LOCAL]
     flush_option [, flush_option] ...
 ```
 
+![Railroad diagram of FLUSH — equivalent to the BNF above](../../../../.gitbook/assets/flush-railroad.svg)
+
 or when flushing tables:
 
 ```sql

--- a/server/reference/sql-statements/administrative-sql-statements/purge-binary-logs.md
+++ b/server/reference/sql-statements/administrative-sql-statements/purge-binary-logs.md
@@ -13,6 +13,8 @@ PURGE { BINARY | MASTER } LOGS
     { TO 'log_name' | BEFORE datetime_expr }
 ```
 
+![Railroad diagram of PURGE BINARY LOGS — equivalent to the BNF above](../../../.gitbook/assets/purge-binary-logs-railroad.svg)
+
 ## Description
 
 The `PURGE BINARY LOGS` statement deletes all the [binary log](../../../server-management/server-monitoring-logs/binary-log/) files listed in the log index file prior to the specified log file name ordate. `BINARY` and `MASTER` are synonyms.Deleted log files also are removed from the list recorded in the index file, sothat the given log file becomes the first in the list.

--- a/server/reference/sql-statements/data-definition/create/generated-columns.md
+++ b/server/reference/sql-statements/data-definition/create/generated-columns.md
@@ -9,9 +9,11 @@ description: >-
 ## Syntax
 
 ```bnf
-<type>  [GENERATED ALWAYS]  AS   ( <expression> )
-[VIRTUAL | PERSISTENT | STORED]  [UNIQUE] [UNIQUE KEY] [COMMENT <text>]
+<type> [GENERATED ALWAYS] AS (<expression>)
+[VIRTUAL | PERSISTENT | STORED] [UNIQUE [KEY]] [COMMENT <text>]
 ```
+
+![Railroad diagram of a generated-column definition — equivalent to the BNF above](../../../../.gitbook/assets/generated-columns-railroad.svg)
 
 {% tabs %}
 {% tab title="Current" %}

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update.md
@@ -17,7 +17,9 @@ INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE]
       [, col=expr] ... ]
 ```
 
-For a Railroad diagram of this form (without the `RETURNING` clause that is also valid on plain `INSERT`), see the diagram on the [INSERT](insert.md#syntax) page.
+![Railroad diagram of INSERT ... ON DUPLICATE KEY UPDATE — equivalent to the BNF above](../../../../.gitbook/assets/insert-on-duplicate-key-update-railroad.svg)
+
+![Railroad diagram of value_list](../../../../.gitbook/assets/insert-on-duplicate-key-update-value-list-railroad.svg)
 
 Or:
 

--- a/server/reference/sql-statements/programmatic-compound-statements/case-statement.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/case-statement.md
@@ -16,6 +16,8 @@ CASE case_value
 END CASE
 ```
 
+![Railroad diagram of the simple CASE form — equivalent to the BNF above](../../../.gitbook/assets/case-statement-railroad.svg)
+
 Or:
 
 ```sql


### PR DESCRIPTION
## Summary

Batch 3 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continues from #545 (ALTER TABLE prototype), #552 (batch 1: 5 pages), and #561 (batch 2: 4 pages + 1 cross-reference). Six more pages this round.

## Pages

| Page | Rank | Views | Diagrams added |
|---|---:|---:|---|
| [OPTIMIZE TABLE](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table) | 17 | 472 | top-level |
| [INSERT … ON DUPLICATE KEY UPDATE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update) | 18 | 435 | top-level + `value_list` |
| [FLUSH](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/flush-commands/flush) | 19 | 406 | top-level |
| [Generated Columns](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/generated-columns) | 37 | 323 | top-level |
| [PURGE BINARY LOGS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/purge-binary-logs) | 40 | 299 | top-level |
| [CASE statement](https://mariadb.com/docs/server/reference/sql-statements/programmatic-compound-statements/case-statement) | 42 | 295 | top-level (**simple form only**) |

7 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## INSERT … ON DUPLICATE KEY UPDATE — added by request

Batch 2 (PR #561) left this page with a prose cross-reference to the INSERT diagram instead of its own, because the BNF is the INSERT BNF minus the `RETURNING` clause. Stefan asked for a real diagram on the page despite the near-duplication. This PR replaces the cross-reference with the diagram (top-level + `value_list` sub-diagram).

## CASE statement — simple form only

The page's `bnf` block documents the **simple** form (`CASE value WHEN match THEN ...`) and only that is diagrammed. The **searched** form (`CASE WHEN condition THEN ...`) lives in a sibling `\`\`\`sql` block — the DOCS-5614 prep retag pass (#544) only converts the first `\`\`\`sql` per `## Syntax` section to `\`\`\`bnf`, so the searched form stayed `sql` and is out of scope here. Reviewers' call whether a follow-up should retag and diagram the searched form too.

## Source-BNF cleanup folded in (Generated Columns)

The Generated Columns page's source BNF read:

```
[VIRTUAL | PERSISTENT | STORED]  [UNIQUE] [UNIQUE KEY] [COMMENT <text>]
```

with `[UNIQUE]` and `[UNIQUE KEY]` as two independent optional clauses, literally allowing the nonsensical sequence `UNIQUE UNIQUE KEY`. The intended form, matching the CREATE TABLE column-spec grammar, is `[UNIQUE [KEY]]` — `UNIQUE` optionally followed by `KEY` (where `KEY` is a synonym in this context). Diagrammed accordingly and the source BNF on the page is fixed to match. Also collapsed the extra double spaces in the BNF for readability.

## Tally and remaining work

After this PR lands, **16 pages** are diagrammed under DOCS-5614:

- 1 prototype: ALTER TABLE (#545)
- 5 in batch 1: CREATE DATABASE, INSERT, UPDATE, DELETE, CREATE VIEW (#552)
- 5 in batch 2: SET PASSWORD, LOAD DATA INFILE, CREATE TRIGGER, SELECT INTO OUTFILE, INSERT … ON DUPLICATE KEY UPDATE *(cross-reference only)* (#561)
- 6 in batch 3: OPTIMIZE TABLE, INSERT … ON DUPLICATE KEY UPDATE *(now real diagram)*, FLUSH, Generated Columns, PURGE BINARY LOGS, CASE statement (this PR)

Roughly **34 to go** to reach the ~50-page target outlined in the ticket. Next batches will dip into the larger-BNF Tier C/D pages (CREATE PROCEDURE, CREATE FUNCTION, SELECT, CHANGE MASTER TO, CREATE USER, ALTER USER, CREATE INDEX, CONSTRAINT, GRANT, CREATE TABLE), where we'll have to decide top-level-only-or-full diagram for each (as we did for ALTER TABLE).

## Test plan

- [ ] GitBook preview renders each diagram inline under its `bnf` block.
- [ ] Generated Columns' corrected BNF reads cleanly and matches the diagram.
- [ ] INSERT … ON DUPLICATE KEY UPDATE shows the diagrams (no leftover prose cross-reference).
- [ ] All 7 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ