### PR TITLE
DOCS-5614 add Railroad diagrams to 4 large account/query pages

### DIFF
--- a/server/.gitbook/assets/alter-user-authentication-option-railroad.svg
+++ b/server/.gitbook/assets/alter-user-authentication-option-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="102" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">IDENTIFIED</text>
+   <rect x="173" y="3" width="38" height="32" rx="10"/>
+   <rect x="171"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="181" y="21">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="251" y="3" width="80" height="32"/>
+      <rect x="249" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="259" y="21">password</text>
+   </a>
+   <rect x="251" y="47" width="100" height="32" rx="10"/>
+   <rect x="249"
+         y="45"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="259" y="65">PASSWORD</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password_hash"
+      xlink:title="password_hash">
+      <rect x="371" y="47" width="120" height="32"/>
+      <rect x="369" y="45" width="120" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="379" y="65">password_hash</text>
+   </a>
+   <rect x="193" y="135" width="44" height="32" rx="10"/>
+   <rect x="191"
+         y="133"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="153">VIA</text>
+   <rect x="193" y="179" width="58" height="32" rx="10"/>
+   <rect x="191"
+         y="177"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="197">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_rule"
+      xlink:title="authentication_rule">
+      <rect x="311" y="135" width="144" height="32"/>
+      <rect x="309" y="133" width="144" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="319" y="153">authentication_rule</text>
+   </a>
+   <rect x="311" y="91" width="40" height="32" rx="10"/>
+   <rect x="309"
+         y="89"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="319" y="109">OR</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m102 0 h10 m20 0 h10 m38 0 h10 m20 0 h10 m80 0 h10 m0 0 h160 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m100 0 h10 m0 0 h10 m120 0 h10 m-358 -44 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v112 m378 0 v-112 m-378 112 q0 10 10 10 m358 0 q10 0 10 -10 m-348 10 h10 m44 0 h10 m0 0 h14 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m40 -44 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m40 0 h10 m0 0 h104 m20 44 h36 m23 -132 h-3"/>
+   <polygon points="549 17 557 13 557 21"/>
+   <polygon points="549 17 541 13 541 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-authentication-rule-railroad.svg
+++ b/server/.gitbook/assets/alter-user-authentication-rule-railroad.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="733" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_plugin"
+      xlink:title="authentication_plugin">
+      <rect x="31" y="3" width="158" height="32"/>
+      <rect x="29" y="1" width="158" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">authentication_plugin</text>
+   </a>
+   <rect x="249" y="35" width="64" height="32" rx="10"/>
+   <rect x="247"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="53">USING</text>
+   <rect x="249" y="79" width="38" height="32" rx="10"/>
+   <rect x="247"
+         y="77"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="97">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_string"
+      xlink:title="authentication_string">
+      <rect x="373" y="35" width="156" height="32"/>
+      <rect x="371" y="33" width="156" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="381" y="53">authentication_string</text>
+   </a>
+   <rect x="373" y="79" width="100" height="32" rx="10"/>
+   <rect x="371"
+         y="77"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="381" y="97">PASSWORD</text>
+   <rect x="493" y="79" width="26" height="32" rx="10"/>
+   <rect x="491"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="501" y="97">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="539" y="79" width="80" height="32"/>
+      <rect x="537" y="77" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="547" y="97">password</text>
+   </a>
+   <rect x="639" y="79" width="26" height="32" rx="10"/>
+   <rect x="637"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="97">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m158 0 h10 m20 0 h10 m0 0 h466 m-496 0 h20 m476 0 h20 m-516 0 q10 0 10 10 m496 0 q0 -10 10 -10 m-506 10 v12 m496 0 v-12 m-496 12 q0 10 10 10 m476 0 q10 0 10 -10 m-466 10 h10 m64 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m38 0 h10 m0 0 h26 m40 -44 h10 m156 0 h10 m0 0 h136 m-332 0 h20 m312 0 h20 m-352 0 q10 0 10 10 m332 0 q0 -10 10 -10 m-342 10 v24 m332 0 v-24 m-332 24 q0 10 10 10 m312 0 q10 0 10 -10 m-322 10 h10 m100 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"/>
+   <polygon points="723 17 731 13 731 21"/>
+   <polygon points="723 17 715 13 715 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-lock-option-railroad.svg
+++ b/server/.gitbook/assets/alter-user-lock-option-railroad.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="281" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="86" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ACCOUNT</text>
+   <rect x="157" y="3" width="56" height="32" rx="10"/>
+   <rect x="155"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="165" y="21">LOCK</text>
+   <rect x="157" y="47" width="76" height="32" rx="10"/>
+   <rect x="155"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="165" y="65">UNLOCK</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -44 h-3"/>
+   <polygon points="271 17 279 13 279 21"/>
+   <polygon points="271 17 263 13 263 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-password-option-railroad.svg
+++ b/server/.gitbook/assets/alter-user-password-option-railroad.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="100" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">PASSWORD</text>
+   <rect x="151" y="3" width="70" height="32" rx="10"/>
+   <rect x="149"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="21">EXPIRE</text>
+   <rect x="261" y="35" width="80" height="32" rx="10"/>
+   <rect x="259"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="53">DEFAULT</text>
+   <rect x="261" y="79" width="64" height="32" rx="10"/>
+   <rect x="259"
+         y="77"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="97">NEVER</text>
+   <rect x="261" y="123" width="88" height="32" rx="10"/>
+   <rect x="259"
+         y="121"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="141">INTERVAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#N"
+      xlink:title="N">
+      <rect x="369" y="123" width="28" height="32"/>
+      <rect x="367" y="121" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="377" y="141">N</text>
+   </a>
+   <rect x="417" y="123" width="48" height="32" rx="10"/>
+   <rect x="415"
+         y="121"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="141">DAY</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h214 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v12 m244 0 v-12 m-244 12 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m80 0 h10 m0 0 h124 m-234 -10 v20 m244 0 v-20 m-244 20 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m64 0 h10 m0 0 h140 m-234 -10 v20 m244 0 v-20 m-244 20 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m88 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m48 0 h10 m23 -120 h-3"/>
+   <polygon points="503 17 511 13 511 21"/>
+   <polygon points="503 17 495 13 495 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-railroad.svg
+++ b/server/.gitbook/assets/alter-user-railroad.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="895" height="321">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="62" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">ALTER</text>
+   <rect x="113" y="47" width="56" height="32" rx="10"/>
+   <rect x="111"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="121" y="65">USER</text>
+   <rect x="209" y="79" width="34" height="32" rx="10"/>
+   <rect x="207"
+         y="77"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="97">IF</text>
+   <rect x="263" y="79" width="70" height="32" rx="10"/>
+   <rect x="261"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="271" y="97">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user_specification"
+      xlink:title="user_specification">
+      <rect x="393" y="47" width="134" height="32"/>
+      <rect x="391" y="45" width="134" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="401" y="65">user_specification</text>
+   </a>
+   <rect x="393" y="3" width="24" height="32" rx="10"/>
+   <rect x="391"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="401" y="21">,</text>
+   <rect x="587" y="47" width="82" height="32" rx="10"/>
+   <rect x="585"
+         y="45"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="595" y="65">REQUIRE</text>
+   <rect x="709" y="47" width="58" height="32" rx="10"/>
+   <rect x="707"
+         y="45"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="717" y="65">NONE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tls_option"
+      xlink:title="tls_option">
+      <rect x="729" y="157" width="84" height="32"/>
+      <rect x="727" y="155" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="737" y="175">tls_option</text>
+   </a>
+   <rect x="729" y="91" width="48" height="32" rx="10"/>
+   <rect x="727"
+         y="89"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="737" y="109">AND</text>
+   <rect x="265" y="255" width="58" height="32" rx="10"/>
+   <rect x="263"
+         y="253"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="273">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#resource_option"
+      xlink:title="resource_option">
+      <rect x="363" y="255" width="124" height="32"/>
+      <rect x="361" y="253" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="371" y="273">resource_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#lock_option"
+      xlink:title="lock_option">
+      <rect x="567" y="287" width="92" height="32"/>
+      <rect x="565" y="285" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="575" y="305">lock_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password_option"
+      xlink:title="password_option">
+      <rect x="719" y="287" width="128" height="32"/>
+      <rect x="717" y="285" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="727" y="305">password_option</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m134 0 h10 m-174 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m154 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m40 44 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h66 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v90 m164 0 v-90 m-164 90 q0 10 10 10 m144 0 q10 0 10 -10 m-134 10 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m104 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-104 0 h10 m0 0 h94 m-114 10 l0 -34 q0 -10 10 -10 m114 44 l0 -34 q0 -10 -10 -10 m-104 0 h10 m48 0 h10 m0 0 h36 m-266 -44 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v124 m306 0 v-124 m-306 124 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m22 -144 l2 0 m2 0 l2 0 m2 0 l2 0 m-672 208 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m144 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-144 0 h10 m0 0 h134 m-262 32 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m40 -34 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m40 -32 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m128 0 h10 m23 -32 h-3"/>
+   <polygon points="885 269 893 265 893 273"/>
+   <polygon points="885 269 877 265 877 273"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-resource-option-railroad.svg
+++ b/server/.gitbook/assets/alter-user-resource-option-railroad.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="459" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="3" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="1"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="21">MAX_QUERIES_PER_HOUR</text>
+   <rect x="71" y="47" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">MAX_UPDATES_PER_HOUR</text>
+   <rect x="71" y="91" width="246" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="246"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">MAX_CONNECTIONS_PER_HOUR</text>
+   <rect x="71" y="135" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="133"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="153">MAX_USER_CONNECTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#count"
+      xlink:title="count">
+      <rect x="357" y="3" width="54" height="32"/>
+      <rect x="355" y="1" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="365" y="21">count</text>
+   </a>
+   <rect x="51" y="179" width="182" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="182"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">MAX_STATEMENT_TIME</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#time"
+      xlink:title="time">
+      <rect x="253" y="179" width="48" height="32"/>
+      <rect x="251" y="177" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="261" y="197">time</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m206 0 h10 m0 0 h40 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m206 0 h10 m0 0 h40 m-276 -10 v20 m286 0 v-20 m-286 20 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m246 0 h10 m-276 -10 v20 m286 0 v-20 m-286 20 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m206 0 h10 m0 0 h40 m20 -132 h10 m54 0 h10 m-400 0 h20 m380 0 h20 m-420 0 q10 0 10 10 m400 0 q0 -10 10 -10 m-410 10 v156 m400 0 v-156 m-400 156 q0 10 10 10 m380 0 q10 0 10 -10 m-390 10 h10 m182 0 h10 m0 0 h10 m48 0 h10 m0 0 h110 m23 -176 h-3"/>
+   <polygon points="449 17 457 13 457 21"/>
+   <polygon points="449 17 441 13 441 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-specification-railroad.svg
+++ b/server/.gitbook/assets/alter-user-specification-railroad.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="363" height="69">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#username"
+      xlink:title="username">
+      <rect x="31" y="3" width="84" height="32"/>
+      <rect x="29" y="1" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">username</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_option"
+      xlink:title="authentication_option">
+      <rect x="155" y="35" width="160" height="32"/>
+      <rect x="153" y="33" width="160" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="163" y="53">authentication_option</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m23 -32 h-3"/>
+   <polygon points="353 17 361 13 361 21"/>
+   <polygon points="353 17 345 13 345 21"/>
+</svg>

--- a/server/.gitbook/assets/alter-user-tls-option-railroad.svg
+++ b/server/.gitbook/assets/alter-user-tls-option-railroad.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="265" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="46" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">SSL</text>
+   <rect x="51" y="47" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">X509</text>
+   <rect x="51" y="91" width="72" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">CIPHER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#cipher"
+      xlink:title="cipher">
+      <rect x="143" y="91" width="58" height="32"/>
+      <rect x="141" y="89" width="58" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="151" y="109">cipher</text>
+   </a>
+   <rect x="51" y="135" width="72" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">ISSUER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#issuer"
+      xlink:title="issuer">
+      <rect x="143" y="135" width="58" height="32"/>
+      <rect x="141" y="133" width="58" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="151" y="153">issuer</text>
+   </a>
+   <rect x="51" y="179" width="80" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">SUBJECT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#subject"
+      xlink:title="subject">
+      <rect x="151" y="179" width="66" height="32"/>
+      <rect x="149" y="177" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="159" y="197">subject</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h120 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h16 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h16 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m80 0 h10 m0 0 h10 m66 0 h10 m23 -176 h-3"/>
+   <polygon points="255 17 263 13 263 21"/>
+   <polygon points="255 17 247 13 247 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-authentication-option-railroad.svg
+++ b/server/.gitbook/assets/create-user-authentication-option-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="102" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">IDENTIFIED</text>
+   <rect x="173" y="3" width="38" height="32" rx="10"/>
+   <rect x="171"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="181" y="21">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="251" y="3" width="80" height="32"/>
+      <rect x="249" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="259" y="21">password</text>
+   </a>
+   <rect x="251" y="47" width="100" height="32" rx="10"/>
+   <rect x="249"
+         y="45"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="259" y="65">PASSWORD</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password_hash"
+      xlink:title="password_hash">
+      <rect x="371" y="47" width="120" height="32"/>
+      <rect x="369" y="45" width="120" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="379" y="65">password_hash</text>
+   </a>
+   <rect x="193" y="135" width="44" height="32" rx="10"/>
+   <rect x="191"
+         y="133"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="153">VIA</text>
+   <rect x="193" y="179" width="58" height="32" rx="10"/>
+   <rect x="191"
+         y="177"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="197">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_rule"
+      xlink:title="authentication_rule">
+      <rect x="311" y="135" width="144" height="32"/>
+      <rect x="309" y="133" width="144" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="319" y="153">authentication_rule</text>
+   </a>
+   <rect x="311" y="91" width="40" height="32" rx="10"/>
+   <rect x="309"
+         y="89"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="319" y="109">OR</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m102 0 h10 m20 0 h10 m38 0 h10 m20 0 h10 m80 0 h10 m0 0 h160 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m100 0 h10 m0 0 h10 m120 0 h10 m-358 -44 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v112 m378 0 v-112 m-378 112 q0 10 10 10 m358 0 q10 0 10 -10 m-348 10 h10 m44 0 h10 m0 0 h14 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m40 -44 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m40 0 h10 m0 0 h104 m20 44 h36 m23 -132 h-3"/>
+   <polygon points="549 17 557 13 557 21"/>
+   <polygon points="549 17 541 13 541 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-authentication-rule-railroad.svg
+++ b/server/.gitbook/assets/create-user-authentication-rule-railroad.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="733" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_plugin"
+      xlink:title="authentication_plugin">
+      <rect x="31" y="3" width="158" height="32"/>
+      <rect x="29" y="1" width="158" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">authentication_plugin</text>
+   </a>
+   <rect x="249" y="35" width="64" height="32" rx="10"/>
+   <rect x="247"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="53">USING</text>
+   <rect x="249" y="79" width="38" height="32" rx="10"/>
+   <rect x="247"
+         y="77"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="97">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_string"
+      xlink:title="authentication_string">
+      <rect x="373" y="35" width="156" height="32"/>
+      <rect x="371" y="33" width="156" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="381" y="53">authentication_string</text>
+   </a>
+   <rect x="373" y="79" width="100" height="32" rx="10"/>
+   <rect x="371"
+         y="77"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="381" y="97">PASSWORD</text>
+   <rect x="493" y="79" width="26" height="32" rx="10"/>
+   <rect x="491"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="501" y="97">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password"
+      xlink:title="password">
+      <rect x="539" y="79" width="80" height="32"/>
+      <rect x="537" y="77" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="547" y="97">password</text>
+   </a>
+   <rect x="639" y="79" width="26" height="32" rx="10"/>
+   <rect x="637"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="97">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m158 0 h10 m20 0 h10 m0 0 h466 m-496 0 h20 m476 0 h20 m-516 0 q10 0 10 10 m496 0 q0 -10 10 -10 m-506 10 v12 m496 0 v-12 m-496 12 q0 10 10 10 m476 0 q10 0 10 -10 m-466 10 h10 m64 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m38 0 h10 m0 0 h26 m40 -44 h10 m156 0 h10 m0 0 h136 m-332 0 h20 m312 0 h20 m-352 0 q10 0 10 10 m332 0 q0 -10 10 -10 m-342 10 v24 m332 0 v-24 m-332 24 q0 10 10 10 m312 0 q10 0 10 -10 m-322 10 h10 m100 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"/>
+   <polygon points="723 17 731 13 731 21"/>
+   <polygon points="723 17 715 13 715 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-lock-option-railroad.svg
+++ b/server/.gitbook/assets/create-user-lock-option-railroad.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="281" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="86" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ACCOUNT</text>
+   <rect x="157" y="3" width="56" height="32" rx="10"/>
+   <rect x="155"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="165" y="21">LOCK</text>
+   <rect x="157" y="47" width="76" height="32" rx="10"/>
+   <rect x="155"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="165" y="65">UNLOCK</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -44 h-3"/>
+   <polygon points="271 17 279 13 279 21"/>
+   <polygon points="271 17 263 13 263 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-password-option-railroad.svg
+++ b/server/.gitbook/assets/create-user-password-option-railroad.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="100" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">PASSWORD</text>
+   <rect x="151" y="3" width="70" height="32" rx="10"/>
+   <rect x="149"
+         y="1"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="21">EXPIRE</text>
+   <rect x="261" y="35" width="80" height="32" rx="10"/>
+   <rect x="259"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="53">DEFAULT</text>
+   <rect x="261" y="79" width="64" height="32" rx="10"/>
+   <rect x="259"
+         y="77"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="97">NEVER</text>
+   <rect x="261" y="123" width="88" height="32" rx="10"/>
+   <rect x="259"
+         y="121"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="141">INTERVAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#N"
+      xlink:title="N">
+      <rect x="369" y="123" width="28" height="32"/>
+      <rect x="367" y="121" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="377" y="141">N</text>
+   </a>
+   <rect x="417" y="123" width="48" height="32" rx="10"/>
+   <rect x="415"
+         y="121"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="141">DAY</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h214 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v12 m244 0 v-12 m-244 12 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m80 0 h10 m0 0 h124 m-234 -10 v20 m244 0 v-20 m-244 20 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m64 0 h10 m0 0 h140 m-234 -10 v20 m244 0 v-20 m-244 20 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m88 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m48 0 h10 m23 -120 h-3"/>
+   <polygon points="503 17 511 13 511 21"/>
+   <polygon points="503 17 495 13 495 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-railroad.svg
+++ b/server/.gitbook/assets/create-user-railroad.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="847" height="407">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">CREATE</text>
+   <rect x="143" y="79" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="77"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="97">OR</text>
+   <rect x="203" y="79" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="77"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="97">REPLACE</text>
+   <rect x="323" y="47" width="56" height="32" rx="10"/>
+   <rect x="321"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="331" y="65">USER</text>
+   <rect x="419" y="79" width="34" height="32" rx="10"/>
+   <rect x="417"
+         y="77"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="427" y="97">IF</text>
+   <rect x="473" y="79" width="48" height="32" rx="10"/>
+   <rect x="471"
+         y="77"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="481" y="97">NOT</text>
+   <rect x="541" y="79" width="70" height="32" rx="10"/>
+   <rect x="539"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="549" y="97">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user_specification"
+      xlink:title="user_specification">
+      <rect x="671" y="47" width="134" height="32"/>
+      <rect x="669" y="45" width="134" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="679" y="65">user_specification</text>
+   </a>
+   <rect x="671" y="3" width="24" height="32" rx="10"/>
+   <rect x="669"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="679" y="21">,</text>
+   <rect x="65" y="161" width="82" height="32" rx="10"/>
+   <rect x="63"
+         y="159"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="179">REQUIRE</text>
+   <rect x="187" y="161" width="58" height="32" rx="10"/>
+   <rect x="185"
+         y="159"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="195" y="179">NONE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tls_option"
+      xlink:title="tls_option">
+      <rect x="207" y="271" width="84" height="32"/>
+      <rect x="205" y="269" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="215" y="289">tls_option</text>
+   </a>
+   <rect x="207" y="205" width="48" height="32" rx="10"/>
+   <rect x="205"
+         y="203"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="215" y="223">AND</text>
+   <rect x="391" y="161" width="58" height="32" rx="10"/>
+   <rect x="389"
+         y="159"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="399" y="179">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#resource_option"
+      xlink:title="resource_option">
+      <rect x="489" y="161" width="124" height="32"/>
+      <rect x="487" y="159" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="497" y="179">resource_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#lock_option"
+      xlink:title="lock_option">
+      <rect x="693" y="193" width="92" height="32"/>
+      <rect x="691" y="191" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="701" y="211">lock_option</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#password_option"
+      xlink:title="password_option">
+      <rect x="671" y="373" width="128" height="32"/>
+      <rect x="669" y="371" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="679" y="391">password_option</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m134 0 h10 m-174 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m154 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-824 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h66 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v90 m164 0 v-90 m-164 90 q0 10 10 10 m144 0 q10 0 10 -10 m-134 10 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m104 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-104 0 h10 m0 0 h94 m-114 10 l0 -34 q0 -10 10 -10 m114 44 l0 -34 q0 -10 -10 -10 m-104 0 h10 m48 0 h10 m0 0 h36 m-266 -44 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v124 m306 0 v-124 m-306 124 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m40 -144 h10 m58 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m144 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-144 0 h10 m0 0 h134 m-262 32 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m40 -34 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-198 180 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m128 0 h10 m23 -32 h-3"/>
+   <polygon points="837 355 845 351 845 359"/>
+   <polygon points="837 355 829 351 829 359"/>
+</svg>

--- a/server/.gitbook/assets/create-user-resource-option-railroad.svg
+++ b/server/.gitbook/assets/create-user-resource-option-railroad.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="459" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="3" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="1"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="21">MAX_QUERIES_PER_HOUR</text>
+   <rect x="71" y="47" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">MAX_UPDATES_PER_HOUR</text>
+   <rect x="71" y="91" width="246" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="246"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">MAX_CONNECTIONS_PER_HOUR</text>
+   <rect x="71" y="135" width="206" height="32" rx="10"/>
+   <rect x="69"
+         y="133"
+         width="206"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="153">MAX_USER_CONNECTIONS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#count"
+      xlink:title="count">
+      <rect x="357" y="3" width="54" height="32"/>
+      <rect x="355" y="1" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="365" y="21">count</text>
+   </a>
+   <rect x="51" y="179" width="182" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="182"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">MAX_STATEMENT_TIME</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#time"
+      xlink:title="time">
+      <rect x="253" y="179" width="48" height="32"/>
+      <rect x="251" y="177" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="261" y="197">time</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m206 0 h10 m0 0 h40 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m206 0 h10 m0 0 h40 m-276 -10 v20 m286 0 v-20 m-286 20 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m246 0 h10 m-276 -10 v20 m286 0 v-20 m-286 20 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m206 0 h10 m0 0 h40 m20 -132 h10 m54 0 h10 m-400 0 h20 m380 0 h20 m-420 0 q10 0 10 10 m400 0 q0 -10 10 -10 m-410 10 v156 m400 0 v-156 m-400 156 q0 10 10 10 m380 0 q10 0 10 -10 m-390 10 h10 m182 0 h10 m0 0 h10 m48 0 h10 m0 0 h110 m23 -176 h-3"/>
+   <polygon points="449 17 457 13 457 21"/>
+   <polygon points="449 17 441 13 441 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-specification-railroad.svg
+++ b/server/.gitbook/assets/create-user-specification-railroad.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="363" height="69">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#username"
+      xlink:title="username">
+      <rect x="31" y="3" width="84" height="32"/>
+      <rect x="29" y="1" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">username</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#authentication_option"
+      xlink:title="authentication_option">
+      <rect x="155" y="35" width="160" height="32"/>
+      <rect x="153" y="33" width="160" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="163" y="53">authentication_option</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m23 -32 h-3"/>
+   <polygon points="353 17 361 13 361 21"/>
+   <polygon points="353 17 345 13 345 21"/>
+</svg>

--- a/server/.gitbook/assets/create-user-tls-option-railroad.svg
+++ b/server/.gitbook/assets/create-user-tls-option-railroad.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="265" height="213">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="46" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">SSL</text>
+   <rect x="51" y="47" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">X509</text>
+   <rect x="51" y="91" width="72" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">CIPHER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#cipher"
+      xlink:title="cipher">
+      <rect x="143" y="91" width="58" height="32"/>
+      <rect x="141" y="89" width="58" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="151" y="109">cipher</text>
+   </a>
+   <rect x="51" y="135" width="72" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">ISSUER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#issuer"
+      xlink:title="issuer">
+      <rect x="143" y="135" width="58" height="32"/>
+      <rect x="141" y="133" width="58" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="151" y="153">issuer</text>
+   </a>
+   <rect x="51" y="179" width="80" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">SUBJECT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#subject"
+      xlink:title="subject">
+      <rect x="151" y="179" width="66" height="32"/>
+      <rect x="149" y="177" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="159" y="197">subject</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h120 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h16 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h16 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m80 0 h10 m0 0 h10 m66 0 h10 m23 -176 h-3"/>
+   <polygon points="255 17 263 13 263 21"/>
+   <polygon points="255 17 247 13 247 21"/>
+</svg>

--- a/server/.gitbook/assets/grant-privileges-railroad.svg
+++ b/server/.gitbook/assets/grant-privileges-railroad.svg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="875" height="349">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">GRANT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_type"
+      xlink:title="priv_type">
+      <rect x="137" y="47" width="80" height="32"/>
+      <rect x="135" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="145" y="65">priv_type</text>
+   </a>
+   <rect x="257" y="79" width="26" height="32" rx="10"/>
+   <rect x="255"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="97">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_list"
+      xlink:title="column_list">
+      <rect x="303" y="79" width="92" height="32"/>
+      <rect x="301" y="77" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="311" y="97">column_list</text>
+   </a>
+   <rect x="415" y="79" width="26" height="32" rx="10"/>
+   <rect x="413"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="97">)</text>
+   <rect x="137" y="3" width="24" height="32" rx="10"/>
+   <rect x="135"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="21">,</text>
+   <rect x="501" y="47" width="40" height="32" rx="10"/>
+   <rect x="499"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="509" y="65">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#object_type"
+      xlink:title="object_type">
+      <rect x="581" y="79" width="94" height="32"/>
+      <rect x="579" y="77" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="589" y="97">object_type</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_level"
+      xlink:title="priv_level">
+      <rect x="715" y="47" width="80" height="32"/>
+      <rect x="713" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="723" y="65">priv_level</text>
+   </a>
+   <rect x="815" y="47" width="38" height="32" rx="10"/>
+   <rect x="813"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="823" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#account_or_role"
+      xlink:title="account_or_role">
+      <rect x="113" y="189" width="122" height="32"/>
+      <rect x="111" y="187" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="121" y="207">account_or_role</text>
+   </a>
+   <rect x="113" y="145" width="24" height="32" rx="10"/>
+   <rect x="111"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="121" y="163">,</text>
+   <rect x="295" y="189" width="82" height="32" rx="10"/>
+   <rect x="293"
+         y="187"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="207">REQUIRE</text>
+   <rect x="417" y="189" width="58" height="32" rx="10"/>
+   <rect x="415"
+         y="187"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="207">NONE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tls_option"
+      xlink:title="tls_option">
+      <rect x="437" y="299" width="84" height="32"/>
+      <rect x="435" y="297" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="445" y="317">tls_option</text>
+   </a>
+   <rect x="437" y="233" width="48" height="32" rx="10"/>
+   <rect x="435"
+         y="231"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="445" y="251">AND</text>
+   <rect x="621" y="221" width="58" height="32" rx="10"/>
+   <rect x="619"
+         y="219"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="629" y="239">WITH</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#grant_option_list"
+      xlink:title="grant_option_list">
+      <rect x="699" y="221" width="128" height="32"/>
+      <rect x="697" y="219" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="707" y="239">grant_option_list</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m66 0 h10 m20 0 h10 m80 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m-344 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m344 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-344 0 h10 m24 0 h10 m0 0 h300 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-804 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m40 44 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h66 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v90 m164 0 v-90 m-164 90 q0 10 10 10 m144 0 q10 0 10 -10 m-134 10 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m104 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-104 0 h10 m0 0 h94 m-114 10 l0 -34 q0 -10 10 -10 m114 44 l0 -34 q0 -10 -10 -10 m-104 0 h10 m48 0 h10 m0 0 h36 m-266 -44 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v124 m306 0 v-124 m-306 124 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m40 -144 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m58 0 h10 m0 0 h10 m128 0 h10 m23 -32 h-3"/>
+   <polygon points="865 203 873 199 873 207"/>
+   <polygon points="865 203 857 199 857 207"/>
+</svg>

--- a/server/.gitbook/assets/grant-proxy-railroad.svg
+++ b/server/.gitbook/assets/grant-proxy-railroad.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="933" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">GRANT</text>
+   <rect x="117" y="47" width="66" height="32" rx="10"/>
+   <rect x="115"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="65">PROXY</text>
+   <rect x="203" y="47" width="40" height="32" rx="10"/>
+   <rect x="201"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="65">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user_or_role"
+      xlink:title="user_or_role">
+      <rect x="263" y="47" width="102" height="32"/>
+      <rect x="261" y="45" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="271" y="65">user_or_role</text>
+   </a>
+   <rect x="385" y="47" width="38" height="32" rx="10"/>
+   <rect x="383"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="393" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#account_or_role"
+      xlink:title="account_or_role">
+      <rect x="463" y="47" width="122" height="32"/>
+      <rect x="461" y="45" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="471" y="65">account_or_role</text>
+   </a>
+   <rect x="463" y="3" width="24" height="32" rx="10"/>
+   <rect x="461"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="471" y="21">,</text>
+   <rect x="645" y="79" width="58" height="32" rx="10"/>
+   <rect x="643"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="97">WITH</text>
+   <rect x="723" y="79" width="66" height="32" rx="10"/>
+   <rect x="721"
+         y="77"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="731" y="97">GRANT</text>
+   <rect x="809" y="79" width="76" height="32" rx="10"/>
+   <rect x="807"
+         y="77"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="817" y="97">OPTION</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m66 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m40 44 h10 m0 0 h250 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v12 m280 0 v-12 m-280 12 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m76 0 h10 m23 -32 h-3"/>
+   <polygon points="923 61 931 57 931 65"/>
+   <polygon points="923 61 915 57 915 65"/>
+</svg>

--- a/server/.gitbook/assets/grant-roles-railroad.svg
+++ b/server/.gitbook/assets/grant-roles-railroad.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="769" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">GRANT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="137" y="47" width="44" height="32"/>
+      <rect x="135" y="45" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="145" y="65">role</text>
+   </a>
+   <rect x="137" y="3" width="24" height="32" rx="10"/>
+   <rect x="135"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="21">,</text>
+   <rect x="221" y="47" width="38" height="32" rx="10"/>
+   <rect x="219"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#account_or_role"
+      xlink:title="account_or_role">
+      <rect x="299" y="47" width="122" height="32"/>
+      <rect x="297" y="45" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="307" y="65">account_or_role</text>
+   </a>
+   <rect x="299" y="3" width="24" height="32" rx="10"/>
+   <rect x="297"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="21">,</text>
+   <rect x="481" y="79" width="58" height="32" rx="10"/>
+   <rect x="479"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="97">WITH</text>
+   <rect x="559" y="79" width="66" height="32" rx="10"/>
+   <rect x="557"
+         y="77"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="567" y="97">ADMIN</text>
+   <rect x="645" y="79" width="76" height="32" rx="10"/>
+   <rect x="643"
+         y="77"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="97">OPTION</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m66 0 h10 m20 0 h10 m44 0 h10 m-84 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m64 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-64 0 h10 m24 0 h10 m0 0 h20 m20 44 h10 m38 0 h10 m20 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m40 44 h10 m0 0 h250 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v12 m280 0 v-12 m-280 12 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m76 0 h10 m23 -32 h-3"/>
+   <polygon points="759 61 767 57 767 65"/>
+   <polygon points="759 61 751 57 751 65"/>
+</svg>

--- a/server/.gitbook/assets/select-export-options-railroad.svg
+++ b/server/.gitbook/assets/select-export-options-railroad.svg
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1235" height="239">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 5 1 1 1 9"/>
+   <polygon points="17 5 9 1 9 9"/>
+   <rect x="71" y="23" width="70" height="32" rx="10"/>
+   <rect x="69"
+         y="21"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="41">FIELDS</text>
+   <rect x="71" y="67" width="88" height="32" rx="10"/>
+   <rect x="69"
+         y="65"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="85">COLUMNS</text>
+   <rect x="219" y="55" width="108" height="32" rx="10"/>
+   <rect x="217"
+         y="53"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="227" y="73">TERMINATED</text>
+   <rect x="347" y="55" width="38" height="32" rx="10"/>
+   <rect x="345"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="405" y="55" width="56" height="32"/>
+      <rect x="403" y="53" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="413" y="73">string</text>
+   </a>
+   <rect x="541" y="87" width="110" height="32" rx="10"/>
+   <rect x="539"
+         y="85"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="549" y="105">OPTIONALLY</text>
+   <rect x="691" y="55" width="92" height="32" rx="10"/>
+   <rect x="689"
+         y="53"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="699" y="73">ENCLOSED</text>
+   <rect x="803" y="55" width="38" height="32" rx="10"/>
+   <rect x="801"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="811" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="861" y="55" width="46" height="32"/>
+      <rect x="859" y="53" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="869" y="73">char</text>
+   </a>
+   <rect x="967" y="55" width="82" height="32" rx="10"/>
+   <rect x="965"
+         y="53"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="975" y="73">ESCAPED</text>
+   <rect x="1069" y="55" width="38" height="32" rx="10"/>
+   <rect x="1067"
+         y="53"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1077" y="73">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#char"
+      xlink:title="char">
+      <rect x="1127" y="55" width="46" height="32"/>
+      <rect x="1125" y="53" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1135" y="73">char</text>
+   </a>
+   <rect x="539" y="173" width="62" height="32" rx="10"/>
+   <rect x="537"
+         y="171"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="547" y="191">LINES</text>
+   <rect x="641" y="205" width="90" height="32" rx="10"/>
+   <rect x="639"
+         y="203"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="649" y="223">STARTING</text>
+   <rect x="751" y="205" width="38" height="32" rx="10"/>
+   <rect x="749"
+         y="203"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="759" y="223">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="809" y="205" width="56" height="32"/>
+      <rect x="807" y="203" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="817" y="223">string</text>
+   </a>
+   <rect x="925" y="205" width="108" height="32" rx="10"/>
+   <rect x="923"
+         y="203"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="933" y="223">TERMINATED</text>
+   <rect x="1053" y="205" width="38" height="32" rx="10"/>
+   <rect x="1051"
+         y="203"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1061" y="223">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#string"
+      xlink:title="string">
+      <rect x="1111" y="205" width="56" height="32"/>
+      <rect x="1109" y="203" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1119" y="223">string</text>
+   </a>
+   <path class="line"
+         d="m17 5 h2 m20 0 h10 m0 0 h1152 m-1182 0 h20 m1162 0 h20 m-1202 0 q10 0 10 10 m1182 0 q0 -10 10 -10 m-1192 10 v12 m1182 0 v-12 m-1182 12 q0 10 10 10 m1162 0 q10 0 10 -10 m-1152 10 h10 m70 0 h10 m0 0 h18 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h396 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v12 m426 0 v-12 m-426 12 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -32 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m82 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-738 150 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m62 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m43 -64 h-3"/>
+   <polygon points="1225 155 1233 151 1233 159"/>
+   <polygon points="1225 155 1217 151 1217 159"/>
+</svg>

--- a/server/.gitbook/assets/select-from-clause-railroad.svg
+++ b/server/.gitbook/assets/select-from-clause-railroad.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="889" height="237">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="60" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#table_references"
+      xlink:title="table_references">
+      <rect x="113" y="3" width="128" height="32"/>
+      <rect x="111" y="1" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="121" y="21">table_references</text>
+   </a>
+   <rect x="281" y="35" width="70" height="32" rx="10"/>
+   <rect x="279"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="289" y="53">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#where_condition"
+      xlink:title="where_condition">
+      <rect x="371" y="35" width="124" height="32"/>
+      <rect x="369" y="33" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="379" y="53">where_condition</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#group_by_clause"
+      xlink:title="group_by_clause">
+      <rect x="555" y="35" width="128" height="32"/>
+      <rect x="553" y="33" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="563" y="53">group_by_clause</text>
+   </a>
+   <rect x="168" y="117" width="74" height="32" rx="10"/>
+   <rect x="166"
+         y="115"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="176" y="135">HAVING</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#where_condition"
+      xlink:title="where_condition">
+      <rect x="262" y="117" width="124" height="32"/>
+      <rect x="260" y="115" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="270" y="135">where_condition</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_by_clause"
+      xlink:title="order_by_clause">
+      <rect x="446" y="117" width="126" height="32"/>
+      <rect x="444" y="115" width="126" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="454" y="135">order_by_clause</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#limit_clause"
+      xlink:title="limit_clause">
+      <rect x="632" y="117" width="94" height="32"/>
+      <rect x="630" y="115" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="640" y="135">limit_clause</text>
+   </a>
+   <rect x="45" y="203" width="104" height="32" rx="10"/>
+   <rect x="43"
+         y="201"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="221">PROCEDURE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#procedure_name"
+      xlink:title="procedure_name">
+      <rect x="169" y="203" width="128" height="32"/>
+      <rect x="167" y="201" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="177" y="221">procedure_name</text>
+   </a>
+   <rect x="317" y="203" width="26" height="32" rx="10"/>
+   <rect x="315"
+         y="201"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="221">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#argument_list"
+      xlink:title="argument_list">
+      <rect x="363" y="203" width="108" height="32"/>
+      <rect x="361" y="201" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="371" y="221">argument_list</text>
+   </a>
+   <rect x="491" y="203" width="26" height="32" rx="10"/>
+   <rect x="489"
+         y="201"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="499" y="221">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#into_clause"
+      xlink:title="into_clause">
+      <rect x="577" y="203" width="92" height="32"/>
+      <rect x="575" y="201" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="585" y="221">into_clause</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#locking_clause"
+      xlink:title="locking_clause">
+      <rect x="729" y="203" width="112" height="32"/>
+      <rect x="727" y="201" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="737" y="221">locking_clause</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m128 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m70 0 h10 m0 0 h10 m124 0 h10 m40 -32 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m128 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-599 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h228 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v12 m258 0 v-12 m-258 12 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m74 0 h10 m0 0 h10 m124 0 h10 m40 -32 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m126 0 h10 m40 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-765 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h482 m-512 0 h20 m492 0 h20 m-532 0 q10 0 10 10 m512 0 q0 -10 10 -10 m-522 10 v12 m512 0 v-12 m-512 12 q0 10 10 10 m492 0 q10 0 10 -10 m-502 10 h10 m104 0 h10 m0 0 h10 m128 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m40 -32 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m112 0 h10 m23 -32 h-3"/>
+   <polygon points="879 185 887 181 887 189"/>
+   <polygon points="879 185 871 181 871 189"/>
+</svg>

--- a/server/.gitbook/assets/select-group-by-clause-railroad.svg
+++ b/server/.gitbook/assets/select-group-by-clause-railroad.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="573" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="68" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">GROUP</text>
+   <rect x="119" y="47" width="38" height="32" rx="10"/>
+   <rect x="117"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="65">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#group_by_item"
+      xlink:title="group_by_item">
+      <rect x="197" y="47" width="116" height="32"/>
+      <rect x="195" y="45" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="205" y="65">group_by_item</text>
+   </a>
+   <rect x="197" y="3" width="24" height="32" rx="10"/>
+   <rect x="195"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="205" y="21">,</text>
+   <rect x="373" y="79" width="58" height="32" rx="10"/>
+   <rect x="371"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="381" y="97">WITH</text>
+   <rect x="451" y="79" width="74" height="32" rx="10"/>
+   <rect x="449"
+         y="77"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="459" y="97">ROLLUP</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m40 44 h10 m0 0 h162 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v12 m192 0 v-12 m-192 12 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m58 0 h10 m0 0 h10 m74 0 h10 m23 -32 h-3"/>
+   <polygon points="563 61 571 57 571 65"/>
+   <polygon points="563 61 555 57 555 65"/>
+</svg>

--- a/server/.gitbook/assets/select-into-clause-railroad.svg
+++ b/server/.gitbook/assets/select-into-clause-railroad.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="889" height="201">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">INTO</text>
+   <rect x="127" y="3" width="80" height="32" rx="10"/>
+   <rect x="125"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="21">OUTFILE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#file_name"
+      xlink:title="file_name">
+      <rect x="227" y="3" width="82" height="32"/>
+      <rect x="225" y="1" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="235" y="21">file_name</text>
+   </a>
+   <rect x="349" y="35" width="102" height="32" rx="10"/>
+   <rect x="347"
+         y="33"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="357" y="53">CHARACTER</text>
+   <rect x="471" y="35" width="44" height="32" rx="10"/>
+   <rect x="469"
+         y="33"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="479" y="53">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#charset_name"
+      xlink:title="charset_name">
+      <rect x="535" y="35" width="110" height="32"/>
+      <rect x="533" y="33" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="543" y="53">charset_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#export_options"
+      xlink:title="export_options">
+      <rect x="705" y="35" width="116" height="32"/>
+      <rect x="703" y="33" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="713" y="53">export_options</text>
+   </a>
+   <rect x="127" y="79" width="90" height="32" rx="10"/>
+   <rect x="125"
+         y="77"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="97">DUMPFILE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#file_name"
+      xlink:title="file_name">
+      <rect x="237" y="79" width="82" height="32"/>
+      <rect x="235" y="77" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="245" y="97">file_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#var_name"
+      xlink:title="var_name">
+      <rect x="147" y="167" width="84" height="32"/>
+      <rect x="145" y="165" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="155" y="185">var_name</text>
+   </a>
+   <rect x="147" y="123" width="24" height="32" rx="10"/>
+   <rect x="145"
+         y="121"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="141">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m56 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h306 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v12 m336 0 v-12 m-336 12 q0 10 10 10 m316 0 q10 0 10 -10 m-326 10 h10 m102 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m110 0 h10 m40 -32 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m-734 -32 h20 m734 0 h20 m-774 0 q10 0 10 10 m754 0 q0 -10 10 -10 m-764 10 v56 m754 0 v-56 m-754 56 q0 10 10 10 m734 0 q10 0 10 -10 m-744 10 h10 m90 0 h10 m0 0 h10 m82 0 h10 m0 0 h522 m-744 -10 v20 m754 0 v-20 m-754 20 v68 m754 0 v-68 m-754 68 q0 10 10 10 m734 0 q10 0 10 -10 m-724 10 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m104 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-104 0 h10 m24 0 h10 m0 0 h60 m20 44 h590 m23 -164 h-3"/>
+   <polygon points="879 17 887 13 887 21"/>
+   <polygon points="879 17 871 13 871 21"/>
+</svg>

--- a/server/.gitbook/assets/select-limit-clause-railroad.svg
+++ b/server/.gitbook/assets/select-limit-clause-railroad.svg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1071" height="255">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="60" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">LIMIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#offset"
+      xlink:title="offset">
+      <rect x="171" y="35" width="56" height="32"/>
+      <rect x="169" y="33" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="179" y="53">offset</text>
+   </a>
+   <rect x="247" y="35" width="24" height="32" rx="10"/>
+   <rect x="245"
+         y="33"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="53">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#row_count"
+      xlink:title="row_count">
+      <rect x="311" y="3" width="86" height="32"/>
+      <rect x="309" y="1" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="319" y="21">row_count</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#row_count"
+      xlink:title="row_count">
+      <rect x="151" y="79" width="86" height="32"/>
+      <rect x="149" y="77" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="159" y="97">row_count</text>
+   </a>
+   <rect x="257" y="79" width="72" height="32" rx="10"/>
+   <rect x="255"
+         y="77"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="97">OFFSET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#offset"
+      xlink:title="offset">
+      <rect x="349" y="79" width="56" height="32"/>
+      <rect x="347" y="77" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="357" y="97">offset</text>
+   </a>
+   <rect x="445" y="111" width="62" height="32" rx="10"/>
+   <rect x="443"
+         y="109"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="453" y="129">ROWS</text>
+   <rect x="527" y="111" width="92" height="32" rx="10"/>
+   <rect x="525"
+         y="109"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="535" y="129">EXAMINED</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#rows_limit"
+      xlink:title="rows_limit">
+      <rect x="639" y="111" width="84" height="32"/>
+      <rect x="637" y="109" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="647" y="129">rows_limit</text>
+   </a>
+   <rect x="71" y="177" width="72" height="32" rx="10"/>
+   <rect x="69"
+         y="175"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="195">OFFSET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#start"
+      xlink:title="start">
+      <rect x="163" y="177" width="50" height="32"/>
+      <rect x="161" y="175" width="50" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="171" y="195">start</text>
+   </a>
+   <rect x="253" y="177" width="54" height="32" rx="10"/>
+   <rect x="251"
+         y="175"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="195">ROW</text>
+   <rect x="253" y="221" width="62" height="32" rx="10"/>
+   <rect x="251"
+         y="219"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="239">ROWS</text>
+   <rect x="395" y="177" width="62" height="32" rx="10"/>
+   <rect x="393"
+         y="175"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="403" y="195">FETCH</text>
+   <rect x="497" y="177" width="60" height="32" rx="10"/>
+   <rect x="495"
+         y="175"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="195">FIRST</text>
+   <rect x="497" y="221" width="56" height="32" rx="10"/>
+   <rect x="495"
+         y="219"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="239">NEXT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#count"
+      xlink:title="count">
+      <rect x="617" y="209" width="54" height="32"/>
+      <rect x="615" y="207" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="625" y="227">count</text>
+   </a>
+   <rect x="731" y="177" width="54" height="32" rx="10"/>
+   <rect x="729"
+         y="175"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="739" y="195">ROW</text>
+   <rect x="731" y="221" width="62" height="32" rx="10"/>
+   <rect x="729"
+         y="219"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="739" y="239">ROWS</text>
+   <rect x="853" y="177" width="58" height="32" rx="10"/>
+   <rect x="851"
+         y="175"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="861" y="195">ONLY</text>
+   <rect x="853" y="221" width="58" height="32" rx="10"/>
+   <rect x="851"
+         y="219"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="861" y="239">WITH</text>
+   <rect x="931" y="221" width="52" height="32" rx="10"/>
+   <rect x="929"
+         y="219"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="939" y="239">TIES</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m60 0 h10 m40 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 -32 h10 m86 0 h10 m0 0 h346 m-632 0 h20 m612 0 h20 m-652 0 q10 0 10 10 m632 0 q0 -10 10 -10 m-642 10 v56 m632 0 v-56 m-632 56 q0 10 10 10 m612 0 q10 0 10 -10 m-622 10 h10 m86 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h288 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v12 m318 0 v-12 m-318 12 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m62 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m84 0 h10 m40 -108 h260 m-1012 0 h20 m992 0 h20 m-1032 0 q10 0 10 10 m1012 0 q0 -10 10 -10 m-1022 10 v122 m1012 0 v-122 m-1012 122 q0 10 10 10 m992 0 q10 0 10 -10 m-982 10 h10 m0 0 h274 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v12 m304 0 v-12 m-304 12 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m72 0 h10 m0 0 h10 m50 0 h10 m20 0 h10 m54 0 h10 m0 0 h8 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -76 h10 m0 0 h618 m-648 0 h20 m628 0 h20 m-668 0 q10 0 10 10 m648 0 q0 -10 10 -10 m-658 10 v12 m648 0 v-12 m-648 12 q0 10 10 10 m628 0 q10 0 10 -10 m-638 10 h10 m62 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m56 0 h10 m0 0 h4 m40 -44 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m40 -32 h10 m54 0 h10 m0 0 h8 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m40 -44 h10 m58 0 h10 m0 0 h72 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m58 0 h10 m0 0 h10 m52 0 h10 m63 -218 h-3"/>
+   <polygon points="1061 17 1069 13 1069 21"/>
+   <polygon points="1061 17 1053 13 1053 21"/>
+</svg>

--- a/server/.gitbook/assets/select-lock-option-railroad.svg
+++ b/server/.gitbook/assets/select-lock-option-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="247" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="129" y="3" width="28" height="32"/>
+      <rect x="127" y="1" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="137" y="21">n</text>
+   </a>
+   <rect x="51" y="47" width="78" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">NOWAIT</text>
+   <rect x="51" y="91" width="54" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">SKIP</text>
+   <rect x="125" y="91" width="74" height="32" rx="10"/>
+   <rect x="123"
+         y="89"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="133" y="109">LOCKED</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m58 0 h10 m0 0 h10 m28 0 h10 m0 0 h42 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h10 m74 0 h10 m23 -88 h-3"/>
+   <polygon points="237 17 245 13 245 21"/>
+   <polygon points="237 17 229 13 229 21"/>
+</svg>

--- a/server/.gitbook/assets/select-locking-clause-railroad.svg
+++ b/server/.gitbook/assets/select-locking-clause-railroad.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="529" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">FOR</text>
+   <rect x="119" y="3" width="74" height="32" rx="10"/>
+   <rect x="117"
+         y="1"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="21">UPDATE</text>
+   <rect x="51" y="47" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">LOCK</text>
+   <rect x="127" y="47" width="36" height="32" rx="10"/>
+   <rect x="125"
+         y="45"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="65">IN</text>
+   <rect x="183" y="47" width="66" height="32" rx="10"/>
+   <rect x="181"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="191" y="65">SHARE</text>
+   <rect x="269" y="47" width="60" height="32" rx="10"/>
+   <rect x="267"
+         y="45"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="65">MODE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#lock_option"
+      xlink:title="lock_option">
+      <rect x="389" y="35" width="92" height="32"/>
+      <rect x="387" y="33" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="397" y="53">lock_option</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h136 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m56 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m60 0 h10 m40 -44 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m23 -32 h-3"/>
+   <polygon points="519 17 527 13 527 21"/>
+   <polygon points="519 17 511 13 511 21"/>
+</svg>

--- a/server/.gitbook/assets/select-order-by-clause-railroad.svg
+++ b/server/.gitbook/assets/select-order-by-clause-railroad.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="357" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="68" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">ORDER</text>
+   <rect x="119" y="47" width="38" height="32" rx="10"/>
+   <rect x="117"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="65">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_by_item"
+      xlink:title="order_by_item">
+      <rect x="197" y="47" width="112" height="32"/>
+      <rect x="195" y="45" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="205" y="65">order_by_item</text>
+   </a>
+   <rect x="197" y="3" width="24" height="32" rx="10"/>
+   <rect x="195"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="205" y="21">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m112 0 h10 m-152 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m132 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-132 0 h10 m24 0 h10 m0 0 h88 m23 44 h-3"/>
+   <polygon points="347 61 355 57 355 65"/>
+   <polygon points="347 61 339 57 339 65"/>
+</svg>

--- a/server/.gitbook/assets/select-railroad.svg
+++ b/server/.gitbook/assets/select-railroad.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="877" height="459">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 51 1 47 1 55"/>
+   <polygon points="17 51 9 47 9 55"/>
+   <rect x="31" y="37" width="70" height="32" rx="10"/>
+   <rect x="29"
+         y="35"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="55">SELECT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#optimizer_hint"
+      xlink:title="optimizer_hint">
+      <rect x="141" y="3" width="112" height="32"/>
+      <rect x="139" y="1" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="149" y="21">optimizer_hint</text>
+   </a>
+   <rect x="313" y="69" width="44" height="32" rx="10"/>
+   <rect x="311"
+         y="67"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="87">ALL</text>
+   <rect x="313" y="113" width="86" height="32" rx="10"/>
+   <rect x="311"
+         y="111"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="131">DISTINCT</text>
+   <rect x="313" y="157" width="122" height="32" rx="10"/>
+   <rect x="311"
+         y="155"
+         width="122"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="321" y="175">DISTINCTROW</text>
+   <rect x="495" y="69" width="134" height="32" rx="10"/>
+   <rect x="493"
+         y="67"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="87">HIGH_PRIORITY</text>
+   <rect x="689" y="69" width="134" height="32" rx="10"/>
+   <rect x="687"
+         y="67"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="697" y="87">STRAIGHT_JOIN</text>
+   <rect x="45" y="239" width="164" height="32" rx="10"/>
+   <rect x="43"
+         y="237"
+         width="164"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="257">SQL_SMALL_RESULT</text>
+   <rect x="269" y="239" width="144" height="32" rx="10"/>
+   <rect x="267"
+         y="237"
+         width="144"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="257">SQL_BIG_RESULT</text>
+   <rect x="473" y="239" width="170" height="32" rx="10"/>
+   <rect x="471"
+         y="237"
+         width="170"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="481" y="257">SQL_BUFFER_RESULT</text>
+   <rect x="703" y="239" width="102" height="32" rx="10"/>
+   <rect x="701"
+         y="237"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="711" y="257">SQL_CACHE</text>
+   <rect x="703" y="283" width="132" height="32" rx="10"/>
+   <rect x="701"
+         y="281"
+         width="132"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="711" y="301">SQL_NO_CACHE</text>
+   <rect x="317" y="425" width="202" height="32" rx="10"/>
+   <rect x="315"
+         y="423"
+         width="202"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="443">SQL_CALC_FOUND_ROWS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_expr"
+      xlink:title="select_expr">
+      <rect x="579" y="393" width="94" height="32"/>
+      <rect x="577" y="391" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="587" y="411">select_expr</text>
+   </a>
+   <rect x="579" y="349" width="24" height="32" rx="10"/>
+   <rect x="577"
+         y="347"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="587" y="367">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#from_clause"
+      xlink:title="from_clause">
+      <rect x="733" y="425" width="96" height="32"/>
+      <rect x="731" y="423" width="96" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="741" y="443">from_clause</text>
+   </a>
+   <path class="line"
+         d="m17 51 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h122 m-152 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m132 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-132 0 h10 m112 0 h10 m40 34 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m44 0 h10 m0 0 h78 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m40 -120 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m40 -32 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-862 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m40 -32 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m40 -32 h10 m0 0 h180 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v12 m210 0 v-12 m-210 12 q0 10 10 10 m190 0 q10 0 10 -10 m-200 10 h10 m170 0 h10 m40 -32 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m102 0 h10 m0 0 h30 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-602 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h212 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v12 m242 0 v-12 m-242 12 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m202 0 h10 m40 -32 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m40 44 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m23 -32 h-3"/>
+   <polygon points="867 407 875 403 875 411"/>
+   <polygon points="867 407 859 403 859 411"/>
+</svg>

--- a/server/reference/sql-statements/account-management-sql-statements/alter-user.md
+++ b/server/reference/sql-statements/account-management-sql-statements/alter-user.md
@@ -29,19 +29,19 @@ authentication_rule:
   | authentication_plugin {USING|AS} 'authentication_string'
   | authentication_plugin {USING|AS} PASSWORD('password')
 
-tls_option
+tls_option:
   SSL 
   | X509
   | CIPHER 'cipher'
   | ISSUER 'issuer'
   | SUBJECT 'subject'
 
-resource_option
-  MAX_QUERIES_PER_HOUR COUNT
-  | MAX_UPDATES_PER_HOUR COUNT
-  | MAX_CONNECTIONS_PER_HOUR COUNT
-  | MAX_USER_CONNECTIONS COUNT
-  | MAX_STATEMENT_TIME TIME
+resource_option:
+  MAX_QUERIES_PER_HOUR count
+  | MAX_UPDATES_PER_HOUR count
+  | MAX_CONNECTIONS_PER_HOUR count
+  | MAX_USER_CONNECTIONS count
+  | MAX_STATEMENT_TIME time
 
 password_option:
   PASSWORD EXPIRE
@@ -52,8 +52,23 @@ password_option:
 lock_option:
     ACCOUNT LOCK
   | ACCOUNT UNLOCK
-}
 ```
+
+![Railroad diagram of ALTER USER — equivalent to the BNF above](../../../.gitbook/assets/alter-user-railroad.svg)
+
+![Railroad diagram of user_specification](../../../.gitbook/assets/alter-user-specification-railroad.svg)
+
+![Railroad diagram of authentication_option](../../../.gitbook/assets/alter-user-authentication-option-railroad.svg)
+
+![Railroad diagram of authentication_rule](../../../.gitbook/assets/alter-user-authentication-rule-railroad.svg)
+
+![Railroad diagram of tls_option](../../../.gitbook/assets/alter-user-tls-option-railroad.svg)
+
+![Railroad diagram of resource_option](../../../.gitbook/assets/alter-user-resource-option-railroad.svg)
+
+![Railroad diagram of password_option](../../../.gitbook/assets/alter-user-password-option-railroad.svg)
+
+![Railroad diagram of lock_option](../../../.gitbook/assets/alter-user-lock-option-railroad.svg)
 
 ## Description
 

--- a/server/reference/sql-statements/account-management-sql-statements/create-user.md
+++ b/server/reference/sql-statements/account-management-sql-statements/create-user.md
@@ -51,8 +51,23 @@ password_option:
 lock_option:
     ACCOUNT LOCK
   | ACCOUNT UNLOCK
-}
 ```
+
+![Railroad diagram of CREATE USER — equivalent to the BNF above](../../../.gitbook/assets/create-user-railroad.svg)
+
+![Railroad diagram of user_specification](../../../.gitbook/assets/create-user-specification-railroad.svg)
+
+![Railroad diagram of authentication_option](../../../.gitbook/assets/create-user-authentication-option-railroad.svg)
+
+![Railroad diagram of authentication_rule](../../../.gitbook/assets/create-user-authentication-rule-railroad.svg)
+
+![Railroad diagram of tls_option](../../../.gitbook/assets/create-user-tls-option-railroad.svg)
+
+![Railroad diagram of resource_option](../../../.gitbook/assets/create-user-resource-option-railroad.svg)
+
+![Railroad diagram of password_option](../../../.gitbook/assets/create-user-password-option-railroad.svg)
+
+![Railroad diagram of lock_option](../../../.gitbook/assets/create-user-lock-option-railroad.svg)
 
 ## Description
 

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -96,6 +96,14 @@ tls_option:
   | SUBJECT 'subject'
 ```
 
+GRANT has three top-level forms. Sub-rule diagrams are not included here — the `priv_type` production alone is a ~60-row alternative list; readers can consult the BNF above for the sub-rule expansions.
+
+![Railroad diagram of GRANT (privileges form)](../../../.gitbook/assets/grant-privileges-railroad.svg)
+
+![Railroad diagram of GRANT PROXY](../../../.gitbook/assets/grant-proxy-railroad.svg)
+
+![Railroad diagram of GRANT (roles form)](../../../.gitbook/assets/grant-roles-railroad.svg)
+
 ## Description
 
 The `GRANT` statement allows you to grant privileges or [roles](grant.md#roles) to accounts. To use `GRANT`, you must have the `GRANT OPTION` privilege, and you must have the privileges that you are granting.

--- a/server/reference/sql-statements/data-manipulation/selecting-data/select.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/select.md
@@ -31,7 +31,7 @@ SELECT
       [ROWS EXAMINED rows_limit] } |
         [OFFSET start { ROW | ROWS }]
         [FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES }] ]
-      procedure|[PROCEDURE procedure_name(argument_list)]
+      [PROCEDURE procedure_name(argument_list)]
       [INTO OUTFILE 'file_name' [CHARACTER SET charset_name] [export_options] |
         INTO DUMPFILE 'file_name' | INTO var_name [, var_name] ]
       [FOR UPDATE lock_option | LOCK IN SHARE MODE lock_option]
@@ -48,6 +48,26 @@ export_options:
 lock_option:
     [WAIT n | NOWAIT | SKIP LOCKED]
 ```
+
+The SELECT grammar is broken out into named sub-clauses for readability. Each clause has its own diagram below.
+
+![Railroad diagram of SELECT — top-level](../../../../.gitbook/assets/select-railroad.svg)
+
+![Railroad diagram of from_clause](../../../../.gitbook/assets/select-from-clause-railroad.svg)
+
+![Railroad diagram of group_by_clause](../../../../.gitbook/assets/select-group-by-clause-railroad.svg)
+
+![Railroad diagram of order_by_clause](../../../../.gitbook/assets/select-order-by-clause-railroad.svg)
+
+![Railroad diagram of limit_clause](../../../../.gitbook/assets/select-limit-clause-railroad.svg)
+
+![Railroad diagram of into_clause](../../../../.gitbook/assets/select-into-clause-railroad.svg)
+
+![Railroad diagram of locking_clause](../../../../.gitbook/assets/select-locking-clause-railroad.svg)
+
+![Railroad diagram of export_options](../../../../.gitbook/assets/select-export-options-railroad.svg)
+
+![Railroad diagram of lock_option](../../../../.gitbook/assets/select-lock-option-railroad.svg)
 
 {% tabs %}
 {% tab title="Current" %}


### PR DESCRIPTION
## Summary

Batch 5 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. After #545 (prototype) + #552 + #561 + #562 + #563. Four more pages — the larger account-management trio plus SELECT.

## Pages

| Page | Rank | Views | Diagrams added |
|---|---:|---:|---|
| [GRANT](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/grant) | 2 | 1684 | 3 top-level forms only (privileges / GRANT PROXY / roles) |
| [CREATE USER](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-user) | 3 | 1530 | top-level + `user_specification` + `authentication_option` + `authentication_rule` + `tls_option` + `resource_option` + `password_option` + `lock_option` |
| [SELECT](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select) | 4 | 938 | top-level + `from_clause` + `group_by_clause` + `order_by_clause` + `limit_clause` + `into_clause` + `locking_clause` + `export_options` + `lock_option` |
| [ALTER USER](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/alter-user) | 20 | 403 | same 8-diagram set as CREATE USER |

28 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## CREATE TABLE — deliberately skipped

The CREATE TABLE page (rank 31, 348 views) has 5 ```bnf blocks but **none are top-level** — they're all sub-rules (`index_definition`, `period_definition`, an option-syntax block, `table_option`, `partition_options`). The "Syntax" section uses ```sql blocks for short examples, not a canonical CREATE TABLE BNF.

Doing a top-level diagram would require either authoring a new top-level BNF on the page first, or synthesising one from the prose (which violates the "diagram only what's in the source" rule). Surfacing as a separate editorial decision rather than rolling a half-solution into this PR.

## GRANT — top-level only

The `priv_type` production alone is a ~60-row alternative list (every privilege keyword in MariaDB). Rendered as a sub-diagram, it would dominate the page. Same applies to `account_or_role` and `authentication_option`. Sub-rules are left as undefined non-terminal boxes on the top-level diagrams; readers consult the BNF for the expansions.

## SELECT — width handled by decomposition

You flagged earlier that the FROM clause was super wide. The grammar now breaks the post-SELECT tail into named sub-clauses (`from_clause`, `group_by_clause`, `order_by_clause`, `limit_clause`, `into_clause`, `locking_clause`). The top-level `SelectStatement` diagram is now compact; each clause has its own small diagram below.

## Source-BNF cleanups folded in

- **CREATE USER**: removed the stray trailing `}` after `lock_option`.
- **ALTER USER**: removed the same trailing `}`, added missing `:` after `tls_option` and `resource_option` rule names, lowercased `COUNT`/`TIME` to `count`/`time` to match the placeholder convention used in CREATE USER.
- **SELECT**: removed the leading `procedure|` typo before `[PROCEDURE procedure_name(argument_list)]`.

## Tally and remaining work

After this PR lands: **25 pages diagrammed**.

- 1 prototype: ALTER TABLE (#545)
- 5 batch 1: CREATE DATABASE, INSERT, UPDATE, DELETE, CREATE VIEW (#552)
- 5 batch 2: SET PASSWORD, LOAD DATA INFILE, CREATE TRIGGER, SELECT INTO OUTFILE, INSERT … ON DUPLICATE KEY UPDATE *(cross-ref)* (#561)
- 6 batch 3: OPTIMIZE TABLE, INSERT … ON DUPLICATE KEY UPDATE *(real)*, FLUSH, Generated Columns, PURGE BINARY LOGS, CASE statement (#562)
- 5 batch 4: CREATE PROCEDURE, CHANGE MASTER TO, CREATE INDEX, CONSTRAINT, CREATE FUNCTION (#563)
- 4 this batch: GRANT, CREATE USER, ALTER USER, SELECT

Remaining top-50: CREATE TABLE (deferred) + ~24 trivial single-line BNFs (data-type, function, SHOW pages — agreed to skip). To reach the ~50 target outlined in the ticket, we'd need to dip into ranks 51+ of the GA report or revisit the skip rule. Worth a quick decision after this PR.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] CREATE USER / ALTER USER no longer have a stray `}` after the BNF block.
- [ ] ALTER USER's `tls_option` and `resource_option` rule lines now end in `:`.
- [ ] SELECT BNF no longer has the `procedure|` typo.
- [ ] The SELECT top-level diagram fits the page width without horizontal scrolling.
- [ ] All 28 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ