### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more SQL pages

### DIFF
--- a/server/.gitbook/assets/analyze-table-railroad.svg
+++ b/server/.gitbook/assets/analyze-table-railroad.svg
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1077" height="343">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 61 3 57 3 65"/>
+   <polygon points="19 61 11 57 11 65"/>
+   <rect x="33" y="47" width="82" height="32" rx="10"/>
+   <rect x="31"
+         y="45"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="65">ANALYZE</text>
+   <rect x="155" y="79" width="188" height="32" rx="10"/>
+   <rect x="153"
+         y="77"
+         width="188"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="97">NO_WRITE_TO_BINLOG</text>
+   <rect x="155" y="123" width="64" height="32" rx="10"/>
+   <rect x="153"
+         y="121"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="141">LOCAL</text>
+   <rect x="383" y="47" width="62" height="32" rx="10"/>
+   <rect x="381"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="391" y="65">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="485" y="47" width="80" height="32"/>
+      <rect x="483" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="493" y="65">tbl_name</text>
+   </a>
+   <rect x="485" y="3" width="24" height="32" rx="10"/>
+   <rect x="483"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="493" y="21">,</text>
+   <rect x="45" y="189" width="106" height="32" rx="10"/>
+   <rect x="43"
+         y="187"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="207">PERSISTENT</text>
+   <rect x="171" y="189" width="48" height="32" rx="10"/>
+   <rect x="169"
+         y="187"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="179" y="207">FOR</text>
+   <rect x="259" y="189" width="44" height="32" rx="10"/>
+   <rect x="257"
+         y="187"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="267" y="207">ALL</text>
+   <rect x="259" y="277" width="88" height="32" rx="10"/>
+   <rect x="257"
+         y="275"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="267" y="295">COLUMNS</text>
+   <rect x="367" y="277" width="26" height="32" rx="10"/>
+   <rect x="365"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="375" y="295">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="453" y="277" width="80" height="32"/>
+      <rect x="451" y="275" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="461" y="295">col_name</text>
+   </a>
+   <rect x="453" y="233" width="24" height="32" rx="10"/>
+   <rect x="451"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="461" y="251">,</text>
+   <rect x="593" y="277" width="26" height="32" rx="10"/>
+   <rect x="591"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="601" y="295">)</text>
+   <rect x="639" y="277" width="80" height="32" rx="10"/>
+   <rect x="637"
+         y="275"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="647" y="295">INDEXES</text>
+   <rect x="739" y="277" width="26" height="32" rx="10"/>
+   <rect x="737"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="747" y="295">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#index_name"
+      xlink:title="index_name">
+      <rect x="825" y="277" width="98" height="32"/>
+      <rect x="823" y="275" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="833" y="295">index_name</text>
+   </a>
+   <rect x="825" y="233" width="24" height="32" rx="10"/>
+   <rect x="823"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="833" y="251">,</text>
+   <rect x="983" y="277" width="26" height="32" rx="10"/>
+   <rect x="981"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="991" y="295">)</text>
+   <path class="line"
+         d="m19 61 h2 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h198 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v12 m228 0 v-12 m-228 12 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m-218 -10 v20 m228 0 v-20 m-228 20 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m64 0 h10 m0 0 h124 m20 -76 h10 m62 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-604 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m106 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m44 0 h10 m0 0 h706 m-790 0 h20 m770 0 h20 m-810 0 q10 0 10 10 m790 0 q0 -10 10 -10 m-800 10 v68 m790 0 v-68 m-790 68 q0 10 10 10 m770 0 q10 0 10 -10 m-780 10 h10 m88 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m-140 44 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v14 m160 0 v-14 m-160 14 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m0 0 h130 m20 -34 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m-158 44 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v14 m178 0 v-14 m-178 14 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m0 0 h148 m20 -34 h10 m26 0 h10 m-1004 -88 h20 m1004 0 h20 m-1044 0 q10 0 10 10 m1024 0 q0 -10 10 -10 m-1034 10 v118 m1024 0 v-118 m-1024 118 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m0 0 h994 m23 -138 h-3"/>
+   <polygon points="1067 203 1075 199 1075 207"/>
+   <polygon points="1067 203 1059 199 1059 207"/>
+</svg>

--- a/server/.gitbook/assets/commit-railroad.svg
+++ b/server/.gitbook/assets/commit-railroad.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="793" height="101">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="78" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">COMMIT</text>
+   <rect x="149" y="35" width="64" height="32" rx="10"/>
+   <rect x="147"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="53">WORK</text>
+   <rect x="273" y="35" width="48" height="32" rx="10"/>
+   <rect x="271"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="281" y="53">AND</text>
+   <rect x="361" y="67" width="40" height="32" rx="10"/>
+   <rect x="359"
+         y="65"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="369" y="85">NO</text>
+   <rect x="441" y="35" width="64" height="32" rx="10"/>
+   <rect x="439"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="449" y="53">CHAIN</text>
+   <rect x="585" y="67" width="40" height="32" rx="10"/>
+   <rect x="583"
+         y="65"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="593" y="85">NO</text>
+   <rect x="665" y="35" width="80" height="32" rx="10"/>
+   <rect x="663"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="673" y="53">RELEASE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m48 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m20 -32 h10 m64 0 h10 m40 -32 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-190 10 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m20 -32 h10 m80 0 h10 m23 -32 h-3"/>
+   <polygon points="783 17 791 13 791 21"/>
+   <polygon points="783 17 775 13 775 21"/>
+</svg>

--- a/server/.gitbook/assets/replace-railroad.svg
+++ b/server/.gitbook/assets/replace-railroad.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="909" height="267">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="80" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">REPLACE</text>
+   <rect x="151" y="35" width="130" height="32" rx="10"/>
+   <rect x="149"
+         y="33"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="53">LOW_PRIORITY</text>
+   <rect x="151" y="79" width="82" height="32" rx="10"/>
+   <rect x="149"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="97">DELAYED</text>
+   <rect x="341" y="35" width="56" height="32" rx="10"/>
+   <rect x="339"
+         y="33"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="53">INTO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="437" y="3" width="80" height="32"/>
+      <rect x="435" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="445" y="21">tbl_name</text>
+   </a>
+   <rect x="557" y="35" width="98" height="32" rx="10"/>
+   <rect x="555"
+         y="33"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="565" y="53">PARTITION</text>
+   <rect x="675" y="35" width="26" height="32" rx="10"/>
+   <rect x="673"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="683" y="53">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_list"
+      xlink:title="partition_list">
+      <rect x="721" y="35" width="100" height="32"/>
+      <rect x="719" y="33" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="729" y="53">partition_list</text>
+   </a>
+   <rect x="841" y="35" width="26" height="32" rx="10"/>
+   <rect x="839"
+         y="33"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="849" y="53">)</text>
+   <rect x="105" y="189" width="26" height="32" rx="10"/>
+   <rect x="103"
+         y="187"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="207">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col"
+      xlink:title="col">
+      <rect x="171" y="189" width="38" height="32"/>
+      <rect x="169" y="187" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="179" y="207">col</text>
+   </a>
+   <rect x="171" y="145" width="24" height="32" rx="10"/>
+   <rect x="169"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="179" y="163">,</text>
+   <rect x="249" y="189" width="26" height="32" rx="10"/>
+   <rect x="247"
+         y="187"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="207">)</text>
+   <rect x="335" y="189" width="72" height="32" rx="10"/>
+   <rect x="333"
+         y="187"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="207">VALUES</text>
+   <rect x="335" y="233" width="64" height="32" rx="10"/>
+   <rect x="333"
+         y="231"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="251">VALUE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value_list"
+      xlink:title="value_list">
+      <rect x="467" y="189" width="80" height="32"/>
+      <rect x="465" y="187" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="475" y="207">value_list</text>
+   </a>
+   <rect x="467" y="145" width="24" height="32" rx="10"/>
+   <rect x="465"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="475" y="163">,</text>
+   <rect x="607" y="189" width="100" height="32" rx="10"/>
+   <rect x="605"
+         y="187"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="615" y="207">RETURNING</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_expr"
+      xlink:title="select_expr">
+      <rect x="747" y="189" width="94" height="32"/>
+      <rect x="745" y="187" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="755" y="207">select_expr</text>
+   </a>
+   <rect x="747" y="145" width="24" height="32" rx="10"/>
+   <rect x="745"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="755" y="163">,</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m82 0 h10 m0 0 h48 m40 -76 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m80 0 h10 m20 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-846 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v14 m210 0 v-14 m-210 14 q0 10 10 10 m190 0 q10 0 10 -10 m-200 10 h10 m0 0 h180 m40 -34 h10 m72 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m64 0 h10 m0 0 h8 m40 -44 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
+   <polygon points="899 203 907 199 907 207"/>
+   <polygon points="899 203 891 199 891 207"/>
+</svg>

--- a/server/.gitbook/assets/replace-value-list-railroad.svg
+++ b/server/.gitbook/assets/replace-value-list-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="311" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="26" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="117" y="47" width="48" height="32"/>
+      <rect x="115" y="45" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="125" y="65">expr</text>
+   </a>
+   <rect x="117" y="91" width="80" height="32" rx="10"/>
+   <rect x="115"
+         y="89"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="109">DEFAULT</text>
+   <rect x="97" y="3" width="24" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">,</text>
+   <rect x="257" y="47" width="26" height="32" rx="10"/>
+   <rect x="255"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="65">)</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m26 0 h10 m40 0 h10 m48 0 h10 m0 0 h32 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-140 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m20 44 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="301 61 309 57 309 65"/>
+   <polygon points="301 61 293 57 293 65"/>
+</svg>

--- a/server/.gitbook/assets/rollback-railroad.svg
+++ b/server/.gitbook/assets/rollback-railroad.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="807" height="101">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="92" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ROLLBACK</text>
+   <rect x="163" y="35" width="64" height="32" rx="10"/>
+   <rect x="161"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="171" y="53">WORK</text>
+   <rect x="287" y="35" width="48" height="32" rx="10"/>
+   <rect x="285"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="53">AND</text>
+   <rect x="375" y="67" width="40" height="32" rx="10"/>
+   <rect x="373"
+         y="65"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="85">NO</text>
+   <rect x="455" y="35" width="64" height="32" rx="10"/>
+   <rect x="453"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="53">CHAIN</text>
+   <rect x="599" y="67" width="40" height="32" rx="10"/>
+   <rect x="597"
+         y="65"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="607" y="85">NO</text>
+   <rect x="679" y="35" width="80" height="32" rx="10"/>
+   <rect x="677"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="687" y="53">RELEASE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m48 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m20 -32 h10 m64 0 h10 m40 -32 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-190 10 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m20 -32 h10 m80 0 h10 m23 -32 h-3"/>
+   <polygon points="797 17 805 13 805 21"/>
+   <polygon points="797 17 789 13 789 21"/>
+</svg>

--- a/server/.gitbook/assets/set-autocommit-railroad.svg
+++ b/server/.gitbook/assets/set-autocommit-railroad.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="361" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="44" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SET</text>
+   <rect x="95" y="3" width="100" height="32" rx="10"/>
+   <rect x="93"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="103" y="21">autocommit</text>
+   <rect x="215" y="3" width="30" height="32" rx="10"/>
+   <rect x="213"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="21">=</text>
+   <rect x="285" y="3" width="28" height="32" rx="10"/>
+   <rect x="283"
+         y="1"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="293" y="21">0</text>
+   <rect x="285" y="47" width="28" height="32" rx="10"/>
+   <rect x="283"
+         y="45"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="293" y="65">1</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m28 0 h10 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m23 -44 h-3"/>
+   <polygon points="351 17 359 13 359 21"/>
+   <polygon points="351 17 343 13 343 21"/>
+</svg>

--- a/server/.gitbook/assets/show-databases-railroad.svg
+++ b/server/.gitbook/assets/show-databases-railroad.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="481" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="3" width="100" height="32" rx="10"/>
+   <rect x="133"
+         y="1"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="21">DATABASES</text>
+   <rect x="135" y="47" width="86" height="32" rx="10"/>
+   <rect x="133"
+         y="45"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="65">SCHEMAS</text>
+   <rect x="295" y="35" width="52" height="32" rx="10"/>
+   <rect x="293"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="53">LIKE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#pattern"
+      xlink:title="pattern">
+      <rect x="367" y="35" width="66" height="32"/>
+      <rect x="365" y="33" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="375" y="53">pattern</text>
+   </a>
+   <rect x="295" y="79" width="70" height="32" rx="10"/>
+   <rect x="293"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="97">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="385" y="79" width="48" height="32"/>
+      <rect x="383" y="77" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="393" y="97">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m86 0 h10 m0 0 h14 m40 -44 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m52 0 h10 m0 0 h10 m66 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -76 h-3"/>
+   <polygon points="471 17 479 13 479 21"/>
+   <polygon points="471 17 463 13 463 21"/>
+</svg>

--- a/server/.gitbook/assets/show-tables-railroad.svg
+++ b/server/.gitbook/assets/show-tables-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="747" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="35" width="54" height="32" rx="10"/>
+   <rect x="133"
+         y="33"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="53">FULL</text>
+   <rect x="229" y="3" width="72" height="32" rx="10"/>
+   <rect x="227"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="237" y="21">TABLES</text>
+   <rect x="341" y="35" width="60" height="32" rx="10"/>
+   <rect x="339"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="53">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#db_name"
+      xlink:title="db_name">
+      <rect x="421" y="35" width="80" height="32"/>
+      <rect x="419" y="33" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="429" y="53">db_name</text>
+   </a>
+   <rect x="561" y="35" width="52" height="32" rx="10"/>
+   <rect x="559"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="569" y="53">LIKE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#pattern"
+      xlink:title="pattern">
+      <rect x="633" y="35" width="66" height="32"/>
+      <rect x="631" y="33" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="641" y="53">pattern</text>
+   </a>
+   <rect x="561" y="79" width="70" height="32" rx="10"/>
+   <rect x="559"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="569" y="97">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="651" y="79" width="48" height="32"/>
+      <rect x="649" y="77" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="659" y="97">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m72 0 h10 m20 0 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m60 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m52 0 h10 m0 0 h10 m66 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -76 h-3"/>
+   <polygon points="737 17 745 13 745 21"/>
+   <polygon points="737 17 729 13 729 21"/>
+</svg>

--- a/server/.gitbook/assets/start-transaction-property-railroad.svg
+++ b/server/.gitbook/assets/start-transaction-property-railroad.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="401" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="58" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">WITH</text>
+   <rect x="129" y="3" width="108" height="32" rx="10"/>
+   <rect x="127"
+         y="1"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="137" y="21">CONSISTENT</text>
+   <rect x="257" y="3" width="96" height="32" rx="10"/>
+   <rect x="255"
+         y="1"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="21">SNAPSHOT</text>
+   <rect x="51" y="47" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">READ</text>
+   <rect x="147" y="47" width="66" height="32" rx="10"/>
+   <rect x="145"
+         y="45"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="65">WRITE</text>
+   <rect x="147" y="91" width="58" height="32" rx="10"/>
+   <rect x="145"
+         y="89"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="109">ONLY</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m58 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m96 0 h10 m-342 0 h20 m322 0 h20 m-362 0 q10 0 10 10 m342 0 q0 -10 10 -10 m-352 10 v24 m342 0 v-24 m-342 24 q0 10 10 10 m322 0 q10 0 10 -10 m-332 10 h10 m56 0 h10 m20 0 h10 m66 0 h10 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m58 0 h10 m0 0 h8 m20 -44 h120 m23 -44 h-3"/>
+   <polygon points="391 17 399 13 399 21"/>
+   <polygon points="391 17 383 13 383 21"/>
+</svg>

--- a/server/.gitbook/assets/start-transaction-railroad.svg
+++ b/server/.gitbook/assets/start-transaction-railroad.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="557" height="179">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="51" y="47" width="64" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">START</text>
+   <rect x="135" y="47" width="120" height="32" rx="10"/>
+   <rect x="133"
+         y="45"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="65">TRANSACTION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#transaction_property"
+      xlink:title="transaction_property">
+      <rect x="315" y="47" width="154" height="32"/>
+      <rect x="313" y="45" width="154" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="323" y="65">transaction_property</text>
+   </a>
+   <rect x="315" y="3" width="24" height="32" rx="10"/>
+   <rect x="313"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="323" y="21">,</text>
+   <rect x="51" y="113" width="64" height="32" rx="10"/>
+   <rect x="49"
+         y="111"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="131">BEGIN</text>
+   <rect x="155" y="145" width="64" height="32" rx="10"/>
+   <rect x="153"
+         y="143"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="163">WORK</text>
+   <path class="line"
+         d="m17 61 h2 m20 0 h10 m64 0 h10 m0 0 h10 m120 0 h10 m40 0 h10 m154 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m-214 44 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v14 m234 0 v-14 m-234 14 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m0 0 h204 m-478 -34 h20 m478 0 h20 m-518 0 q10 0 10 10 m498 0 q0 -10 10 -10 m-508 10 v46 m498 0 v-46 m-498 46 q0 10 10 10 m478 0 q10 0 10 -10 m-488 10 h10 m64 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h270 m23 -66 h-3"/>
+   <polygon points="547 61 555 57 555 65"/>
+   <polygon points="547 61 539 57 539 65"/>
+</svg>

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-databases.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-databases.md
@@ -13,6 +13,8 @@ SHOW {DATABASES | SCHEMAS}
     [LIKE 'pattern' | WHERE expr]
 ```
 
+![Railroad diagram of SHOW DATABASES — equivalent to the BNF above](../../../../.gitbook/assets/show-databases-railroad.svg)
+
 ## Description
 
 `SHOW DATABASES` lists the databases on the MariaDB server host.`SHOW SCHEMAS` is a synonym for`SHOW DATABASES`. The `LIKE` clause, if present on its own, indicates which database names to match. The `WHERE` and `LIKE` clauses can be given to select rows using more general conditions, as discussed in [Extended SHOW](extended-show.md).

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-tables.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-tables.md
@@ -13,6 +13,8 @@ SHOW [FULL] TABLES [FROM db_name]
     [LIKE 'pattern' | WHERE expr]
 ```
 
+![Railroad diagram of SHOW TABLES — equivalent to the BNF above](../../../../.gitbook/assets/show-tables-railroad.svg)
+
 ## Description
 
 {% tabs %}

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/replace.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/replace.md
@@ -20,6 +20,10 @@ REPLACE [LOW_PRIORITY | DELAYED]
       [, select_expr ...]]
 ```
 
+![Railroad diagram of REPLACE — equivalent to the BNF above](../../../../.gitbook/assets/replace-railroad.svg)
+
+![Railroad diagram of value_list](../../../../.gitbook/assets/replace-value-list-railroad.svg)
+
 Or:
 
 ```sql

--- a/server/reference/sql-statements/table-statements/analyze-table.md
+++ b/server/reference/sql-statements/table-statements/analyze-table.md
@@ -17,6 +17,8 @@ ANALYZE [NO_WRITE_TO_BINLOG | LOCAL] TABLE tbl_name [,tbl_name ...]
   ]
 ```
 
+![Railroad diagram of ANALYZE TABLE — equivalent to the BNF above](../../../.gitbook/assets/analyze-table-railroad.svg)
+
 ## Description
 
 `ANALYZE TABLE` analyzes and stores the key distribution for a table ([index statistics](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/index-statistics.md)). This statement works with [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/), [Aria](../../../server-usage/storage-engines/aria/), and [InnoDB](../../../server-usage/storage-engines/innodb/) tables. During the analysis, InnoDB will allow reads/writes, and MyISAM/Aria reads/inserts. For MyISAM tables, this statement is equivalent to using [myisamchk --analyze](../../../clients-and-utilities/myisam-clients-and-utilities/myisamchk.md).

--- a/server/reference/sql-statements/transactions/start-transaction.md
+++ b/server/reference/sql-statements/transactions/start-transaction.md
@@ -21,6 +21,18 @@ transaction_property:
   | READ ONLY
 ```
 
+The BNF above documents four related statements together; each gets its own diagram below.
+
+![Railroad diagram of START TRANSACTION / BEGIN](../../../.gitbook/assets/start-transaction-railroad.svg)
+
+![Railroad diagram of COMMIT](../../../.gitbook/assets/commit-railroad.svg)
+
+![Railroad diagram of ROLLBACK](../../../.gitbook/assets/rollback-railroad.svg)
+
+![Railroad diagram of SET autocommit](../../../.gitbook/assets/set-autocommit-railroad.svg)
+
+![Railroad diagram of transaction_property](../../../.gitbook/assets/start-transaction-property-railroad.svg)
+
 ## Description
 
 The `START TRANSACTION` or `BEGIN` statement begins a new transaction. [COMMIT](commit.md) commits the current transaction, making its changes permanent. [ROLLBACK](rollback.md) rolls back the current transaction, canceling its changes. The [SET](../programmatic-compound-statements/set-variable.md) [autocommit](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#autocommit) statement disables or enables the default autocommit mode for the current session.


### PR DESCRIPTION
## Summary

Batch 6 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. **First batch drawing from GA ranks 51+** — the original top-50 list is exhausted of non-trivial undone pages (CREATE TABLE excepted, deferred earlier for structural reasons).

Refreshed the GA cross-reference from the existing sheet ([Page views server space Jan–Jun 2026](https://docs.google.com/spreadsheets/d/1miBXjkjfC3uISZrk58qLrqDz4HumtXhgZ4J_NyErcOE/)) and ranked the 95 remaining BNF-containing pages with non-zero traffic. This batch picks 5 with structural variety; skipping repetitive 2-form "alternative-syntax" pages (UNIX_TIMESTAMP, IFNULL, INT, etc.) where a diagram would just show a choice between two boxes.

## Pages

| Page | New rank | Views | Diagrams |
|---|---:|---:|---|
| [SHOW TABLES](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-tables) | 2 | 379 | top-level |
| [SHOW DATABASES](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-databases) | 3 | 343 | top-level |
| [ANALYZE TABLE](https://mariadb.com/docs/server/reference/sql-statements/table-statements/analyze-table) | 6 | 234 | top-level |
| [REPLACE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/replace) | 9 | 211 | top-level + `value_list` |
| [START TRANSACTION](https://mariadb.com/docs/server/reference/sql-statements/transactions/start-transaction) | 11 | 210 | 5 top-level diagrams + `transaction_property` |

10 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## START TRANSACTION — five top-level diagrams

The page's `## Syntax` BNF block documents four related statements together (START TRANSACTION / BEGIN, COMMIT, ROLLBACK, SET autocommit), plus the `transaction_property` sub-rule. Each gets its own top-level diagram so readers see them side by side, matching the source layout.

## No source-BNF cleanups this batch

All five pages have clean BNFs that translate directly.

## Tally and remaining work

After this PR lands: **30 pages diagrammed**.

- 1 prototype: ALTER TABLE (#545)
- 5 batch 1: CREATE DATABASE, INSERT, UPDATE, DELETE, CREATE VIEW (#552)
- 5 batch 2 (4 + 1 cross-ref): SET PASSWORD, LOAD DATA INFILE, CREATE TRIGGER, SELECT INTO OUTFILE, INSERT … ON DUPLICATE KEY UPDATE *(cross-ref)* (#561)
- 6 batch 3: OPTIMIZE TABLE, INSERT … ON DUPLICATE KEY UPDATE *(real)*, FLUSH, Generated Columns, PURGE BINARY LOGS, CASE statement (#562)
- 5 batch 4: CREATE PROCEDURE, CHANGE MASTER TO, CREATE INDEX, CONSTRAINT, CREATE FUNCTION (#563)
- 4 batch 5: GRANT, CREATE USER, ALTER USER, SELECT (#564)
- 5 this batch: SHOW TABLES, SHOW DATABASES, ANALYZE TABLE, REPLACE, START TRANSACTION

Roughly **~20 more pages** to reach the ~50 target. Next batches will continue from the GA rank-51+ list.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] START TRANSACTION shows all five top-level diagrams plus `transaction_property` in sequence.
- [ ] All 10 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ