### PR TITLE
DOCS-5614 add Railroad diagrams to 5 mid-sized SQL pages

### DIFF
--- a/server/.gitbook/assets/change-master-to-master-def-railroad.svg
+++ b/server/.gitbook/assets/change-master-to-master-def-railroad.svg
@@ -1,0 +1,768 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="629" height="1709">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="120" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">MASTER_BIND</text>
+   <rect x="191" y="3" width="30" height="32" rx="10"/>
+   <rect x="189"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="21">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interface_name"
+      xlink:title="interface_name">
+      <rect x="241" y="3" width="118" height="32"/>
+      <rect x="239" y="1" width="118" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="249" y="21">interface_name</text>
+   </a>
+   <rect x="51" y="47" width="122" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="122"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">MASTER_HOST</text>
+   <rect x="193" y="47" width="30" height="32" rx="10"/>
+   <rect x="191"
+         y="45"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="65">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#host_name"
+      xlink:title="host_name">
+      <rect x="243" y="47" width="92" height="32"/>
+      <rect x="241" y="45" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="251" y="65">host_name</text>
+   </a>
+   <rect x="51" y="91" width="120" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">MASTER_USER</text>
+   <rect x="191" y="91" width="30" height="32" rx="10"/>
+   <rect x="189"
+         y="89"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="109">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user_name"
+      xlink:title="user_name">
+      <rect x="241" y="91" width="92" height="32"/>
+      <rect x="239" y="89" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="249" y="109">user_name</text>
+   </a>
+   <rect x="51" y="135" width="164" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="164"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">MASTER_PASSWORD</text>
+   <rect x="235" y="135" width="30" height="32" rx="10"/>
+   <rect x="233"
+         y="133"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="153">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="285" y="135" width="80" height="32"/>
+      <rect x="283" y="133" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="293" y="153">password</text>
+   </a>
+   <rect x="51" y="179" width="122" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="122"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">MASTER_PORT</text>
+   <rect x="193" y="179" width="30" height="32" rx="10"/>
+   <rect x="191"
+         y="177"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="197">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#port_num"
+      xlink:title="port_num">
+      <rect x="243" y="179" width="82" height="32"/>
+      <rect x="241" y="177" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="251" y="197">port_num</text>
+   </a>
+   <rect x="71" y="223" width="202" height="32" rx="10"/>
+   <rect x="69"
+         y="221"
+         width="202"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="241">MASTER_CONNECT_RETRY</text>
+   <rect x="71" y="267" width="226" height="32" rx="10"/>
+   <rect x="69"
+         y="265"
+         width="226"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="285">MASTER_HEARTBEAT_PERIOD</text>
+   <rect x="337" y="223" width="30" height="32" rx="10"/>
+   <rect x="335"
+         y="221"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="241">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="407" y="223" width="68" height="32"/>
+      <rect x="405" y="221" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="415" y="241">interval</text>
+   </a>
+   <rect x="407" y="267" width="80" height="32" rx="10"/>
+   <rect x="405"
+         y="265"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="415" y="285">DEFAULT</text>
+   <rect x="51" y="311" width="152" height="32" rx="10"/>
+   <rect x="49"
+         y="309"
+         width="152"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="329">MASTER_LOG_FILE</text>
+   <rect x="223" y="311" width="30" height="32" rx="10"/>
+   <rect x="221"
+         y="309"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="231" y="329">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#master_log_name"
+      xlink:title="master_log_name">
+      <rect x="273" y="311" width="136" height="32"/>
+      <rect x="271" y="309" width="136" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="281" y="329">master_log_name</text>
+   </a>
+   <rect x="51" y="355" width="150" height="32" rx="10"/>
+   <rect x="49"
+         y="353"
+         width="150"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="373">MASTER_LOG_POS</text>
+   <rect x="221" y="355" width="30" height="32" rx="10"/>
+   <rect x="219"
+         y="353"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="373">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#master_log_pos"
+      xlink:title="master_log_pos">
+      <rect x="271" y="355" width="122" height="32"/>
+      <rect x="269" y="353" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="279" y="373">master_log_pos</text>
+   </a>
+   <rect x="51" y="399" width="140" height="32" rx="10"/>
+   <rect x="49"
+         y="397"
+         width="140"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="417">RELAY_LOG_FILE</text>
+   <rect x="211" y="399" width="30" height="32" rx="10"/>
+   <rect x="209"
+         y="397"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="417">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#relay_log_name"
+      xlink:title="relay_log_name">
+      <rect x="261" y="399" width="122" height="32"/>
+      <rect x="259" y="397" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="269" y="417">relay_log_name</text>
+   </a>
+   <rect x="51" y="443" width="138" height="32" rx="10"/>
+   <rect x="49"
+         y="441"
+         width="138"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="461">RELAY_LOG_POS</text>
+   <rect x="209" y="443" width="30" height="32" rx="10"/>
+   <rect x="207"
+         y="441"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="461">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#relay_log_pos"
+      xlink:title="relay_log_pos">
+      <rect x="259" y="443" width="110" height="32"/>
+      <rect x="257" y="441" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="267" y="461">relay_log_pos</text>
+   </a>
+   <rect x="51" y="487" width="128" height="32" rx="10"/>
+   <rect x="49"
+         y="485"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="505">MASTER_DELAY</text>
+   <rect x="199" y="487" width="30" height="32" rx="10"/>
+   <rect x="197"
+         y="485"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="207" y="505">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="249" y="487" width="68" height="32"/>
+      <rect x="247" y="485" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="257" y="505">interval</text>
+   </a>
+   <rect x="71" y="531" width="110" height="32" rx="10"/>
+   <rect x="69"
+         y="529"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="549">MASTER_SSL</text>
+   <rect x="71" y="575" width="276" height="32" rx="10"/>
+   <rect x="69"
+         y="573"
+         width="276"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="593">MASTER_SSL_VERIFY_SERVER_CERT</text>
+   <rect x="387" y="531" width="30" height="32" rx="10"/>
+   <rect x="385"
+         y="529"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="395" y="549">=</text>
+   <rect x="457" y="531" width="28" height="32" rx="10"/>
+   <rect x="455"
+         y="529"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="465" y="549">0</text>
+   <rect x="457" y="575" width="28" height="32" rx="10"/>
+   <rect x="455"
+         y="573"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="465" y="593">1</text>
+   <rect x="457" y="619" width="80" height="32" rx="10"/>
+   <rect x="455"
+         y="617"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="465" y="637">DEFAULT</text>
+   <rect x="51" y="663" width="138" height="32" rx="10"/>
+   <rect x="49"
+         y="661"
+         width="138"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="681">MASTER_SSL_CA</text>
+   <rect x="209" y="663" width="30" height="32" rx="10"/>
+   <rect x="207"
+         y="661"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="681">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ca_file_name"
+      xlink:title="ca_file_name">
+      <rect x="279" y="663" width="104" height="32"/>
+      <rect x="277" y="661" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="287" y="681">ca_file_name</text>
+   </a>
+   <rect x="279" y="707" width="80" height="32" rx="10"/>
+   <rect x="277"
+         y="705"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="287" y="725">DEFAULT</text>
+   <rect x="51" y="751" width="174" height="32" rx="10"/>
+   <rect x="49"
+         y="749"
+         width="174"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="769">MASTER_SSL_CAPATH</text>
+   <rect x="245" y="751" width="30" height="32" rx="10"/>
+   <rect x="243"
+         y="749"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="253" y="769">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ca_directory_name"
+      xlink:title="ca_directory_name">
+      <rect x="315" y="751" width="142" height="32"/>
+      <rect x="313" y="749" width="142" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="323" y="769">ca_directory_name</text>
+   </a>
+   <rect x="315" y="795" width="80" height="32" rx="10"/>
+   <rect x="313"
+         y="793"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="323" y="813">DEFAULT</text>
+   <rect x="51" y="839" width="154" height="32" rx="10"/>
+   <rect x="49"
+         y="837"
+         width="154"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="857">MASTER_SSL_CERT</text>
+   <rect x="225" y="839" width="30" height="32" rx="10"/>
+   <rect x="223"
+         y="837"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="233" y="857">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#cert_file_name"
+      xlink:title="cert_file_name">
+      <rect x="295" y="839" width="114" height="32"/>
+      <rect x="293" y="837" width="114" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="303" y="857">cert_file_name</text>
+   </a>
+   <rect x="295" y="883" width="80" height="32" rx="10"/>
+   <rect x="293"
+         y="881"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="901">DEFAULT</text>
+   <rect x="51" y="927" width="146" height="32" rx="10"/>
+   <rect x="49"
+         y="925"
+         width="146"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="945">MASTER_SSL_CRL</text>
+   <rect x="217" y="927" width="30" height="32" rx="10"/>
+   <rect x="215"
+         y="925"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="945">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#crl_file_name"
+      xlink:title="crl_file_name">
+      <rect x="287" y="927" width="104" height="32"/>
+      <rect x="285" y="925" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="295" y="945">crl_file_name</text>
+   </a>
+   <rect x="287" y="971" width="80" height="32" rx="10"/>
+   <rect x="285"
+         y="969"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="989">DEFAULT</text>
+   <rect x="51" y="1015" width="182" height="32" rx="10"/>
+   <rect x="49"
+         y="1013"
+         width="182"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1033">MASTER_SSL_CRLPATH</text>
+   <rect x="253" y="1015" width="30" height="32" rx="10"/>
+   <rect x="251"
+         y="1013"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="1033">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#crl_directory_name"
+      xlink:title="crl_directory_name">
+      <rect x="323" y="1015" width="142" height="32"/>
+      <rect x="321"
+            y="1013"
+            width="142"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="331" y="1033">crl_directory_name</text>
+   </a>
+   <rect x="323" y="1059" width="80" height="32" rx="10"/>
+   <rect x="321"
+         y="1057"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="331" y="1077">DEFAULT</text>
+   <rect x="51" y="1103" width="146" height="32" rx="10"/>
+   <rect x="49"
+         y="1101"
+         width="146"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1121">MASTER_SSL_KEY</text>
+   <rect x="217" y="1103" width="30" height="32" rx="10"/>
+   <rect x="215"
+         y="1101"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="1121">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#key_file_name"
+      xlink:title="key_file_name">
+      <rect x="287" y="1103" width="112" height="32"/>
+      <rect x="285"
+            y="1101"
+            width="112"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="295" y="1121">key_file_name</text>
+   </a>
+   <rect x="287" y="1147" width="80" height="32" rx="10"/>
+   <rect x="285"
+         y="1145"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="1165">DEFAULT</text>
+   <rect x="51" y="1191" width="172" height="32" rx="10"/>
+   <rect x="49"
+         y="1189"
+         width="172"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1209">MASTER_SSL_CIPHER</text>
+   <rect x="243" y="1191" width="30" height="32" rx="10"/>
+   <rect x="241"
+         y="1189"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="251" y="1209">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#cipher_list"
+      xlink:title="cipher_list">
+      <rect x="313" y="1191" width="84" height="32"/>
+      <rect x="311" y="1189" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="321" y="1209">cipher_list</text>
+   </a>
+   <rect x="313" y="1235" width="80" height="32" rx="10"/>
+   <rect x="311"
+         y="1233"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="1253">DEFAULT</text>
+   <rect x="51" y="1279" width="154" height="32" rx="10"/>
+   <rect x="49"
+         y="1277"
+         width="154"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1297">MASTER_USE_GTID</text>
+   <rect x="225" y="1279" width="30" height="32" rx="10"/>
+   <rect x="223"
+         y="1277"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="233" y="1297">=</text>
+   <rect x="295" y="1279" width="102" height="32" rx="10"/>
+   <rect x="293"
+         y="1277"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="1297">current_pos</text>
+   <rect x="295" y="1323" width="88" height="32" rx="10"/>
+   <rect x="293"
+         y="1321"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="1341">slave_pos</text>
+   <rect x="295" y="1367" width="36" height="32" rx="10"/>
+   <rect x="293"
+         y="1365"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="1385">no</text>
+   <rect x="295" y="1411" width="80" height="32" rx="10"/>
+   <rect x="293"
+         y="1409"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="1429">DEFAULT</text>
+   <rect x="51" y="1455" width="222" height="32" rx="10"/>
+   <rect x="49"
+         y="1453"
+         width="222"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1473">MASTER_DEMOTE_TO_SLAVE</text>
+   <rect x="293" y="1455" width="30" height="32" rx="10"/>
+   <rect x="291"
+         y="1453"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="1473">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#bool"
+      xlink:title="bool">
+      <rect x="343" y="1455" width="46" height="32"/>
+      <rect x="341" y="1453" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="351" y="1473">bool</text>
+   </a>
+   <rect x="71" y="1499" width="172" height="32" rx="10"/>
+   <rect x="69"
+         y="1497"
+         width="172"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="1517">IGNORE_SERVER_IDS</text>
+   <rect x="263" y="1499" width="30" height="32" rx="10"/>
+   <rect x="261"
+         y="1497"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="271" y="1517">=</text>
+   <rect x="313" y="1499" width="26" height="32" rx="10"/>
+   <rect x="311"
+         y="1497"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="1517">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#server_id_list"
+      xlink:title="server_id_list">
+      <rect x="359" y="1499" width="106" height="32"/>
+      <rect x="357"
+            y="1497"
+            width="106"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="367" y="1517">server_id_list</text>
+   </a>
+   <rect x="91" y="1543" width="142" height="32" rx="10"/>
+   <rect x="89"
+         y="1541"
+         width="142"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="99" y="1561">DO_DOMAIN_IDS</text>
+   <rect x="91" y="1587" width="176" height="32" rx="10"/>
+   <rect x="89"
+         y="1585"
+         width="176"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="99" y="1605">IGNORE_DOMAIN_IDS</text>
+   <rect x="307" y="1543" width="30" height="32" rx="10"/>
+   <rect x="305"
+         y="1541"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="1561">=</text>
+   <rect x="357" y="1543" width="26" height="32" rx="10"/>
+   <rect x="355"
+         y="1541"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="365" y="1561">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#domain_id_list"
+      xlink:title="domain_id_list">
+      <rect x="403" y="1543" width="112" height="32"/>
+      <rect x="401"
+            y="1541"
+            width="112"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="411" y="1561">domain_id_list</text>
+   </a>
+   <rect x="555" y="1499" width="26" height="32" rx="10"/>
+   <rect x="553"
+         y="1497"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="563" y="1517">)</text>
+   <rect x="51" y="1631" width="186" height="32" rx="10"/>
+   <rect x="49"
+         y="1629"
+         width="186"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="1649">MASTER_RETRY_COUNT</text>
+   <rect x="257" y="1631" width="30" height="32" rx="10"/>
+   <rect x="255"
+         y="1629"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="1649">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#count"
+      xlink:title="count">
+      <rect x="327" y="1631" width="54" height="32"/>
+      <rect x="325" y="1629" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="335" y="1649">count</text>
+   </a>
+   <rect x="327" y="1675" width="80" height="32" rx="10"/>
+   <rect x="325"
+         y="1673"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="335" y="1693">DEFAULT</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m118 0 h10 m0 0 h222 m-570 0 h20 m550 0 h20 m-590 0 q10 0 10 10 m570 0 q0 -10 10 -10 m-580 10 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m122 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m92 0 h10 m0 0 h246 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m120 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m92 0 h10 m0 0 h248 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m164 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m80 0 h10 m0 0 h216 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m122 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m82 0 h10 m0 0 h256 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-540 10 h10 m202 0 h10 m0 0 h24 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v24 m266 0 v-24 m-266 24 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m226 0 h10 m20 -44 h10 m30 0 h10 m20 0 h10 m68 0 h10 m0 0 h12 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -44 h74 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m152 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m136 0 h10 m0 0 h172 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m150 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m122 0 h10 m0 0 h188 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m140 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m122 0 h10 m0 0 h198 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m138 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m110 0 h10 m0 0 h212 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m128 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m68 0 h10 m0 0 h264 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-540 10 h10 m110 0 h10 m0 0 h166 m-316 0 h20 m296 0 h20 m-336 0 q10 0 10 10 m316 0 q0 -10 10 -10 m-326 10 v24 m316 0 v-24 m-316 24 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m276 0 h10 m20 -44 h10 m30 0 h10 m20 0 h10 m28 0 h10 m0 0 h52 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m28 0 h10 m0 0 h52 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -88 h24 m-560 -10 v20 m570 0 v-20 m-570 20 v112 m570 0 v-112 m-570 112 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m138 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m104 0 h10 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m80 0 h10 m0 0 h24 m20 -44 h178 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m174 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m142 0 h10 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v24 m182 0 v-24 m-182 24 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m80 0 h10 m0 0 h62 m20 -44 h104 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m154 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m114 0 h10 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m80 0 h10 m0 0 h34 m20 -44 h152 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m146 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m104 0 h10 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m80 0 h10 m0 0 h24 m20 -44 h170 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m182 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m142 0 h10 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v24 m182 0 v-24 m-182 24 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m80 0 h10 m0 0 h62 m20 -44 h96 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m146 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m112 0 h10 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v24 m152 0 v-24 m-152 24 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m80 0 h10 m0 0 h32 m20 -44 h162 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m172 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m84 0 h10 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m80 0 h10 m0 0 h4 m20 -44 h164 m-560 -10 v20 m570 0 v-20 m-570 20 v68 m570 0 v-68 m-570 68 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m154 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m102 0 h10 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m88 0 h10 m0 0 h14 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m36 0 h10 m0 0 h66 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m80 0 h10 m0 0 h22 m20 -132 h164 m-560 -10 v20 m570 0 v-20 m-570 20 v156 m570 0 v-156 m-570 156 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m222 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m46 0 h10 m0 0 h192 m-560 -10 v20 m570 0 v-20 m-570 20 v24 m570 0 v-24 m-570 24 q0 10 10 10 m550 0 q10 0 10 -10 m-540 10 h10 m172 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h50 m-484 0 h20 m464 0 h20 m-504 0 q10 0 10 10 m484 0 q0 -10 10 -10 m-494 10 v24 m484 0 v-24 m-484 24 q0 10 10 10 m464 0 q10 0 10 -10 m-454 10 h10 m142 0 h10 m0 0 h34 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m20 -44 h10 m30 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m112 0 h10 m20 -44 h10 m26 0 h10 m-560 -10 v20 m570 0 v-20 m-570 20 v112 m570 0 v-112 m-570 112 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m186 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m54 0 h10 m0 0 h26 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -44 h154 m23 -1628 h-3"/>
+   <polygon points="619 17 627 13 627 21"/>
+   <polygon points="619 17 611 13 611 21"/>
+</svg>

--- a/server/.gitbook/assets/change-master-to-railroad.svg
+++ b/server/.gitbook/assets/change-master-to-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="977" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">CHANGE</text>
+   <rect x="127" y="47" width="76" height="32" rx="10"/>
+   <rect x="125"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="65">MASTER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#connection_name"
+      xlink:title="connection_name">
+      <rect x="243" y="79" width="132" height="32"/>
+      <rect x="241" y="77" width="132" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="251" y="97">connection_name</text>
+   </a>
+   <rect x="415" y="47" width="38" height="32" rx="10"/>
+   <rect x="413"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#master_def"
+      xlink:title="master_def">
+      <rect x="493" y="47" width="92" height="32"/>
+      <rect x="491" y="45" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="501" y="65">master_def</text>
+   </a>
+   <rect x="493" y="3" width="24" height="32" rx="10"/>
+   <rect x="491"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="501" y="21">,</text>
+   <rect x="645" y="79" width="48" height="32" rx="10"/>
+   <rect x="643"
+         y="77"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="97">FOR</text>
+   <rect x="713" y="79" width="84" height="32" rx="10"/>
+   <rect x="711"
+         y="77"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="721" y="97">CHANNEL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#channel_name"
+      xlink:title="channel_name">
+      <rect x="817" y="79" width="112" height="32"/>
+      <rect x="815" y="77" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="825" y="97">channel_name</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m76 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m20 -32 h10 m38 0 h10 m20 0 h10 m92 0 h10 m-132 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m112 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-112 0 h10 m24 0 h10 m0 0 h68 m40 44 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-314 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m112 0 h10 m23 -32 h-3"/>
+   <polygon points="967 61 975 57 975 65"/>
+   <polygon points="967 61 959 57 959 65"/>
+</svg>

--- a/server/.gitbook/assets/constraint-expression-railroad.svg
+++ b/server/.gitbook/assets/constraint-expression-railroad.svg
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1865" height="365">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="71" y="47" width="84" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">PRIMARY</text>
+   <rect x="175" y="47" width="46" height="32" rx="10"/>
+   <rect x="173"
+         y="45"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="183" y="65">KEY</text>
+   <rect x="71" y="91" width="74" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">UNIQUE</text>
+   <rect x="185" y="123" width="64" height="32" rx="10"/>
+   <rect x="183"
+         y="121"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="193" y="141">INDEX</text>
+   <rect x="185" y="167" width="46" height="32" rx="10"/>
+   <rect x="183"
+         y="165"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="193" y="185">KEY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_name"
+      xlink:title="index_name">
+      <rect x="309" y="123" width="98" height="32"/>
+      <rect x="307" y="121" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="317" y="141">index_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_type"
+      xlink:title="index_type">
+      <rect x="487" y="79" width="90" height="32"/>
+      <rect x="485" y="77" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="495" y="97">index_type</text>
+   </a>
+   <rect x="617" y="47" width="26" height="32" rx="10"/>
+   <rect x="615"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="625" y="65">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_col_name"
+      xlink:title="index_col_name">
+      <rect x="683" y="47" width="124" height="32"/>
+      <rect x="681" y="45" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="691" y="65">index_col_name</text>
+   </a>
+   <rect x="683" y="3" width="24" height="32" rx="10"/>
+   <rect x="681"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="691" y="21">,</text>
+   <rect x="847" y="47" width="26" height="32" rx="10"/>
+   <rect x="845"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="855" y="65">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_option"
+      xlink:title="index_option">
+      <rect x="913" y="13" width="102" height="32"/>
+      <rect x="911" y="11" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="921" y="31">index_option</text>
+   </a>
+   <rect x="51" y="255" width="82" height="32" rx="10"/>
+   <rect x="49"
+         y="253"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="273">FOREIGN</text>
+   <rect x="153" y="255" width="46" height="32" rx="10"/>
+   <rect x="151"
+         y="253"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="161" y="273">KEY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_name"
+      xlink:title="index_name">
+      <rect x="239" y="287" width="98" height="32"/>
+      <rect x="237" y="285" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="247" y="305">index_name</text>
+   </a>
+   <rect x="377" y="255" width="26" height="32" rx="10"/>
+   <rect x="375"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="385" y="273">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_col_name"
+      xlink:title="index_col_name">
+      <rect x="443" y="255" width="124" height="32"/>
+      <rect x="441" y="253" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="451" y="273">index_col_name</text>
+   </a>
+   <rect x="443" y="211" width="24" height="32" rx="10"/>
+   <rect x="441"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="229">,</text>
+   <rect x="607" y="255" width="26" height="32" rx="10"/>
+   <rect x="605"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="615" y="273">)</text>
+   <rect x="653" y="255" width="108" height="32" rx="10"/>
+   <rect x="651"
+         y="253"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="661" y="273">REFERENCES</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="781" y="255" width="80" height="32"/>
+      <rect x="779" y="253" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="789" y="273">tbl_name</text>
+   </a>
+   <rect x="881" y="255" width="26" height="32" rx="10"/>
+   <rect x="879"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="889" y="273">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_col_name"
+      xlink:title="index_col_name">
+      <rect x="947" y="255" width="124" height="32"/>
+      <rect x="945" y="253" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="955" y="273">index_col_name</text>
+   </a>
+   <rect x="947" y="211" width="24" height="32" rx="10"/>
+   <rect x="945"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="955" y="229">,</text>
+   <rect x="1111" y="255" width="26" height="32" rx="10"/>
+   <rect x="1109"
+         y="253"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1119" y="273">)</text>
+   <rect x="1177" y="287" width="40" height="32" rx="10"/>
+   <rect x="1175"
+         y="285"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1185" y="305">ON</text>
+   <rect x="1237" y="287" width="70" height="32" rx="10"/>
+   <rect x="1235"
+         y="285"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1245" y="305">DELETE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#reference_option"
+      xlink:title="reference_option">
+      <rect x="1327" y="287" width="128" height="32"/>
+      <rect x="1325"
+            y="285"
+            width="128"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="1335" y="305">reference_option</text>
+   </a>
+   <rect x="1515" y="287" width="40" height="32" rx="10"/>
+   <rect x="1513"
+         y="285"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1523" y="305">ON</text>
+   <rect x="1575" y="287" width="74" height="32" rx="10"/>
+   <rect x="1573"
+         y="285"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1583" y="305">UPDATE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#reference_option"
+      xlink:title="reference_option">
+      <rect x="1669" y="287" width="128" height="32"/>
+      <rect x="1667"
+            y="285"
+            width="128"
+            height="32"
+            class="nonterminal"/>
+      <text class="nonterminal" x="1677" y="305">reference_option</text>
+   </a>
+   <rect x="51" y="331" width="64" height="32" rx="10"/>
+   <rect x="49"
+         y="329"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="349">CHECK</text>
+   <rect x="135" y="331" width="26" height="32" rx="10"/>
+   <rect x="133"
+         y="329"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="349">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#check_constraints"
+      xlink:title="check_constraints">
+      <rect x="181" y="331" width="134" height="32"/>
+      <rect x="179" y="329" width="134" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="189" y="349">check_constraints</text>
+   </a>
+   <rect x="335" y="331" width="26" height="32" rx="10"/>
+   <rect x="333"
+         y="329"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="349">)</text>
+   <path class="line"
+         d="m17 61 h2 m40 0 h10 m84 0 h10 m0 0 h10 m46 0 h10 m0 0 h206 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v24 m396 0 v-24 m-396 24 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m74 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m46 0 h10 m0 0 h18 m40 -76 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m60 -76 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h112 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m122 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-122 0 h10 m102 0 h10 m20 34 h782 m-1806 0 h20 m1786 0 h20 m-1826 0 q10 0 10 10 m1806 0 q0 -10 10 -10 m-1816 10 v188 m1806 0 v-188 m-1806 188 q0 10 10 10 m1786 0 q10 0 10 -10 m-1796 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h288 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v12 m318 0 v-12 m-318 12 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m40 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m128 0 h10 m40 -32 h10 m0 0 h292 m-322 0 h20 m302 0 h20 m-342 0 q10 0 10 10 m322 0 q0 -10 10 -10 m-332 10 v12 m322 0 v-12 m-322 12 q0 10 10 10 m302 0 q10 0 10 -10 m-312 10 h10 m40 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m128 0 h10 m-1776 -42 v20 m1806 0 v-20 m-1806 20 v56 m1806 0 v-56 m-1806 56 q0 10 10 10 m1786 0 q10 0 10 -10 m-1796 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m26 0 h10 m0 0 h1456 m23 -284 h-3"/>
+   <polygon points="1855 61 1863 57 1863 65"/>
+   <polygon points="1855 61 1847 57 1847 65"/>
+</svg>

--- a/server/.gitbook/assets/constraint-index-col-name-railroad.svg
+++ b/server/.gitbook/assets/constraint-index-col-name-railroad.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="467" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="31" y="3" width="80" height="32"/>
+      <rect x="29" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">col_name</text>
+   </a>
+   <rect x="151" y="35" width="26" height="32" rx="10"/>
+   <rect x="149"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="53">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#length"
+      xlink:title="length">
+      <rect x="197" y="35" width="60" height="32"/>
+      <rect x="195" y="33" width="60" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="205" y="53">length</text>
+   </a>
+   <rect x="277" y="35" width="26" height="32" rx="10"/>
+   <rect x="275"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="285" y="53">)</text>
+   <rect x="363" y="35" width="46" height="32" rx="10"/>
+   <rect x="361"
+         y="33"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="371" y="53">ASC</text>
+   <rect x="363" y="79" width="56" height="32" rx="10"/>
+   <rect x="361"
+         y="77"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="371" y="97">DESC</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h162 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v12 m192 0 v-12 m-192 12 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m26 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m23 -76 h-3"/>
+   <polygon points="457 17 465 13 465 21"/>
+   <polygon points="457 17 449 13 449 21"/>
+</svg>

--- a/server/.gitbook/assets/constraint-index-option-railroad.svg
+++ b/server/.gitbook/assets/constraint-index-option-railroad.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="405" height="289">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="142" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="142"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">KEY_BLOCK_SIZE</text>
+   <rect x="233" y="35" width="30" height="32" rx="10"/>
+   <rect x="231"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="241" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value"
+      xlink:title="value">
+      <rect x="303" y="3" width="54" height="32"/>
+      <rect x="301" y="1" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="311" y="21">value</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_type"
+      xlink:title="index_type">
+      <rect x="51" y="79" width="90" height="32"/>
+      <rect x="49" y="77" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="97">index_type</text>
+   </a>
+   <rect x="51" y="123" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="121"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="141">WITH</text>
+   <rect x="129" y="123" width="74" height="32" rx="10"/>
+   <rect x="127"
+         y="121"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="137" y="141">PARSER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#parser_name"
+      xlink:title="parser_name">
+      <rect x="223" y="123" width="104" height="32"/>
+      <rect x="221" y="121" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="231" y="141">parser_name</text>
+   </a>
+   <rect x="51" y="167" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="165"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="185">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="159" y="167" width="56" height="32"/>
+      <rect x="157" y="165" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="167" y="185">string</text>
+   </a>
+   <rect x="51" y="211" width="108" height="32" rx="10"/>
+   <rect x="49"
+         y="209"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="229">CLUSTERING</text>
+   <rect x="179" y="211" width="30" height="32" rx="10"/>
+   <rect x="177"
+         y="209"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="229">=</text>
+   <rect x="249" y="211" width="46" height="32" rx="10"/>
+   <rect x="247"
+         y="209"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="229">YES</text>
+   <rect x="249" y="255" width="40" height="32" rx="10"/>
+   <rect x="247"
+         y="253"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="273">NO</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m142 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m54 0 h10 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v56 m346 0 v-56 m-346 56 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m90 0 h10 m0 0 h216 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m58 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m104 0 h10 m0 0 h30 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m88 0 h10 m0 0 h10 m56 0 h10 m0 0 h142 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m108 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m46 0 h10 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v24 m86 0 v-24 m-86 24 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m40 0 h10 m0 0 h6 m20 -44 h42 m23 -208 h-3"/>
+   <polygon points="395 17 403 13 403 21"/>
+   <polygon points="395 17 387 13 387 21"/>
+</svg>

--- a/server/.gitbook/assets/constraint-index-type-railroad.svg
+++ b/server/.gitbook/assets/constraint-index-type-railroad.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="245" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">USING</text>
+   <rect x="135" y="3" width="62" height="32" rx="10"/>
+   <rect x="133"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="21">BTREE</text>
+   <rect x="135" y="47" width="58" height="32" rx="10"/>
+   <rect x="133"
+         y="45"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="65">HASH</text>
+   <rect x="135" y="91" width="62" height="32" rx="10"/>
+   <rect x="133"
+         y="89"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="109">RTREE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m62 0 h10 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m58 0 h10 m0 0 h4 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m23 -88 h-3"/>
+   <polygon points="235 17 243 13 243 21"/>
+   <polygon points="235 17 227 13 227 21"/>
+</svg>

--- a/server/.gitbook/assets/constraint-railroad.svg
+++ b/server/.gitbook/assets/constraint-railroad.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="101">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="35" width="110" height="32" rx="10"/>
+   <rect x="49"
+         y="33"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="53">CONSTRAINT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#symbol"
+      xlink:title="symbol">
+      <rect x="201" y="67" width="64" height="32"/>
+      <rect x="199" y="65" width="64" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="209" y="85">symbol</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#constraint_expression"
+      xlink:title="constraint_expression">
+      <rect x="325" y="3" width="160" height="32"/>
+      <rect x="323" y="1" width="160" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="333" y="21">constraint_expression</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m110 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -64 h10 m160 0 h10 m3 0 h-3"/>
+   <polygon points="503 17 511 13 511 21"/>
+   <polygon points="503 17 495 13 495 21"/>
+</svg>

--- a/server/.gitbook/assets/constraint-reference-option-railroad.svg
+++ b/server/.gitbook/assets/constraint-reference-option-railroad.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="283" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">RESTRICT</text>
+   <rect x="51" y="47" width="84" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">CASCADE</text>
+   <rect x="51" y="91" width="44" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">SET</text>
+   <rect x="135" y="91" width="56" height="32" rx="10"/>
+   <rect x="133"
+         y="89"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="109">NULL</text>
+   <rect x="135" y="135" width="80" height="32" rx="10"/>
+   <rect x="133"
+         y="133"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="153">DEFAULT</text>
+   <rect x="51" y="179" width="40" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">NO</text>
+   <rect x="111" y="179" width="74" height="32" rx="10"/>
+   <rect x="109"
+         y="177"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="197">ACTION</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m88 0 h10 m0 0 h96 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m84 0 h10 m0 0 h100 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m44 0 h10 m20 0 h10 m56 0 h10 m0 0 h24 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-194 -54 v20 m224 0 v-20 m-224 20 v68 m224 0 v-68 m-224 68 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m40 0 h10 m0 0 h10 m74 0 h10 m0 0 h50 m23 -176 h-3"/>
+   <polygon points="273 17 281 13 281 21"/>
+   <polygon points="273 17 265 13 265 21"/>
+</svg>

--- a/server/.gitbook/assets/create-function-characteristic-railroad.svg
+++ b/server/.gitbook/assets/create-function-characteristic-railroad.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="399" height="421">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="3" width="94" height="32" rx="10"/>
+   <rect x="69"
+         y="1"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="21">LANGUAGE</text>
+   <rect x="71" y="47" width="92" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">CONTAINS</text>
+   <rect x="71" y="91" width="40" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">NO</text>
+   <rect x="205" y="3" width="48" height="32" rx="10"/>
+   <rect x="203"
+         y="1"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="213" y="21">SQL</text>
+   <rect x="71" y="167" width="48" height="32" rx="10"/>
+   <rect x="69"
+         y="165"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="185">NOT</text>
+   <rect x="159" y="135" width="130" height="32" rx="10"/>
+   <rect x="157"
+         y="133"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="153">DETERMINISTIC</text>
+   <rect x="71" y="211" width="66" height="32" rx="10"/>
+   <rect x="69"
+         y="209"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="229">READS</text>
+   <rect x="71" y="255" width="90" height="32" rx="10"/>
+   <rect x="69"
+         y="253"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="273">MODIFIES</text>
+   <rect x="201" y="211" width="48" height="32" rx="10"/>
+   <rect x="199"
+         y="209"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="229">SQL</text>
+   <rect x="269" y="211" width="56" height="32" rx="10"/>
+   <rect x="267"
+         y="209"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="229">DATA</text>
+   <rect x="51" y="299" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="297"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="317">SQL</text>
+   <rect x="119" y="299" width="88" height="32" rx="10"/>
+   <rect x="117"
+         y="297"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="317">SECURITY</text>
+   <rect x="247" y="299" width="80" height="32" rx="10"/>
+   <rect x="245"
+         y="297"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="317">DEFINER</text>
+   <rect x="247" y="343" width="84" height="32" rx="10"/>
+   <rect x="245"
+         y="341"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="361">INVOKER</text>
+   <rect x="51" y="387" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="385"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="405">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="159" y="387" width="56" height="32"/>
+      <rect x="157" y="385" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="167" y="405">string</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m94 0 h10 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m92 0 h10 m0 0 h2 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m40 0 h10 m0 0 h54 m20 -88 h10 m48 0 h10 m0 0 h98 m-340 0 h20 m320 0 h20 m-360 0 q10 0 10 10 m340 0 q0 -10 10 -10 m-350 10 v112 m340 0 v-112 m-340 112 q0 10 10 10 m320 0 q10 0 10 -10 m-310 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m130 0 h10 m0 0 h62 m-330 -10 v20 m340 0 v-20 m-340 20 v56 m340 0 v-56 m-340 56 q0 10 10 10 m320 0 q10 0 10 -10 m-310 10 h10 m66 0 h10 m0 0 h24 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m20 -44 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h26 m-330 -10 v20 m340 0 v-20 m-340 20 v68 m340 0 v-68 m-340 68 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m48 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m80 0 h10 m0 0 h4 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m-310 -54 v20 m340 0 v-20 m-340 20 v68 m340 0 v-68 m-340 68 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m88 0 h10 m0 0 h10 m56 0 h10 m0 0 h136 m23 -384 h-3"/>
+   <polygon points="389 17 397 13 397 21"/>
+   <polygon points="389 17 381 13 381 21"/>
+</svg>

--- a/server/.gitbook/assets/create-function-parameter-railroad.svg
+++ b/server/.gitbook/assets/create-function-parameter-railroad.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="633" height="221">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="91" y="67" width="36" height="32" rx="10"/>
+   <rect x="89"
+         y="65"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="99" y="85">IN</text>
+   <rect x="167" y="35" width="48" height="32" rx="10"/>
+   <rect x="165"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="175" y="53">OUT</text>
+   <rect x="71" y="111" width="66" height="32" rx="10"/>
+   <rect x="69"
+         y="109"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="129">INOUT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#param_name"
+      xlink:title="param_name">
+      <rect x="255" y="3" width="104" height="32"/>
+      <rect x="253" y="1" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="263" y="21">param_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="379" y="3" width="48" height="32"/>
+      <rect x="377" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="387" y="21">type</text>
+   </a>
+   <rect x="71" y="187" width="36" height="32" rx="10"/>
+   <rect x="69"
+         y="185"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="205">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#param_name"
+      xlink:title="param_name">
+      <rect x="147" y="155" width="104" height="32"/>
+      <rect x="145" y="153" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="155" y="173">param_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="271" y="155" width="48" height="32"/>
+      <rect x="269" y="153" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="279" y="173">type</text>
+   </a>
+   <rect x="359" y="187" width="80" height="32" rx="10"/>
+   <rect x="357"
+         y="185"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="367" y="205">DEFAULT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#default_value"
+      xlink:title="default_value">
+      <rect x="459" y="187" width="106" height="32"/>
+      <rect x="457" y="185" width="106" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="467" y="205">default_value</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-154 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m48 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v56 m184 0 v-56 m-184 56 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m66 0 h10 m0 0 h78 m20 -108 h10 m104 0 h10 m0 0 h10 m48 0 h10 m0 0 h158 m-574 0 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v132 m574 0 v-132 m-574 132 q0 10 10 10 m554 0 q10 0 10 -10 m-544 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m80 0 h10 m0 0 h10 m106 0 h10 m43 -184 h-3"/>
+   <polygon points="623 17 631 13 631 21"/>
+   <polygon points="623 17 615 13 615 21"/>
+</svg>

--- a/server/.gitbook/assets/create-function-railroad.svg
+++ b/server/.gitbook/assets/create-function-railroad.svg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="979" height="443">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="80" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">DEFINER</text>
+   <rect x="443" y="35" width="30" height="32" rx="10"/>
+   <rect x="441"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="513" y="35" width="48" height="32"/>
+      <rect x="511" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="53">user</text>
+   </a>
+   <rect x="513" y="79" width="128" height="32" rx="10"/>
+   <rect x="511"
+         y="77"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="97">CURRENT_USER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="513" y="123" width="44" height="32"/>
+      <rect x="511" y="121" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="141">role</text>
+   </a>
+   <rect x="513" y="167" width="130" height="32" rx="10"/>
+   <rect x="511"
+         y="165"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="185">CURRENT_ROLE</text>
+   <rect x="723" y="35" width="102" height="32" rx="10"/>
+   <rect x="721"
+         y="33"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="731" y="53">AGGREGATE</text>
+   <rect x="865" y="3" width="92" height="32" rx="10"/>
+   <rect x="863"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="873" y="21">FUNCTION</text>
+   <rect x="98" y="309" width="34" height="32" rx="10"/>
+   <rect x="96"
+         y="307"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="106" y="327">IF</text>
+   <rect x="152" y="309" width="48" height="32" rx="10"/>
+   <rect x="150"
+         y="307"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="160" y="327">NOT</text>
+   <rect x="220" y="309" width="70" height="32" rx="10"/>
+   <rect x="218"
+         y="307"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="228" y="327">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#func_name"
+      xlink:title="func_name">
+      <rect x="330" y="277" width="90" height="32"/>
+      <rect x="328" y="275" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="338" y="295">func_name</text>
+   </a>
+   <rect x="440" y="277" width="26" height="32" rx="10"/>
+   <rect x="438"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="448" y="295">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#func_parameter"
+      xlink:title="func_parameter">
+      <rect x="526" y="277" width="120" height="32"/>
+      <rect x="524" y="275" width="120" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="534" y="295">func_parameter</text>
+   </a>
+   <rect x="526" y="233" width="24" height="32" rx="10"/>
+   <rect x="524"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="534" y="251">,</text>
+   <rect x="706" y="277" width="26" height="32" rx="10"/>
+   <rect x="704"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="714" y="295">)</text>
+   <rect x="752" y="277" width="84" height="32" rx="10"/>
+   <rect x="750"
+         y="275"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="760" y="295">RETURNS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="856" y="277" width="48" height="32"/>
+      <rect x="854" y="275" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="864" y="295">type</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#characteristic"
+      xlink:title="characteristic">
+      <rect x="721" y="375" width="104" height="32"/>
+      <rect x="719" y="373" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="729" y="393">characteristic</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#func_body"
+      xlink:title="func_body">
+      <rect x="865" y="409" width="86" height="32"/>
+      <rect x="863" y="407" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="873" y="427">func_body</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h330 m-360 0 h20 m340 0 h20 m-380 0 q10 0 10 10 m360 0 q0 -10 10 -10 m-370 10 v12 m360 0 v-12 m-360 12 q0 10 10 10 m340 0 q10 0 10 -10 m-350 10 h10 m80 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m48 0 h10 m0 0 h82 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m60 -164 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-923 274 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m120 0 h10 m-160 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m-180 44 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v14 m200 0 v-14 m-200 14 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m0 0 h170 m20 -34 h10 m26 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-247 132 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h114 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m124 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-124 0 h10 m104 0 h10 m20 34 h10 m86 0 h10 m3 0 h-3"/>
+   <polygon points="969 423 977 419 977 427"/>
+   <polygon points="969 423 961 419 961 427"/>
+</svg>

--- a/server/.gitbook/assets/create-index-algorithm-option-railroad.svg
+++ b/server/.gitbook/assets/create-index-algorithm-option-railroad.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="393" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="104" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALGORITHM</text>
+   <rect x="175" y="35" width="30" height="32" rx="10"/>
+   <rect x="173"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="183" y="53">=</text>
+   <rect x="265" y="3" width="80" height="32" rx="10"/>
+   <rect x="263"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="21">DEFAULT</text>
+   <rect x="265" y="47" width="80" height="32" rx="10"/>
+   <rect x="263"
+         y="45"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="65">INPLACE</text>
+   <rect x="265" y="91" width="58" height="32" rx="10"/>
+   <rect x="263"
+         y="89"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="109">COPY</text>
+   <rect x="265" y="135" width="78" height="32" rx="10"/>
+   <rect x="263"
+         y="133"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="153">NOCOPY</text>
+   <rect x="265" y="179" width="80" height="32" rx="10"/>
+   <rect x="263"
+         y="177"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="197">INSTANT</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m104 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m40 -32 h10 m80 0 h10 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m58 0 h10 m0 0 h22 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m78 0 h10 m0 0 h2 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m23 -176 h-3"/>
+   <polygon points="383 17 391 13 391 21"/>
+   <polygon points="383 17 375 13 375 21"/>
+</svg>

--- a/server/.gitbook/assets/create-index-col-name-railroad.svg
+++ b/server/.gitbook/assets/create-index-col-name-railroad.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="467" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="31" y="3" width="80" height="32"/>
+      <rect x="29" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">col_name</text>
+   </a>
+   <rect x="151" y="35" width="26" height="32" rx="10"/>
+   <rect x="149"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="53">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#length"
+      xlink:title="length">
+      <rect x="197" y="35" width="60" height="32"/>
+      <rect x="195" y="33" width="60" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="205" y="53">length</text>
+   </a>
+   <rect x="277" y="35" width="26" height="32" rx="10"/>
+   <rect x="275"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="285" y="53">)</text>
+   <rect x="363" y="35" width="46" height="32" rx="10"/>
+   <rect x="361"
+         y="33"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="371" y="53">ASC</text>
+   <rect x="363" y="79" width="56" height="32" rx="10"/>
+   <rect x="361"
+         y="77"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="371" y="97">DESC</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h162 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v12 m192 0 v-12 m-192 12 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m26 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m23 -76 h-3"/>
+   <polygon points="457 17 465 13 465 21"/>
+   <polygon points="457 17 449 13 449 21"/>
+</svg>

--- a/server/.gitbook/assets/create-index-lock-option-railroad.svg
+++ b/server/.gitbook/assets/create-index-lock-option-railroad.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="361" height="169">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">LOCK</text>
+   <rect x="127" y="35" width="30" height="32" rx="10"/>
+   <rect x="125"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="53">=</text>
+   <rect x="217" y="3" width="80" height="32" rx="10"/>
+   <rect x="215"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="21">DEFAULT</text>
+   <rect x="217" y="47" width="58" height="32" rx="10"/>
+   <rect x="215"
+         y="45"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="65">NONE</text>
+   <rect x="217" y="91" width="76" height="32" rx="10"/>
+   <rect x="215"
+         y="89"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="109">SHARED</text>
+   <rect x="217" y="135" width="96" height="32" rx="10"/>
+   <rect x="215"
+         y="133"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="153">EXCLUSIVE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m40 -32 h10 m80 0 h10 m0 0 h16 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m58 0 h10 m0 0 h38 m-126 -10 v20 m136 0 v-20 m-136 20 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m76 0 h10 m0 0 h20 m-126 -10 v20 m136 0 v-20 m-136 20 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m23 -132 h-3"/>
+   <polygon points="351 17 359 13 359 21"/>
+   <polygon points="351 17 343 13 343 21"/>
+</svg>

--- a/server/.gitbook/assets/create-index-option-railroad.svg
+++ b/server/.gitbook/assets/create-index-option-railroad.svg
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="405" height="497">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="142" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="142"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">KEY_BLOCK_SIZE</text>
+   <rect x="233" y="35" width="30" height="32" rx="10"/>
+   <rect x="231"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="241" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value"
+      xlink:title="value">
+      <rect x="303" y="3" width="54" height="32"/>
+      <rect x="301" y="1" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="311" y="21">value</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_type"
+      xlink:title="index_type">
+      <rect x="51" y="79" width="90" height="32"/>
+      <rect x="49" y="77" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="97">index_type</text>
+   </a>
+   <rect x="51" y="123" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="121"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="141">WITH</text>
+   <rect x="129" y="123" width="74" height="32" rx="10"/>
+   <rect x="127"
+         y="121"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="137" y="141">PARSER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#parser_name"
+      xlink:title="parser_name">
+      <rect x="223" y="123" width="104" height="32"/>
+      <rect x="221" y="121" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="231" y="141">parser_name</text>
+   </a>
+   <rect x="51" y="167" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="165"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="185">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="159" y="167" width="56" height="32"/>
+      <rect x="157" y="165" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="167" y="185">string</text>
+   </a>
+   <rect x="51" y="211" width="108" height="32" rx="10"/>
+   <rect x="49"
+         y="209"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="229">CLUSTERING</text>
+   <rect x="179" y="211" width="30" height="32" rx="10"/>
+   <rect x="177"
+         y="209"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="187" y="229">=</text>
+   <rect x="249" y="211" width="46" height="32" rx="10"/>
+   <rect x="247"
+         y="209"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="229">YES</text>
+   <rect x="249" y="255" width="40" height="32" rx="10"/>
+   <rect x="247"
+         y="253"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="273">NO</text>
+   <rect x="71" y="331" width="48" height="32" rx="10"/>
+   <rect x="69"
+         y="329"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="349">NOT</text>
+   <rect x="159" y="299" width="84" height="32" rx="10"/>
+   <rect x="157"
+         y="297"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="317">IGNORED</text>
+   <rect x="51" y="375" width="90" height="32" rx="10"/>
+   <rect x="49"
+         y="373"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="393">DISTANCE</text>
+   <rect x="161" y="375" width="30" height="32" rx="10"/>
+   <rect x="159"
+         y="373"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="169" y="393">=</text>
+   <rect x="231" y="375" width="98" height="32" rx="10"/>
+   <rect x="229"
+         y="373"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="393">EUCLIDEAN</text>
+   <rect x="231" y="419" width="74" height="32" rx="10"/>
+   <rect x="229"
+         y="417"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="437">COSINE</text>
+   <rect x="51" y="463" width="30" height="32" rx="10"/>
+   <rect x="49"
+         y="461"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="481">M</text>
+   <rect x="101" y="463" width="30" height="32" rx="10"/>
+   <rect x="99"
+         y="461"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="109" y="481">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="151" y="463" width="68" height="32"/>
+      <rect x="149" y="461" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="159" y="481">number</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m142 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m54 0 h10 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v56 m346 0 v-56 m-346 56 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m90 0 h10 m0 0 h216 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m58 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m104 0 h10 m0 0 h30 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m88 0 h10 m0 0 h10 m56 0 h10 m0 0 h142 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m108 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m46 0 h10 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v24 m86 0 v-24 m-86 24 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m40 0 h10 m0 0 h6 m20 -44 h42 m-336 -10 v20 m346 0 v-20 m-346 20 v68 m346 0 v-68 m-346 68 q0 10 10 10 m326 0 q10 0 10 -10 m-316 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m84 0 h10 m0 0 h114 m-336 -10 v20 m346 0 v-20 m-346 20 v56 m346 0 v-56 m-346 56 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m90 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m98 0 h10 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v24 m138 0 v-24 m-138 24 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m74 0 h10 m0 0 h24 m20 -44 h8 m-336 -10 v20 m346 0 v-20 m-346 20 v68 m346 0 v-68 m-346 68 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m30 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m68 0 h10 m0 0 h138 m23 -460 h-3"/>
+   <polygon points="395 17 403 13 403 21"/>
+   <polygon points="395 17 387 13 387 21"/>
+</svg>

--- a/server/.gitbook/assets/create-index-railroad.svg
+++ b/server/.gitbook/assets/create-index-railroad.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="941" height="517">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="74" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">UNIQUE</text>
+   <rect x="343" y="79" width="86" height="32" rx="10"/>
+   <rect x="341"
+         y="77"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="97">FULLTEXT</text>
+   <rect x="343" y="123" width="78" height="32" rx="10"/>
+   <rect x="341"
+         y="121"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="141">SPATIAL</text>
+   <rect x="343" y="167" width="74" height="32" rx="10"/>
+   <rect x="341"
+         y="165"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="185">VECTOR</text>
+   <rect x="469" y="3" width="64" height="32" rx="10"/>
+   <rect x="467"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="477" y="21">INDEX</text>
+   <rect x="573" y="35" width="34" height="32" rx="10"/>
+   <rect x="571"
+         y="33"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="581" y="53">IF</text>
+   <rect x="627" y="35" width="48" height="32" rx="10"/>
+   <rect x="625"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="635" y="53">NOT</text>
+   <rect x="695" y="35" width="70" height="32" rx="10"/>
+   <rect x="693"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="703" y="53">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_name"
+      xlink:title="index_name">
+      <rect x="805" y="3" width="98" height="32"/>
+      <rect x="803" y="1" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="813" y="21">index_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_type"
+      xlink:title="index_type">
+      <rect x="45" y="309" width="90" height="32"/>
+      <rect x="43" y="307" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="53" y="327">index_type</text>
+   </a>
+   <rect x="175" y="277" width="40" height="32" rx="10"/>
+   <rect x="173"
+         y="275"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="183" y="295">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="235" y="277" width="80" height="32"/>
+      <rect x="233" y="275" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="243" y="295">tbl_name</text>
+   </a>
+   <rect x="335" y="277" width="26" height="32" rx="10"/>
+   <rect x="333"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="295">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_col_name"
+      xlink:title="index_col_name">
+      <rect x="401" y="277" width="124" height="32"/>
+      <rect x="399" y="275" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="409" y="295">index_col_name</text>
+   </a>
+   <rect x="401" y="233" width="24" height="32" rx="10"/>
+   <rect x="399"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="409" y="251">,</text>
+   <rect x="565" y="277" width="26" height="32" rx="10"/>
+   <rect x="563"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="573" y="295">)</text>
+   <rect x="631" y="309" width="58" height="32" rx="10"/>
+   <rect x="629"
+         y="307"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="639" y="327">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="709" y="309" width="28" height="32"/>
+      <rect x="707" y="307" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="717" y="327">n</text>
+   </a>
+   <rect x="631" y="353" width="78" height="32" rx="10"/>
+   <rect x="629"
+         y="351"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="639" y="371">NOWAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_option"
+      xlink:title="index_option">
+      <rect x="797" y="309" width="102" height="32"/>
+      <rect x="795" y="307" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="805" y="327">index_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#algorithm_option"
+      xlink:title="algorithm_option">
+      <rect x="765" y="463" width="128" height="32"/>
+      <rect x="763" y="461" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="773" y="481">algorithm_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#lock_option"
+      xlink:title="lock_option">
+      <rect x="765" y="419" width="92" height="32"/>
+      <rect x="763" y="417" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="773" y="437">lock_option</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m74 0 h10 m0 0 h12 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m78 0 h10 m0 0 h8 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m74 0 h10 m0 0 h12 m20 -164 h10 m64 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-922 274 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m20 -32 h10 m40 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m40 -76 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-218 220 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h138 m-168 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m148 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-148 0 h10 m128 0 h10 m-158 10 l0 -44 q0 -10 10 -10 m158 54 l0 -44 q0 -10 -10 -10 m-148 0 h10 m92 0 h10 m0 0 h36 m23 78 h-3"/>
+   <polygon points="931 511 939 507 939 515"/>
+   <polygon points="931 511 923 507 923 515"/>
+</svg>

--- a/server/.gitbook/assets/create-index-type-railroad.svg
+++ b/server/.gitbook/assets/create-index-type-railroad.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="245" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">USING</text>
+   <rect x="135" y="3" width="62" height="32" rx="10"/>
+   <rect x="133"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="21">BTREE</text>
+   <rect x="135" y="47" width="58" height="32" rx="10"/>
+   <rect x="133"
+         y="45"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="65">HASH</text>
+   <rect x="135" y="91" width="62" height="32" rx="10"/>
+   <rect x="133"
+         y="89"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="109">RTREE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m62 0 h10 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m58 0 h10 m0 0 h4 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m23 -88 h-3"/>
+   <polygon points="235 17 243 13 243 21"/>
+   <polygon points="235 17 227 13 227 21"/>
+</svg>

--- a/server/.gitbook/assets/create-procedure-characteristic-railroad.svg
+++ b/server/.gitbook/assets/create-procedure-characteristic-railroad.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="399" height="421">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="3" width="94" height="32" rx="10"/>
+   <rect x="69"
+         y="1"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="21">LANGUAGE</text>
+   <rect x="71" y="47" width="92" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">CONTAINS</text>
+   <rect x="71" y="91" width="40" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">NO</text>
+   <rect x="205" y="3" width="48" height="32" rx="10"/>
+   <rect x="203"
+         y="1"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="213" y="21">SQL</text>
+   <rect x="71" y="167" width="48" height="32" rx="10"/>
+   <rect x="69"
+         y="165"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="185">NOT</text>
+   <rect x="159" y="135" width="130" height="32" rx="10"/>
+   <rect x="157"
+         y="133"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="153">DETERMINISTIC</text>
+   <rect x="71" y="211" width="66" height="32" rx="10"/>
+   <rect x="69"
+         y="209"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="229">READS</text>
+   <rect x="71" y="255" width="90" height="32" rx="10"/>
+   <rect x="69"
+         y="253"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="273">MODIFIES</text>
+   <rect x="201" y="211" width="48" height="32" rx="10"/>
+   <rect x="199"
+         y="209"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="229">SQL</text>
+   <rect x="269" y="211" width="56" height="32" rx="10"/>
+   <rect x="267"
+         y="209"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="229">DATA</text>
+   <rect x="51" y="299" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="297"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="317">SQL</text>
+   <rect x="119" y="299" width="88" height="32" rx="10"/>
+   <rect x="117"
+         y="297"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="317">SECURITY</text>
+   <rect x="247" y="299" width="80" height="32" rx="10"/>
+   <rect x="245"
+         y="297"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="317">DEFINER</text>
+   <rect x="247" y="343" width="84" height="32" rx="10"/>
+   <rect x="245"
+         y="341"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="361">INVOKER</text>
+   <rect x="51" y="387" width="88" height="32" rx="10"/>
+   <rect x="49"
+         y="385"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="405">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="159" y="387" width="56" height="32"/>
+      <rect x="157" y="385" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="167" y="405">string</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m94 0 h10 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m92 0 h10 m0 0 h2 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m40 0 h10 m0 0 h54 m20 -88 h10 m48 0 h10 m0 0 h98 m-340 0 h20 m320 0 h20 m-360 0 q10 0 10 10 m340 0 q0 -10 10 -10 m-350 10 v112 m340 0 v-112 m-340 112 q0 10 10 10 m320 0 q10 0 10 -10 m-310 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m130 0 h10 m0 0 h62 m-330 -10 v20 m340 0 v-20 m-340 20 v56 m340 0 v-56 m-340 56 q0 10 10 10 m320 0 q10 0 10 -10 m-310 10 h10 m66 0 h10 m0 0 h24 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m20 -44 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h26 m-330 -10 v20 m340 0 v-20 m-340 20 v68 m340 0 v-68 m-340 68 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m48 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m80 0 h10 m0 0 h4 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m-310 -54 v20 m340 0 v-20 m-340 20 v68 m340 0 v-68 m-340 68 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m88 0 h10 m0 0 h10 m56 0 h10 m0 0 h136 m23 -384 h-3"/>
+   <polygon points="389 17 397 13 397 21"/>
+   <polygon points="389 17 381 13 381 21"/>
+</svg>

--- a/server/.gitbook/assets/create-procedure-parameter-railroad.svg
+++ b/server/.gitbook/assets/create-procedure-parameter-railroad.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="633" height="221">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="91" y="67" width="36" height="32" rx="10"/>
+   <rect x="89"
+         y="65"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="99" y="85">IN</text>
+   <rect x="167" y="35" width="48" height="32" rx="10"/>
+   <rect x="165"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="175" y="53">OUT</text>
+   <rect x="71" y="111" width="66" height="32" rx="10"/>
+   <rect x="69"
+         y="109"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="129">INOUT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#param_name"
+      xlink:title="param_name">
+      <rect x="255" y="3" width="104" height="32"/>
+      <rect x="253" y="1" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="263" y="21">param_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="379" y="3" width="48" height="32"/>
+      <rect x="377" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="387" y="21">type</text>
+   </a>
+   <rect x="71" y="187" width="36" height="32" rx="10"/>
+   <rect x="69"
+         y="185"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="205">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#param_name"
+      xlink:title="param_name">
+      <rect x="147" y="155" width="104" height="32"/>
+      <rect x="145" y="153" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="155" y="173">param_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#type"
+      xlink:title="type">
+      <rect x="271" y="155" width="48" height="32"/>
+      <rect x="269" y="153" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="279" y="173">type</text>
+   </a>
+   <rect x="359" y="187" width="80" height="32" rx="10"/>
+   <rect x="357"
+         y="185"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="367" y="205">DEFAULT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#default_value"
+      xlink:title="default_value">
+      <rect x="459" y="187" width="106" height="32"/>
+      <rect x="457" y="185" width="106" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="467" y="205">default_value</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-154 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m48 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v56 m184 0 v-56 m-184 56 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m66 0 h10 m0 0 h78 m20 -108 h10 m104 0 h10 m0 0 h10 m48 0 h10 m0 0 h158 m-574 0 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v132 m574 0 v-132 m-574 132 q0 10 10 10 m554 0 q10 0 10 -10 m-544 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m80 0 h10 m0 0 h10 m106 0 h10 m43 -184 h-3"/>
+   <polygon points="623 17 631 13 631 21"/>
+   <polygon points="623 17 615 13 615 21"/>
+</svg>

--- a/server/.gitbook/assets/create-procedure-railroad.svg
+++ b/server/.gitbook/assets/create-procedure-railroad.svg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="855" height="409">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="80" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">DEFINER</text>
+   <rect x="443" y="35" width="30" height="32" rx="10"/>
+   <rect x="441"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="513" y="35" width="48" height="32"/>
+      <rect x="511" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="53">user</text>
+   </a>
+   <rect x="513" y="79" width="128" height="32" rx="10"/>
+   <rect x="511"
+         y="77"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="97">CURRENT_USER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="513" y="123" width="44" height="32"/>
+      <rect x="511" y="121" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="141">role</text>
+   </a>
+   <rect x="513" y="167" width="130" height="32" rx="10"/>
+   <rect x="511"
+         y="165"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="185">CURRENT_ROLE</text>
+   <rect x="703" y="3" width="104" height="32" rx="10"/>
+   <rect x="701"
+         y="1"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="711" y="21">PROCEDURE</text>
+   <rect x="45" y="309" width="34" height="32" rx="10"/>
+   <rect x="43"
+         y="307"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="327">IF</text>
+   <rect x="99" y="309" width="48" height="32" rx="10"/>
+   <rect x="97"
+         y="307"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="107" y="327">NOT</text>
+   <rect x="167" y="309" width="70" height="32" rx="10"/>
+   <rect x="165"
+         y="307"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="175" y="327">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#sp_name"
+      xlink:title="sp_name">
+      <rect x="277" y="277" width="78" height="32"/>
+      <rect x="275" y="275" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="285" y="295">sp_name</text>
+   </a>
+   <rect x="375" y="277" width="26" height="32" rx="10"/>
+   <rect x="373"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="295">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#proc_parameter"
+      xlink:title="proc_parameter">
+      <rect x="461" y="277" width="122" height="32"/>
+      <rect x="459" y="275" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="469" y="295">proc_parameter</text>
+   </a>
+   <rect x="461" y="233" width="24" height="32" rx="10"/>
+   <rect x="459"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="469" y="251">,</text>
+   <rect x="643" y="277" width="26" height="32" rx="10"/>
+   <rect x="641"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="651" y="295">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#characteristic"
+      xlink:title="characteristic">
+      <rect x="709" y="243" width="104" height="32"/>
+      <rect x="707" y="241" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="717" y="261">characteristic</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#routine_body"
+      xlink:title="routine_body">
+      <rect x="723" y="375" width="104" height="32"/>
+      <rect x="721" y="373" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="731" y="393">routine_body</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h330 m-360 0 h20 m340 0 h20 m-380 0 q10 0 10 10 m360 0 q0 -10 10 -10 m-370 10 v12 m360 0 v-12 m-360 12 q0 10 10 10 m340 0 q10 0 10 -10 m-350 10 h10 m80 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m48 0 h10 m0 0 h82 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -164 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-826 274 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m78 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m-182 44 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v14 m202 0 v-14 m-202 14 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m0 0 h172 m20 -34 h10 m26 0 h10 m20 0 h10 m0 0 h114 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m124 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-124 0 h10 m104 0 h10 m22 34 l2 0 m2 0 l2 0 m2 0 l2 0 m-154 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m3 0 h-3"/>
+   <polygon points="845 389 853 385 853 393"/>
+   <polygon points="845 389 837 385 837 393"/>
+</svg>

--- a/server/reference/sql-statements/administrative-sql-statements/replication-statements/change-master-to.md
+++ b/server/reference/sql-statements/administrative-sql-statements/replication-statements/change-master-to.md
@@ -51,6 +51,10 @@ master_def:
   | MASTER_RETRY_COUNT = {long | DEFAULT}
 ```
 
+![Railroad diagram of CHANGE MASTER TO — equivalent to the BNF above](../../../../.gitbook/assets/change-master-to-railroad.svg)
+
+![Railroad diagram of master_def](../../../../.gitbook/assets/change-master-to-master-def-railroad.svg)
+
 Note: The value is extracted from the corresponding server option or system variable that support `DEFAULT`. This allows you to reset a replication configuration parameter to its [server-level configuration](#using-configurable-defaults) without providing an explicit value.
 
 ## Replication Configuration

--- a/server/reference/sql-statements/data-definition/constraint.md
+++ b/server/reference/sql-statements/data-definition/constraint.md
@@ -43,6 +43,18 @@ reference_option:
 ```
 {% endcode %}
 
+![Railroad diagram of CONSTRAINT — equivalent to the BNF above](../../../.gitbook/assets/constraint-railroad.svg)
+
+![Railroad diagram of constraint_expression](../../../.gitbook/assets/constraint-expression-railroad.svg)
+
+![Railroad diagram of index_type](../../../.gitbook/assets/constraint-index-type-railroad.svg)
+
+![Railroad diagram of index_col_name](../../../.gitbook/assets/constraint-index-col-name-railroad.svg)
+
+![Railroad diagram of index_option](../../../.gitbook/assets/constraint-index-option-railroad.svg)
+
+![Railroad diagram of reference_option](../../../.gitbook/assets/constraint-reference-option-railroad.svg)
+
 ## Description
 
 Constraints provide restrictions on the data you can add to a table. This allows to enforce data integrity in MariaDB, rather than through application logic. When a statement violates a constraint, MariaDB throws an error.

--- a/server/reference/sql-statements/data-definition/create/create-function.md
+++ b/server/reference/sql-statements/data-definition/create/create-function.md
@@ -34,6 +34,12 @@ func_body:
     Valid SQL procedure statement
 ```
 
+![Railroad diagram of CREATE FUNCTION — equivalent to the BNF above](../../../../.gitbook/assets/create-function-railroad.svg)
+
+![Railroad diagram of func_parameter](../../../../.gitbook/assets/create-function-parameter-railroad.svg)
+
+![Railroad diagram of characteristic](../../../../.gitbook/assets/create-function-characteristic-railroad.svg)
+
 ## Description
 
 Use the `CREATE FUNCTION` statement to create a new [stored function](../../../../server-usage/stored-routines/stored-functions/). You must have the [CREATE ROUTINE](../../account-management-sql-statements/grant.md#database-privileges) database privilege to use `CREATE FUNCTION`. A function takes any number of arguments and returns a value from the function body. The function body can be any valid SQL expression as you would use, for example, in any select expression. If you have the appropriate privileges, you can call the function exactly as you would any built-in function. See [Security](create-function.md#security) below for details on privileges.

--- a/server/reference/sql-statements/data-definition/create/create-index.md
+++ b/server/reference/sql-statements/data-definition/create/create-index.md
@@ -9,8 +9,8 @@ description: >-
 ## Syntax
 
 ```bnf
-CREATE [OR REPLACE] [UNIQUE|FULLTEXT|SPATIAL|VECTOR] INDEX 
-  [IF NOT EXISTS] index_name
+CREATE [OR REPLACE] [UNIQUE|FULLTEXT|SPATIAL|VECTOR] INDEX
+    [IF NOT EXISTS] index_name
     [index_type]
     ON tbl_name (index_col_name,...)
     [WAIT n | NOWAIT]
@@ -24,14 +24,14 @@ index_type:
     USING {BTREE | HASH | RTREE}
 
 index_option:
-    [ KEY_BLOCK_SIZE [=] value
+    KEY_BLOCK_SIZE [=] value
   | index_type
   | WITH PARSER parser_name
   | COMMENT 'string'
-  | CLUSTERING={YES| NO} ]
-  [ IGNORED | NOT IGNORED ]
-  | DISTANCE={EUCLIDEAN| COSINE} ]
-  | M=number ]
+  | CLUSTERING = {YES | NO}
+  | IGNORED | NOT IGNORED
+  | DISTANCE = {EUCLIDEAN | COSINE}
+  | M = number
 
 algorithm_option:
     ALGORITHM [=] {DEFAULT|INPLACE|COPY|NOCOPY|INSTANT}
@@ -39,6 +39,18 @@ algorithm_option:
 lock_option:
     LOCK [=] {DEFAULT|NONE|SHARED|EXCLUSIVE}
 ```
+
+![Railroad diagram of CREATE INDEX — equivalent to the BNF above](../../../../.gitbook/assets/create-index-railroad.svg)
+
+![Railroad diagram of index_col_name](../../../../.gitbook/assets/create-index-col-name-railroad.svg)
+
+![Railroad diagram of index_type](../../../../.gitbook/assets/create-index-type-railroad.svg)
+
+![Railroad diagram of index_option](../../../../.gitbook/assets/create-index-option-railroad.svg)
+
+![Railroad diagram of algorithm_option](../../../../.gitbook/assets/create-index-algorithm-option-railroad.svg)
+
+![Railroad diagram of lock_option](../../../../.gitbook/assets/create-index-lock-option-railroad.svg)
 
 ## Description
 

--- a/server/server-usage/stored-routines/stored-procedures/create-procedure.md
+++ b/server/server-usage/stored-routines/stored-procedures/create-procedure.md
@@ -35,6 +35,12 @@ routine_body:
     Valid SQL procedure statement
 ```
 
+![Railroad diagram of CREATE PROCEDURE — equivalent to the BNF above](../../../.gitbook/assets/create-procedure-railroad.svg)
+
+![Railroad diagram of proc_parameter](../../../.gitbook/assets/create-procedure-parameter-railroad.svg)
+
+![Railroad diagram of characteristic](../../../.gitbook/assets/create-procedure-characteristic-railroad.svg)
+
 The `IN OUT` parameter works only in [Oracle mode](create-procedure.md#oracle-mode).
 {% endtab %}
 


### PR DESCRIPTION
## Summary

Batch 4 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Five more pages, in the upper-Tier-B / Tier-C range — larger BNFs than earlier batches, but still amenable to complete diagrams.

Continues from #545 (ALTER TABLE prototype), #552 (batch 1), #561 (batch 2), #562 (batch 3).

## Pages

| Page | Rank | Views | Diagrams added |
|---|---:|---:|---|
| [CREATE PROCEDURE](https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures/create-procedure) | 8 | 727 | top-level + `proc_parameter` + `characteristic` |
| [CHANGE MASTER TO](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/replication-statements/change-master-to) | 9 | 575 | top-level + `master_def` *(tall — see below)* |
| [CREATE INDEX](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-index) | 23 | 388 | top-level + `index_col_name` + `index_type` + `index_option` + `algorithm_option` + `lock_option` |
| [CONSTRAINT](https://mariadb.com/docs/server/reference/sql-statements/data-definition/constraint) | 27 | 361 | top-level + `constraint_expression` + `index_type` + `index_col_name` + `index_option` + `reference_option` |
| [CREATE FUNCTION](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-function) | 43 | 294 | top-level + `func_parameter` + `characteristic` |

20 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## CHANGE MASTER TO — the `master_def` sub-diagram is tall

The `master_def` production lists **27 alternatives** (one per `MASTER_*` keyword). Bottlecaps renders that as a tall vertical column right under the top-level diagram. The result is technically complete but visually imposing. Two reasonable follow-up options if it doesn't sit well:

1. **Keep as-is** — the diagram is accurate and readers can scroll past it; the BNF block above it gives the same information in a more compact textual form.
2. **Drop the `master_def` sub-diagram** — leave just the top-level diagram, and let the BNF block carry the option list. Readers learn what `master_def` is from the BNF.

I lean (1) for now since the diagram is what reviewers asked for ("complete diagrams"), but happy to drop the `master_def` SVG in a follow-up if you'd prefer.

## Source-BNF cleanup folded in (CREATE INDEX)

The CREATE INDEX page's `index_option` production was unparseable as written:

```
index_option:
    [ KEY_BLOCK_SIZE [=] value
  | index_type
  | WITH PARSER parser_name
  | COMMENT 'string'
  | CLUSTERING={YES| NO} ]
  [ IGNORED | NOT IGNORED ]
  | DISTANCE={EUCLIDEAN| COSINE} ]
  | M=number ]
```

The brackets are clearly broken — `[ IGNORED | NOT IGNORED ]` is outside the choice block, and the trailing alternatives carry stray `]`. The intent (cross-referenced against the same production in CREATE TABLE column-spec) is a flat list of mutually-exclusive alternatives. Diagrammed accordingly and the source BNF is corrected on the page to match.

## Not a fix — `IN OUT` in CREATE PROCEDURE / CREATE FUNCTION

Both pages' `proc_parameter` / `func_parameter` BNF lists three parameter modes: `OUT`, `INOUT`, and `IN OUT` (two tokens). On first read I treated `IN OUT` as a typo for `INOUT`, but line 38 of the CREATE PROCEDURE page explicitly says **"The `IN OUT` parameter works only in [Oracle mode]"** — it's deliberate, the Oracle-mode variant of the standard `INOUT`. All three modes are diagrammed; no BNF change on those pages.

## Tally and remaining work

After this PR lands, **21 pages** are diagrammed under DOCS-5614:

- 1 prototype: ALTER TABLE (#545)
- 5 in batch 1: CREATE DATABASE, INSERT, UPDATE, DELETE, CREATE VIEW (#552)
- 5 in batch 2: SET PASSWORD, LOAD DATA INFILE, CREATE TRIGGER, SELECT INTO OUTFILE, INSERT … ON DUPLICATE KEY UPDATE *(cross-ref only)* (#561)
- 6 in batch 3: OPTIMIZE TABLE, INSERT … ON DUPLICATE KEY UPDATE *(now real diagram)*, FLUSH, Generated Columns, PURGE BINARY LOGS, CASE statement (#562)
- 5 in this batch: CREATE PROCEDURE, CHANGE MASTER TO, CREATE INDEX, CONSTRAINT, CREATE FUNCTION

Roughly **29 to go** to reach the ~50-page target. The remaining big ones to decide on are SELECT (rank 4, 38 lines), CREATE USER (rank 3, 43 lines), ALTER USER (rank 20, 43 lines), GRANT (rank 2, 84 lines), and CREATE TABLE (rank 31, 106 lines across 5 blocks). For each, we'll need to decide top-level-only vs full diagram (as we did for ALTER TABLE).

## Test plan

- [ ] GitBook preview renders each diagram inline under its `bnf` block.
- [ ] CREATE INDEX's corrected `index_option` BNF reads cleanly and matches the diagram.
- [ ] The `IN OUT` alternative is visible in both `proc_parameter` and `func_parameter` diagrams.
- [ ] All 20 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.
- [ ] Reviewer call: is the tall `master_def` sub-diagram OK, or should we drop it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ