### PR TITLE
DOCS-5614 add Railroad diagrams to 6 more SQL pages

### DIFF
--- a/server/.gitbook/assets/create-sequence-railroad.svg
+++ b/server/.gitbook/assets/create-sequence-railroad.svg
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="979" height="751">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="72" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">CREATE</text>
+   <rect x="145" y="35" width="40" height="32" rx="10"/>
+   <rect x="143"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="153" y="53">OR</text>
+   <rect x="205" y="35" width="80" height="32" rx="10"/>
+   <rect x="203"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="213" y="53">REPLACE</text>
+   <rect x="345" y="35" width="104" height="32" rx="10"/>
+   <rect x="343"
+         y="33"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="53">TEMPORARY</text>
+   <rect x="489" y="3" width="92" height="32" rx="10"/>
+   <rect x="487"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="497" y="21">SEQUENCE</text>
+   <rect x="621" y="35" width="34" height="32" rx="10"/>
+   <rect x="619"
+         y="33"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="629" y="53">IF</text>
+   <rect x="675" y="35" width="48" height="32" rx="10"/>
+   <rect x="673"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="683" y="53">NOT</text>
+   <rect x="743" y="35" width="70" height="32" rx="10"/>
+   <rect x="741"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="751" y="53">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#sequence_name"
+      xlink:title="sequence_name">
+      <rect x="51" y="101" width="124" height="32"/>
+      <rect x="49" y="99" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="119">sequence_name</text>
+   </a>
+   <rect x="215" y="133" width="38" height="32" rx="10"/>
+   <rect x="213"
+         y="131"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="151">AS</text>
+   <rect x="293" y="133" width="78" height="32" rx="10"/>
+   <rect x="291"
+         y="131"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="151">TINYINT</text>
+   <rect x="293" y="177" width="90" height="32" rx="10"/>
+   <rect x="291"
+         y="175"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="195">SMALLINT</text>
+   <rect x="293" y="221" width="102" height="32" rx="10"/>
+   <rect x="291"
+         y="219"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="239">MEDIUMINT</text>
+   <rect x="293" y="265" width="44" height="32" rx="10"/>
+   <rect x="291"
+         y="263"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="283">INT</text>
+   <rect x="293" y="309" width="80" height="32" rx="10"/>
+   <rect x="291"
+         y="307"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="327">INTEGER</text>
+   <rect x="293" y="353" width="70" height="32" rx="10"/>
+   <rect x="291"
+         y="351"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="301" y="371">BIGINT</text>
+   <rect x="455" y="165" width="72" height="32" rx="10"/>
+   <rect x="453"
+         y="163"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="183">SIGNED</text>
+   <rect x="455" y="209" width="92" height="32" rx="10"/>
+   <rect x="453"
+         y="207"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="227">UNSIGNED</text>
+   <rect x="627" y="133" width="100" height="32" rx="10"/>
+   <rect x="625"
+         y="131"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="635" y="151">INCREMENT</text>
+   <rect x="767" y="165" width="38" height="32" rx="10"/>
+   <rect x="765"
+         y="163"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="775" y="183">BY</text>
+   <rect x="767" y="209" width="30" height="32" rx="10"/>
+   <rect x="765"
+         y="207"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="775" y="227">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="845" y="133" width="68" height="32"/>
+      <rect x="843" y="131" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="853" y="151">number</text>
+   </a>
+   <rect x="191" y="435" width="92" height="32" rx="10"/>
+   <rect x="189"
+         y="433"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="453">MINVALUE</text>
+   <rect x="323" y="467" width="30" height="32" rx="10"/>
+   <rect x="321"
+         y="465"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="331" y="485">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="393" y="435" width="68" height="32"/>
+      <rect x="391" y="433" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="401" y="453">number</text>
+   </a>
+   <rect x="191" y="511" width="40" height="32" rx="10"/>
+   <rect x="189"
+         y="509"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="529">NO</text>
+   <rect x="251" y="511" width="92" height="32" rx="10"/>
+   <rect x="249"
+         y="509"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="259" y="529">MINVALUE</text>
+   <rect x="191" y="555" width="112" height="32" rx="10"/>
+   <rect x="189"
+         y="553"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="573">NOMINVALUE</text>
+   <rect x="521" y="435" width="94" height="32" rx="10"/>
+   <rect x="519"
+         y="433"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="529" y="453">MAXVALUE</text>
+   <rect x="655" y="467" width="30" height="32" rx="10"/>
+   <rect x="653"
+         y="465"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="663" y="485">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="725" y="435" width="68" height="32"/>
+      <rect x="723" y="433" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="733" y="453">number</text>
+   </a>
+   <rect x="521" y="511" width="40" height="32" rx="10"/>
+   <rect x="519"
+         y="509"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="529" y="529">NO</text>
+   <rect x="581" y="511" width="94" height="32" rx="10"/>
+   <rect x="579"
+         y="509"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="589" y="529">MAXVALUE</text>
+   <rect x="521" y="555" width="114" height="32" rx="10"/>
+   <rect x="519"
+         y="553"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="529" y="573">NOMAXVALUE</text>
+   <rect x="45" y="641" width="64" height="32" rx="10"/>
+   <rect x="43"
+         y="639"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="659">START</text>
+   <rect x="149" y="673" width="58" height="32" rx="10"/>
+   <rect x="147"
+         y="671"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="691">WITH</text>
+   <rect x="149" y="717" width="30" height="32" rx="10"/>
+   <rect x="147"
+         y="715"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="157" y="735">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="247" y="641" width="68" height="32"/>
+      <rect x="245" y="639" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="255" y="659">number</text>
+   </a>
+   <rect x="375" y="641" width="66" height="32" rx="10"/>
+   <rect x="373"
+         y="639"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="659">CACHE</text>
+   <rect x="481" y="673" width="30" height="32" rx="10"/>
+   <rect x="479"
+         y="671"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="489" y="691">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#number"
+      xlink:title="number">
+      <rect x="551" y="641" width="68" height="32"/>
+      <rect x="549" y="639" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="559" y="659">number</text>
+   </a>
+   <rect x="375" y="717" width="86" height="32" rx="10"/>
+   <rect x="373"
+         y="715"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="735">NOCACHE</text>
+   <rect x="679" y="641" width="62" height="32" rx="10"/>
+   <rect x="677"
+         y="639"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="687" y="659">CYCLE</text>
+   <rect x="679" y="685" width="84" height="32" rx="10"/>
+   <rect x="677"
+         y="683"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="687" y="703">NOCYCLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#table_options"
+      xlink:title="table_options">
+      <rect x="823" y="641" width="108" height="32"/>
+      <rect x="821" y="639" width="108" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="831" y="659">table_options</text>
+   </a>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h114 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v12 m144 0 v-12 m-144 12 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m20 -32 h10 m92 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-826 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m20 0 h10 m0 0 h362 m-392 0 h20 m372 0 h20 m-412 0 q10 0 10 10 m392 0 q0 -10 10 -10 m-402 10 v12 m392 0 v-12 m-392 12 q0 10 10 10 m372 0 q10 0 10 -10 m-382 10 h10 m38 0 h10 m20 0 h10 m78 0 h10 m0 0 h24 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m90 0 h10 m0 0 h12 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m44 0 h10 m0 0 h58 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m80 0 h10 m0 0 h22 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m70 0 h10 m0 0 h32 m40 -220 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m72 0 h10 m0 0 h20 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m60 -108 h10 m0 0 h296 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v12 m326 0 v-12 m-326 12 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m100 0 h10 m20 0 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m30 0 h10 m0 0 h8 m20 -76 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-806 302 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h280 m-310 0 h20 m290 0 h20 m-330 0 q10 0 10 10 m310 0 q0 -10 10 -10 m-320 10 v12 m310 0 v-12 m-310 12 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m92 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m68 0 h10 m-300 -10 v20 m310 0 v-20 m-310 20 v56 m310 0 v-56 m-310 56 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m40 0 h10 m0 0 h10 m92 0 h10 m0 0 h118 m-300 -10 v20 m310 0 v-20 m-310 20 v24 m310 0 v-24 m-310 24 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m112 0 h10 m0 0 h158 m40 -152 h10 m0 0 h282 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v12 m312 0 v-12 m-312 12 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m94 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m68 0 h10 m-302 -10 v20 m312 0 v-20 m-312 20 v56 m312 0 v-56 m-312 56 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h118 m-302 -10 v20 m312 0 v-20 m-312 20 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m114 0 h10 m0 0 h158 m22 -152 l2 0 m2 0 l2 0 m2 0 l2 0 m-832 206 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h280 m-310 0 h20 m290 0 h20 m-330 0 q10 0 10 10 m310 0 q0 -10 10 -10 m-320 10 v12 m310 0 v-12 m-310 12 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m64 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m30 0 h10 m0 0 h28 m20 -76 h10 m68 0 h10 m40 -32 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m66 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m68 0 h10 m-274 -10 v20 m284 0 v-20 m-284 20 v56 m284 0 v-56 m-284 56 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m86 0 h10 m0 0 h158 m40 -108 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m62 0 h10 m0 0 h22 m-114 -10 v20 m124 0 v-20 m-124 20 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m40 -76 h10 m0 0 h118 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v12 m148 0 v-12 m-148 12 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m108 0 h10 m23 -32 h-3"/>
+   <polygon points="969 623 977 619 977 627"/>
+   <polygon points="969 623 961 619 961 627"/>
+</svg>

--- a/server/.gitbook/assets/json-table-railroad.svg
+++ b/server/.gitbook/assets/json-table-railroad.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="927" height="135">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="108" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="108"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">JSON_TABLE</text>
+   <rect x="159" y="3" width="26" height="32" rx="10"/>
+   <rect x="157"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#json_doc"
+      xlink:title="json_doc">
+      <rect x="205" y="3" width="76" height="32"/>
+      <rect x="203" y="1" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="213" y="21">json_doc</text>
+   </a>
+   <rect x="301" y="3" width="24" height="32" rx="10"/>
+   <rect x="299"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="309" y="21">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#context_path"
+      xlink:title="context_path">
+      <rect x="345" y="3" width="104" height="32"/>
+      <rect x="343" y="1" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="353" y="21">context_path</text>
+   </a>
+   <rect x="469" y="3" width="88" height="32" rx="10"/>
+   <rect x="467"
+         y="1"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="477" y="21">COLUMNS</text>
+   <rect x="577" y="3" width="26" height="32" rx="10"/>
+   <rect x="575"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="585" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_list"
+      xlink:title="column_list">
+      <rect x="623" y="3" width="92" height="32"/>
+      <rect x="621" y="1" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="631" y="21">column_list</text>
+   </a>
+   <rect x="735" y="3" width="26" height="32" rx="10"/>
+   <rect x="733"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="743" y="21">)</text>
+   <rect x="781" y="3" width="26" height="32" rx="10"/>
+   <rect x="779"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="789" y="21">)</text>
+   <rect x="847" y="35" width="38" height="32" rx="10"/>
+   <rect x="845"
+         y="33"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="855" y="53">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#alias"
+      xlink:title="alias">
+      <rect x="849" y="101" width="50" height="32"/>
+      <rect x="847" y="99" width="50" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="857" y="119">alias</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m104 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-100 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m50 0 h10 m3 0 h-3"/>
+   <polygon points="917 115 925 111 925 119"/>
+   <polygon points="917 115 909 111 909 119"/>
+</svg>

--- a/server/.gitbook/assets/lock-tables-railroad.svg
+++ b/server/.gitbook/assets/lock-tables-railroad.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="861" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">LOCK</text>
+   <rect x="127" y="47" width="62" height="32" rx="10"/>
+   <rect x="125"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="65">TABLE</text>
+   <rect x="127" y="91" width="72" height="32" rx="10"/>
+   <rect x="125"
+         y="89"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="109">TABLES</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="259" y="47" width="80" height="32"/>
+      <rect x="257" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="267" y="65">tbl_name</text>
+   </a>
+   <rect x="399" y="111" width="38" height="32" rx="10"/>
+   <rect x="397"
+         y="109"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="407" y="129">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#alias"
+      xlink:title="alias">
+      <rect x="477" y="79" width="50" height="32"/>
+      <rect x="475" y="77" width="50" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="485" y="97">alias</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#lock_type"
+      xlink:title="lock_type">
+      <rect x="567" y="47" width="80" height="32"/>
+      <rect x="565" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="575" y="65">lock_type</text>
+   </a>
+   <rect x="259" y="3" width="24" height="32" rx="10"/>
+   <rect x="257"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="267" y="21">,</text>
+   <rect x="707" y="79" width="58" height="32" rx="10"/>
+   <rect x="705"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="97">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="785" y="79" width="28" height="32"/>
+      <rect x="783" y="77" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="793" y="97">n</text>
+   </a>
+   <rect x="707" y="123" width="78" height="32" rx="10"/>
+   <rect x="705"
+         y="121"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="141">NOWAIT</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m56 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -44 h10 m80 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-158 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m50 0 h10 m20 -32 h10 m80 0 h10 m-428 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m408 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-408 0 h10 m24 0 h10 m0 0 h364 m40 44 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m23 -76 h-3"/>
+   <polygon points="851 61 859 57 859 65"/>
+   <polygon points="851 61 843 57 843 65"/>
+</svg>

--- a/server/.gitbook/assets/lock-tables-type-railroad.svg
+++ b/server/.gitbook/assets/lock-tables-type-railroad.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="355" height="189">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">READ</text>
+   <rect x="147" y="35" width="64" height="32" rx="10"/>
+   <rect x="145"
+         y="33"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="53">LOCAL</text>
+   <rect x="71" y="111" width="130" height="32" rx="10"/>
+   <rect x="69"
+         y="109"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="129">LOW_PRIORITY</text>
+   <rect x="241" y="79" width="66" height="32" rx="10"/>
+   <rect x="239"
+         y="77"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="249" y="97">WRITE</text>
+   <rect x="51" y="155" width="66" height="32" rx="10"/>
+   <rect x="49"
+         y="153"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="173">WRITE</text>
+   <rect x="137" y="155" width="114" height="32" rx="10"/>
+   <rect x="135"
+         y="153"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="173">CONCURRENT</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m56 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h76 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v56 m296 0 v-56 m-296 56 q0 10 10 10 m276 0 q10 0 10 -10 m-266 10 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m20 -32 h10 m66 0 h10 m-286 -10 v20 m296 0 v-20 m-296 20 v56 m296 0 v-56 m-296 56 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m66 0 h10 m0 0 h10 m114 0 h10 m0 0 h56 m23 -152 h-3"/>
+   <polygon points="345 17 353 13 353 21"/>
+   <polygon points="345 17 337 13 337 21"/>
+</svg>

--- a/server/.gitbook/assets/rename-table-railroad.svg
+++ b/server/.gitbook/assets/rename-table-railroad.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="949" height="157">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">RENAME</text>
+   <rect x="147" y="47" width="62" height="32" rx="10"/>
+   <rect x="145"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="65">TABLE</text>
+   <rect x="147" y="91" width="72" height="32" rx="10"/>
+   <rect x="145"
+         y="89"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="109">TABLES</text>
+   <rect x="279" y="79" width="34" height="32" rx="10"/>
+   <rect x="277"
+         y="77"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="287" y="97">IF</text>
+   <rect x="333" y="79" width="70" height="32" rx="10"/>
+   <rect x="331"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="97">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="443" y="47" width="80" height="32"/>
+      <rect x="441" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="451" y="65">tbl_name</text>
+   </a>
+   <rect x="563" y="79" width="58" height="32" rx="10"/>
+   <rect x="561"
+         y="77"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="571" y="97">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="641" y="79" width="28" height="32"/>
+      <rect x="639" y="77" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="649" y="97">n</text>
+   </a>
+   <rect x="563" y="123" width="78" height="32" rx="10"/>
+   <rect x="561"
+         y="121"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="571" y="141">NOWAIT</text>
+   <rect x="729" y="47" width="38" height="32" rx="10"/>
+   <rect x="727"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="737" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#new_tbl_name"
+      xlink:title="new_tbl_name">
+      <rect x="787" y="47" width="114" height="32"/>
+      <rect x="785" y="45" width="114" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="795" y="65">new_tbl_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="729" y="3" width="80" height="32"/>
+      <rect x="727" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="737" y="21">tbl_name</text>
+   </a>
+   <rect x="829" y="3" width="24" height="32" rx="10"/>
+   <rect x="827"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="837" y="21">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m76 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -44 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m80 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m40 -76 h10 m38 0 h10 m0 0 h10 m114 0 h10 m-212 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m192 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-192 0 h10 m80 0 h10 m0 0 h10 m24 0 h10 m0 0 h48 m23 44 h-3"/>
+   <polygon points="939 61 947 57 947 65"/>
+   <polygon points="939 61 931 57 931 65"/>
+</svg>

--- a/server/.gitbook/assets/show-columns-railroad.svg
+++ b/server/.gitbook/assets/show-columns-railroad.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="983" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="35" width="54" height="32" rx="10"/>
+   <rect x="133"
+         y="33"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="53">FULL</text>
+   <rect x="249" y="3" width="88" height="32" rx="10"/>
+   <rect x="247"
+         y="1"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="21">COLUMNS</text>
+   <rect x="249" y="47" width="70" height="32" rx="10"/>
+   <rect x="247"
+         y="45"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="65">FIELDS</text>
+   <rect x="377" y="3" width="60" height="32" rx="10"/>
+   <rect x="375"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="385" y="21">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="457" y="3" width="80" height="32"/>
+      <rect x="455" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="465" y="21">tbl_name</text>
+   </a>
+   <rect x="577" y="35" width="60" height="32" rx="10"/>
+   <rect x="575"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="585" y="53">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#db_name"
+      xlink:title="db_name">
+      <rect x="657" y="35" width="80" height="32"/>
+      <rect x="655" y="33" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="665" y="53">db_name</text>
+   </a>
+   <rect x="797" y="35" width="52" height="32" rx="10"/>
+   <rect x="795"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="805" y="53">LIKE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#pattern"
+      xlink:title="pattern">
+      <rect x="869" y="35" width="66" height="32"/>
+      <rect x="867" y="33" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="877" y="53">pattern</text>
+   </a>
+   <rect x="797" y="79" width="70" height="32" rx="10"/>
+   <rect x="795"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="805" y="97">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="887" y="79" width="48" height="32"/>
+      <rect x="885" y="77" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="895" y="97">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m40 -32 h10 m88 0 h10 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m70 0 h10 m0 0 h18 m20 -44 h10 m60 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m60 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m52 0 h10 m0 0 h10 m66 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -76 h-3"/>
+   <polygon points="973 17 981 13 981 21"/>
+   <polygon points="973 17 965 13 965 21"/>
+</svg>

--- a/server/.gitbook/assets/unlock-tables-railroad.svg
+++ b/server/.gitbook/assets/unlock-tables-railroad.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="227" height="37">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">UNLOCK</text>
+   <rect x="127" y="3" width="72" height="32" rx="10"/>
+   <rect x="125"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="21">TABLES</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m72 0 h10 m3 0 h-3"/>
+   <polygon points="217 17 225 13 225 21"/>
+   <polygon points="217 17 209 13 209 21"/>
+</svg>

--- a/server/reference/sql-functions/special-functions/json-functions/json_table.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json_table.md
@@ -20,6 +20,8 @@ JSON_TABLE(json_doc,
 ) [AS] alias
 ```
 
+![Railroad diagram of JSON_TABLE — equivalent to the BNF above](../../../../.gitbook/assets/json-table-railroad.svg)
+
 ```sql
 column_list:
     column[, column][, ...]

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-columns.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-columns.md
@@ -13,6 +13,8 @@ SHOW [FULL] {COLUMNS | FIELDS} FROM tbl_name [FROM db_name]
     [LIKE 'pattern' | WHERE expr]
 ```
 
+![Railroad diagram of SHOW COLUMNS — equivalent to the BNF above](../../../../.gitbook/assets/show-columns-railroad.svg)
+
 ## Description
 
 `SHOW COLUMNS` displays information about the columns in a given table. It also works for views. The `LIKE` clause, if present on its own, indicates which column names to match. The `WHERE` and `LIKE` clauses can be given to select rows using more general conditions, as discussed in [Extended SHOW](extended-show.md).

--- a/server/reference/sql-statements/data-definition/rename-table.md
+++ b/server/reference/sql-statements/data-definition/rename-table.md
@@ -15,6 +15,8 @@ RENAME TABLE[S] [IF EXISTS] tbl_name
     [, tbl_name2 TO new_tbl_name2] ...
 ```
 
+![Railroad diagram of RENAME TABLE — equivalent to the BNF above](../../../.gitbook/assets/rename-table-railroad.svg)
+
 ## Description
 
 This statement renames one or more tables or [views](../../../server-usage/views/), but not the privileges associated with them. For InnoDB tables, it also triggers a reload of [InnoDB statistics](../../../ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/innodb-persistent-statistics.md).

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning.md
@@ -23,6 +23,10 @@ INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE]
       [, select_expr ...]]
 ```
 
+![Railroad diagram of INSERT (with RETURNING and ON DUPLICATE KEY UPDATE branches) — equivalent to the BNF above](../../../../.gitbook/assets/insert-railroad.svg)
+
+![Railroad diagram of value_list](../../../../.gitbook/assets/insert-value-list-railroad.svg)
+
 Or:
 
 ```sql

--- a/server/reference/sql-statements/transactions/lock-tables.md
+++ b/server/reference/sql-statements/transactions/lock-tables.md
@@ -23,6 +23,12 @@ lock_type:
 UNLOCK TABLES
 ```
 
+![Railroad diagram of LOCK TABLES](../../../.gitbook/assets/lock-tables-railroad.svg)
+
+![Railroad diagram of lock_type](../../../.gitbook/assets/lock-tables-type-railroad.svg)
+
+![Railroad diagram of UNLOCK TABLES](../../../.gitbook/assets/unlock-tables-railroad.svg)
+
 ## Description
 
 The _lock\_type_ can be one of:

--- a/server/reference/sql-structure/sequences/create-sequence.md
+++ b/server/reference/sql-structure/sequences/create-sequence.md
@@ -12,7 +12,7 @@ description: >-
 {% tab title="Current" %}
 ```bnf
 CREATE [OR REPLACE] [TEMPORARY] SEQUENCE [IF NOT EXISTS] sequence_name
-[AS { TINYINT | SMALLINT | |MEDIUMINT | INT | INTEGER | BIGINT } [SIGNED | UNSIGNED]]
+[AS { TINYINT | SMALLINT | MEDIUMINT | INT | INTEGER | BIGINT } [SIGNED | UNSIGNED]]
 [ INCREMENT [ BY | = ] number ]
 [ MINVALUE [=] number | NO MINVALUE | NOMINVALUE ]
 [ MAXVALUE [=] number | NO MAXVALUE | NOMAXVALUE ]
@@ -20,6 +20,9 @@ CREATE [OR REPLACE] [TEMPORARY] SEQUENCE [IF NOT EXISTS] sequence_name
 [ CACHE [=] number | NOCACHE ] [ CYCLE | NOCYCLE] 
 [table_options]
 ```
+
+![Railroad diagram of CREATE SEQUENCE — equivalent to the BNF above](../../../.gitbook/assets/create-sequence-railroad.svg)
+
 {% endtab %}
 
 {% tab title="< 11.5" %}


### PR DESCRIPTION
## Summary

Batch 7 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continuing from GA ranks 51+. **Six pages get diagrams; only five required fresh renders** — the sixth (INSERT RETURNING) reuses the existing INSERT diagram since the BNFs are identical.

## Pages

| Page | New rank | Views | Diagrams |
|---|---:|---:|---|
| [JSON_TABLE](https://mariadb.com/docs/server/reference/sql-functions/special-functions/json-functions/json_table) | 4 | 288 | top-level |
| [SHOW COLUMNS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-columns) | 5 | 236 | top-level |
| [RENAME TABLE](https://mariadb.com/docs/server/reference/sql-statements/data-definition/rename-table) | 13 | 204 | top-level |
| [LOCK TABLES](https://mariadb.com/docs/server/reference/sql-statements/transactions/lock-tables) | 15 | 202 | LOCK TABLES + lock_type + UNLOCK TABLES |
| [INSERT RETURNING](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning) | 18 | 191 | **reuses** `insert-railroad.svg` + `insert-value-list-railroad.svg` |
| [CREATE SEQUENCE](https://mariadb.com/docs/server/reference/sql-structure/sequences/create-sequence) | 25 | 150 | top-level |

7 SVGs new. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## INSERT RETURNING — diagram reuse

The page's `bnf` block is **character-for-character identical** to plain INSERT's BNF (the same `INSERT [LOW_PRIORITY | DELAYED | HIGH_PRIORITY] [IGNORE] ... [RETURNING select_expr [, select_expr ...]]`). Rendering a duplicate SVG would just create a maintenance burden. Instead the page embeds the existing `insert-railroad.svg` + `insert-value-list-railroad.svg` from batch 1 (PR #552), with an alt-text that calls out the RETURNING + ON DUPLICATE KEY UPDATE branches.

## Source-BNF cleanup folded in (CREATE SEQUENCE)

The page's AS-clause BNF read:

```
{ TINYINT | SMALLINT | |MEDIUMINT | INT | INTEGER | BIGINT }
```

with a stray empty alternative (`| |`) between `SMALLINT` and `MEDIUMINT`. Removed; the BNF now lists the 6 integer types cleanly. Diagram matches.

## Tally and remaining work

After this PR lands: **36 pages diagrammed**.

- 1 prototype + 5 + 5 + 6 + 5 + 4 + 5 + 6 = 36 across PR #545, #552, #561, #562, #563, #564, #565, and this one.

Roughly **~14 more pages** to reach the ~50 target. Continuing down the GA rank-51+ list in the next batches.

## Test plan

- [ ] GitBook preview renders each new diagram inline.
- [ ] CREATE SEQUENCE's AS-clause BNF no longer has the `| |` stray.
- [ ] INSERT RETURNING shows the embedded INSERT diagram (no broken image).
- [ ] All 7 new SVG references + 2 reused ones resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ