### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more SQL pages

### DIFF
--- a/server/.gitbook/assets/case-operator-searched-railroad.svg
+++ b/server/.gitbook/assets/case-operator-searched-railroad.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="783" height="85">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 33 1 29 1 37"/>
+   <polygon points="17 33 9 29 9 37"/>
+   <rect x="31" y="19" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="37">CASE</text>
+   <rect x="127" y="19" width="62" height="32" rx="10"/>
+   <rect x="125"
+         y="17"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="37">WHEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#condition"
+      xlink:title="condition">
+      <rect x="229" y="51" width="78" height="32"/>
+      <rect x="227" y="49" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="237" y="69">condition</text>
+   </a>
+   <rect x="347" y="19" width="56" height="32" rx="10"/>
+   <rect x="345"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="37">THEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#result"
+      xlink:title="result">
+      <rect x="423" y="19" width="56" height="32"/>
+      <rect x="421" y="17" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="431" y="37">result</text>
+   </a>
+   <rect x="539" y="51" width="52" height="32" rx="10"/>
+   <rect x="537"
+         y="49"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="547" y="69">ELSE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#result"
+      xlink:title="result">
+      <rect x="611" y="51" width="56" height="32"/>
+      <rect x="609" y="49" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="619" y="69">result</text>
+   </a>
+   <rect x="707" y="19" width="48" height="32" rx="10"/>
+   <rect x="705"
+         y="17"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="715" y="37">END</text>
+   <path class="line"
+         d="m17 33 h2 m0 0 h10 m56 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m56 0 h10 m-392 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m372 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-372 0 h10 m0 0 h362 m40 32 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m52 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m48 0 h10 m3 0 h-3"/>
+   <polygon points="773 33 781 29 781 37"/>
+   <polygon points="773 33 765 29 765 37"/>
+</svg>

--- a/server/.gitbook/assets/case-operator-simple-railroad.svg
+++ b/server/.gitbook/assets/case-operator-simple-railroad.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="895" height="85">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 33 1 29 1 37"/>
+   <polygon points="17 33 9 29 9 37"/>
+   <rect x="31" y="19" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="37">CASE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value"
+      xlink:title="value">
+      <rect x="107" y="19" width="54" height="32"/>
+      <rect x="105" y="17" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="115" y="37">value</text>
+   </a>
+   <rect x="201" y="19" width="62" height="32" rx="10"/>
+   <rect x="199"
+         y="17"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="209" y="37">WHEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#compare_value"
+      xlink:title="compare_value">
+      <rect x="303" y="51" width="116" height="32"/>
+      <rect x="301" y="49" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="311" y="69">compare_value</text>
+   </a>
+   <rect x="459" y="19" width="56" height="32" rx="10"/>
+   <rect x="457"
+         y="17"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="467" y="37">THEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#result"
+      xlink:title="result">
+      <rect x="535" y="19" width="56" height="32"/>
+      <rect x="533" y="17" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="543" y="37">result</text>
+   </a>
+   <rect x="651" y="51" width="52" height="32" rx="10"/>
+   <rect x="649"
+         y="49"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="659" y="69">ELSE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#result"
+      xlink:title="result">
+      <rect x="723" y="51" width="56" height="32"/>
+      <rect x="721" y="49" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="731" y="69">result</text>
+   </a>
+   <rect x="819" y="19" width="48" height="32" rx="10"/>
+   <rect x="817"
+         y="17"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="827" y="37">END</text>
+   <path class="line"
+         d="m17 33 h2 m0 0 h10 m56 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m56 0 h10 m-430 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m410 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-410 0 h10 m0 0 h400 m40 32 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m52 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m48 0 h10 m3 0 h-3"/>
+   <polygon points="885 33 893 29 893 37"/>
+   <polygon points="885 33 877 29 877 37"/>
+</svg>

--- a/server/.gitbook/assets/if-statement-railroad.svg
+++ b/server/.gitbook/assets/if-statement-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="855" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="34" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">IF</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#search_condition"
+      xlink:title="search_condition">
+      <rect x="105" y="47" width="128" height="32"/>
+      <rect x="103" y="45" width="128" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="113" y="65">search_condition</text>
+   </a>
+   <rect x="253" y="47" width="56" height="32" rx="10"/>
+   <rect x="251"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="261" y="65">THEN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#statement_list"
+      xlink:title="statement_list">
+      <rect x="329" y="47" width="112" height="32"/>
+      <rect x="327" y="45" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="337" y="65">statement_list</text>
+   </a>
+   <rect x="105" y="3" width="68" height="32" rx="10"/>
+   <rect x="103"
+         y="1"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="21">ELSEIF</text>
+   <rect x="501" y="79" width="52" height="32" rx="10"/>
+   <rect x="499"
+         y="77"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="509" y="97">ELSE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#statement_list"
+      xlink:title="statement_list">
+      <rect x="573" y="79" width="112" height="32"/>
+      <rect x="571" y="77" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="581" y="97">statement_list</text>
+   </a>
+   <rect x="725" y="47" width="48" height="32" rx="10"/>
+   <rect x="723"
+         y="45"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="733" y="65">END</text>
+   <rect x="793" y="47" width="34" height="32" rx="10"/>
+   <rect x="791"
+         y="45"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="801" y="65">IF</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m34 0 h10 m20 0 h10 m128 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m112 0 h10 m-376 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m356 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-356 0 h10 m68 0 h10 m0 0 h268 m40 44 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m52 0 h10 m0 0 h10 m112 0 h10 m20 -32 h10 m48 0 h10 m0 0 h10 m34 0 h10 m3 0 h-3"/>
+   <polygon points="845 61 853 57 853 65"/>
+   <polygon points="845 61 837 57 837 65"/>
+</svg>

--- a/server/.gitbook/assets/insert-select-railroad.svg
+++ b/server/.gitbook/assets/insert-select-railroad.svg
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="939" height="283">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="70" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">INSERT</text>
+   <rect x="141" y="79" width="130" height="32" rx="10"/>
+   <rect x="139"
+         y="77"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="97">LOW_PRIORITY</text>
+   <rect x="141" y="123" width="134" height="32" rx="10"/>
+   <rect x="139"
+         y="121"
+         width="134"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="141">HIGH_PRIORITY</text>
+   <rect x="335" y="79" width="74" height="32" rx="10"/>
+   <rect x="333"
+         y="77"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="97">IGNORE</text>
+   <rect x="469" y="79" width="56" height="32" rx="10"/>
+   <rect x="467"
+         y="77"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="477" y="97">INTO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="565" y="47" width="80" height="32"/>
+      <rect x="563" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="573" y="65">tbl_name</text>
+   </a>
+   <rect x="685" y="47" width="26" height="32" rx="10"/>
+   <rect x="683"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="693" y="65">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="751" y="47" width="80" height="32"/>
+      <rect x="749" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="759" y="65">col_name</text>
+   </a>
+   <rect x="751" y="3" width="24" height="32" rx="10"/>
+   <rect x="749"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="759" y="21">,</text>
+   <rect x="871" y="47" width="26" height="32" rx="10"/>
+   <rect x="869"
+         y="45"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="879" y="65">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#select_statement"
+      xlink:title="select_statement">
+      <rect x="145" y="233" width="130" height="32"/>
+      <rect x="143" y="231" width="130" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="153" y="251">select_statement</text>
+   </a>
+   <rect x="315" y="233" width="40" height="32" rx="10"/>
+   <rect x="313"
+         y="231"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="323" y="251">ON</text>
+   <rect x="375" y="233" width="98" height="32" rx="10"/>
+   <rect x="373"
+         y="231"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="251">DUPLICATE</text>
+   <rect x="493" y="233" width="46" height="32" rx="10"/>
+   <rect x="491"
+         y="231"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="501" y="251">KEY</text>
+   <rect x="559" y="233" width="74" height="32" rx="10"/>
+   <rect x="557"
+         y="231"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="567" y="251">UPDATE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="673" y="233" width="80" height="32"/>
+      <rect x="671" y="231" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="681" y="251">col_name</text>
+   </a>
+   <rect x="773" y="233" width="30" height="32" rx="10"/>
+   <rect x="771"
+         y="231"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="781" y="251">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="823" y="233" width="48" height="32"/>
+      <rect x="821" y="231" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="831" y="251">expr</text>
+   </a>
+   <rect x="673" y="189" width="24" height="32" rx="10"/>
+   <rect x="671"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="681" y="207">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m130 0 h10 m0 0 h4 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m40 -76 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -32 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m80 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-816 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m130 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-238 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m218 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-218 0 h10 m24 0 h10 m0 0 h174 m-596 44 h20 m596 0 h20 m-636 0 q10 0 10 10 m616 0 q0 -10 10 -10 m-626 10 v14 m616 0 v-14 m-616 14 q0 10 10 10 m596 0 q10 0 10 -10 m-606 10 h10 m0 0 h586 m23 -34 h-3"/>
+   <polygon points="929 247 937 243 937 251"/>
+   <polygon points="929 247 921 243 921 251"/>
+</svg>

--- a/server/.gitbook/assets/now-railroad.svg
+++ b/server/.gitbook/assets/now-railroad.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="581" height="201">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="54" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">NOW</text>
+   <rect x="125" y="3" width="26" height="32" rx="10"/>
+   <rect x="123"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="133" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#precision"
+      xlink:title="precision">
+      <rect x="191" y="35" width="76" height="32"/>
+      <rect x="189" y="33" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="199" y="53">precision</text>
+   </a>
+   <rect x="307" y="3" width="26" height="32" rx="10"/>
+   <rect x="305"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="21">)</text>
+   <rect x="71" y="79" width="174" height="32" rx="10"/>
+   <rect x="69"
+         y="77"
+         width="174"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="97">CURRENT_TIMESTAMP</text>
+   <rect x="71" y="123" width="100" height="32" rx="10"/>
+   <rect x="69"
+         y="121"
+         width="100"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="141">LOCALTIME</text>
+   <rect x="71" y="167" width="146" height="32" rx="10"/>
+   <rect x="69"
+         y="165"
+         width="146"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="185">LOCALTIMESTAMP</text>
+   <rect x="305" y="111" width="26" height="32" rx="10"/>
+   <rect x="303"
+         y="109"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="129">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#precision"
+      xlink:title="precision">
+      <rect x="371" y="143" width="76" height="32"/>
+      <rect x="369" y="141" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="379" y="161">precision</text>
+   </a>
+   <rect x="487" y="111" width="26" height="32" rx="10"/>
+   <rect x="485"
+         y="109"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="495" y="129">)</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m20 -32 h10 m26 0 h10 m0 0 h200 m-522 0 h20 m502 0 h20 m-542 0 q10 0 10 10 m522 0 q0 -10 10 -10 m-532 10 v56 m522 0 v-56 m-522 56 q0 10 10 10 m502 0 q10 0 10 -10 m-492 10 h10 m174 0 h10 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v24 m214 0 v-24 m-214 24 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m100 0 h10 m0 0 h74 m-204 -10 v20 m214 0 v-20 m-214 20 v24 m214 0 v-24 m-214 24 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m146 0 h10 m0 0 h28 m40 -88 h10 m0 0 h218 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v12 m248 0 v-12 m-248 12 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m26 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m20 -32 h10 m26 0 h10 m43 -108 h-3"/>
+   <polygon points="571 17 579 13 579 21"/>
+   <polygon points="571 17 563 13 563 21"/>
+</svg>

--- a/server/.gitbook/assets/row-number-railroad.svg
+++ b/server/.gitbook/assets/row-number-railroad.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="775" height="167">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="120" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ROW_NUMBER</text>
+   <rect x="171" y="3" width="26" height="32" rx="10"/>
+   <rect x="169"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="179" y="21">(</text>
+   <rect x="217" y="3" width="26" height="32" rx="10"/>
+   <rect x="215"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="21">)</text>
+   <rect x="263" y="3" width="58" height="32" rx="10"/>
+   <rect x="261"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="271" y="21">OVER</text>
+   <rect x="341" y="3" width="26" height="32" rx="10"/>
+   <rect x="339"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="21">(</text>
+   <rect x="407" y="35" width="98" height="32" rx="10"/>
+   <rect x="405"
+         y="33"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="415" y="53">PARTITION</text>
+   <rect x="525" y="35" width="38" height="32" rx="10"/>
+   <rect x="523"
+         y="33"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="533" y="53">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_expression"
+      xlink:title="partition_expression">
+      <rect x="583" y="35" width="150" height="32"/>
+      <rect x="581" y="33" width="150" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="591" y="53">partition_expression</text>
+   </a>
+   <rect x="455" y="133" width="68" height="32" rx="10"/>
+   <rect x="453"
+         y="131"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="151">ORDER</text>
+   <rect x="543" y="133" width="38" height="32" rx="10"/>
+   <rect x="541"
+         y="131"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="551" y="151">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_list"
+      xlink:title="order_list">
+      <rect x="601" y="133" width="80" height="32"/>
+      <rect x="599" y="131" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="609" y="151">order_list</text>
+   </a>
+   <rect x="721" y="101" width="26" height="32" rx="10"/>
+   <rect x="719"
+         y="99"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="729" y="119">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m120 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m150 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-362 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h236 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v12 m266 0 v-12 m-266 12 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="765 115 773 111 773 119"/>
+   <polygon points="765 115 757 111 757 119"/>
+</svg>

--- a/server/reference/sql-functions/control-flow-functions/case-operator.md
+++ b/server/reference/sql-functions/control-flow-functions/case-operator.md
@@ -16,6 +16,12 @@ CASE WHEN [condition] THEN result [WHEN [condition] THEN result ...]
 [ELSE result] END
 ```
 
+The BNF documents the two CASE-operator forms (simple and searched); each gets its own diagram.
+
+![Railroad diagram of the simple CASE form](../../../.gitbook/assets/case-operator-simple-railroad.svg)
+
+![Railroad diagram of the searched CASE form](../../../.gitbook/assets/case-operator-searched-railroad.svg)
+
 ## Description
 
 The first version returns the result for the first `value=compare_value` comparison that is true. The second version returns the result for the first condition that is true. If there was no matching result value, the result after ELSE is returned, or NULL if there is no ELSE part.

--- a/server/reference/sql-functions/date-time-functions/now.md
+++ b/server/reference/sql-functions/date-time-functions/now.md
@@ -13,10 +13,13 @@ description: >-
 NOW([precision])
 CURRENT_TIMESTAMP
 CURRENT_TIMESTAMP([precision])
-LOCALTIME, LOCALTIME([precision])
+LOCALTIME
+LOCALTIME([precision])
 LOCALTIMESTAMP
 LOCALTIMESTAMP([precision])
 ```
+
+![Railroad diagram of NOW and synonyms — equivalent to the BNF above](../../../.gitbook/assets/now-railroad.svg)
 
 ## Description
 

--- a/server/reference/sql-functions/special-functions/window-functions/row_number.md
+++ b/server/reference/sql-functions/special-functions/window-functions/row_number.md
@@ -15,6 +15,8 @@ ROW_NUMBER() OVER (
 )
 ```
 
+![Railroad diagram of ROW_NUMBER — equivalent to the BNF above](../../../../.gitbook/assets/row-number-railroad.svg)
+
 ## Description
 
 `ROW_NUMBER()` is a [window function](./) that displays the number of a given row, starting at one and following the [ORDER BY](../../../sql-statements/data-manipulation/selecting-data/order-by.md) sequence of the window function, with identical values receiving different row numbers. It is similar to the [RANK()](rank.md) and [DENSE\_RANK()](dense_rank.md) functions except that in that function, identical values will receive the same rank for each result.

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select.md
@@ -15,6 +15,8 @@ INSERT [LOW_PRIORITY | HIGH_PRIORITY] [IGNORE]
     [ ON DUPLICATE KEY UPDATE col_name=expr, ... ]
 ```
 
+![Railroad diagram of INSERT ... SELECT — equivalent to the BNF above](../../../../.gitbook/assets/insert-select-railroad.svg)
+
 ## Description
 
 With `INSERT ... SELECT`, you can quickly insert many rows into a table from one or more other tables. For example:

--- a/server/reference/sql-statements/programmatic-compound-statements/if.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/if.md
@@ -12,8 +12,10 @@ description: >-
 IF search_condition THEN statement_list
     [ELSEIF search_condition THEN statement_list] ...
     [ELSE statement_list]
-END IF;
+END IF
 ```
+
+![Railroad diagram of the IF statement — equivalent to the BNF above](../../../.gitbook/assets/if-statement-railroad.svg)
 
 ## Description
 


### PR DESCRIPTION
## Summary

Batch 8 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continuing from GA ranks 51+.

## Pages

| Page | New rank | Views | Diagrams |
|---|---:|---:|---|
| [CASE operator](https://mariadb.com/docs/server/reference/sql-functions/control-flow-functions/case-operator) | 8 | 214 | simple + searched forms |
| [NOW](https://mariadb.com/docs/server/reference/sql-functions/date-time-functions/now) | 14 | 203 | top-level (covers NOW and its CURRENT_TIMESTAMP / LOCALTIME / LOCALTIMESTAMP synonyms) |
| [ROW_NUMBER](https://mariadb.com/docs/server/reference/sql-functions/special-functions/window-functions/row_number) | 16 | 193 | top-level (first window-function diagram in this rollout) |
| [INSERT SELECT](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select) | 17 | 192 | top-level |
| [IF statement](https://mariadb.com/docs/server/reference/sql-statements/programmatic-compound-statements/if) | 21 | 167 | top-level |

6 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## CASE operator — paired with the CASE statement

The page's `bnf` block documents both the **simple** form (`CASE value WHEN match THEN ...`) and the **searched** form (`CASE WHEN condition THEN ...`). Each gets its own top-level diagram. This parallels the CASE statement page (batch 3) where only the simple form lived in the `bnf` block; the CASE operator page is more complete and both forms get diagrammed here.

## Source-BNF cleanups folded in

- **NOW**: the line `LOCALTIME, LOCALTIME([precision])` is split into two lines (`LOCALTIME` and `LOCALTIME([precision])`) to match the pattern shown for `CURRENT_TIMESTAMP` and `LOCALTIMESTAMP` directly above and below it.
- **IF statement**: the source ended with `END IF;`. Dropped the stray trailing `;`, matching the BNF convention applied to CREATE TRIGGER in batch 2.

## Tally and remaining work

After this PR lands: **41 pages diagrammed**.

Roughly **9 more** to reach the ~50 target. Remaining candidates from GA rank-51+ include SHOW INDEX, SET command, SHOW VARIABLES, CREATE ROLE, LAG, SELECT INTO, SHOW TABLE STATUS, RANGE PARTITIONING TYPE.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] NOW's BNF block now lists `LOCALTIME` and `LOCALTIME([precision])` on separate lines.
- [ ] IF statement's BNF block ends with `END IF` (no trailing `;`).
- [ ] All 6 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ