### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more SQL pages

### DIFF
--- a/server/.gitbook/assets/range-partitioning-railroad.svg
+++ b/server/.gitbook/assets/range-partitioning-railroad.svg
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="775" height="245">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="98" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">PARTITION</text>
+   <rect x="151" y="3" width="38" height="32" rx="10"/>
+   <rect x="149"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="21">BY</text>
+   <rect x="209" y="3" width="66" height="32" rx="10"/>
+   <rect x="207"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="21">RANGE</text>
+   <rect x="295" y="3" width="26" height="32" rx="10"/>
+   <rect x="293"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="303" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partitioning_expression"
+      xlink:title="partitioning_expression">
+      <rect x="341" y="3" width="170" height="32"/>
+      <rect x="339" y="1" width="170" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="349" y="21">partitioning_expression</text>
+   </a>
+   <rect x="531" y="3" width="26" height="32" rx="10"/>
+   <rect x="529"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="539" y="21">)</text>
+   <rect x="577" y="3" width="26" height="32" rx="10"/>
+   <rect x="575"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="585" y="21">(</text>
+   <rect x="68" y="113" width="98" height="32" rx="10"/>
+   <rect x="66"
+         y="111"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="76" y="131">PARTITION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_name"
+      xlink:title="partition_name">
+      <rect x="186" y="113" width="116" height="32"/>
+      <rect x="184" y="111" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="194" y="131">partition_name</text>
+   </a>
+   <rect x="322" y="113" width="72" height="32" rx="10"/>
+   <rect x="320"
+         y="111"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="330" y="131">VALUES</text>
+   <rect x="414" y="113" width="54" height="32" rx="10"/>
+   <rect x="412"
+         y="111"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="422" y="131">LESS</text>
+   <rect x="488" y="113" width="58" height="32" rx="10"/>
+   <rect x="486"
+         y="111"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="496" y="131">THAN</text>
+   <rect x="566" y="113" width="26" height="32" rx="10"/>
+   <rect x="564"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="574" y="131">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#value"
+      xlink:title="value">
+      <rect x="612" y="113" width="54" height="32"/>
+      <rect x="610" y="111" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="620" y="131">value</text>
+   </a>
+   <rect x="686" y="113" width="26" height="32" rx="10"/>
+   <rect x="684"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="694" y="131">)</text>
+   <rect x="68" y="69" width="24" height="32" rx="10"/>
+   <rect x="66"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="76" y="87">,</text>
+   <rect x="45" y="211" width="24" height="32" rx="10"/>
+   <rect x="43"
+         y="209"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="229">,</text>
+   <rect x="89" y="211" width="98" height="32" rx="10"/>
+   <rect x="87"
+         y="209"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="229">PARTITION</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_name"
+      xlink:title="partition_name">
+      <rect x="207" y="211" width="116" height="32"/>
+      <rect x="205" y="209" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="215" y="229">partition_name</text>
+   </a>
+   <rect x="343" y="211" width="72" height="32" rx="10"/>
+   <rect x="341"
+         y="209"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="229">VALUES</text>
+   <rect x="435" y="211" width="54" height="32" rx="10"/>
+   <rect x="433"
+         y="209"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="443" y="229">LESS</text>
+   <rect x="509" y="211" width="58" height="32" rx="10"/>
+   <rect x="507"
+         y="209"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="517" y="229">THAN</text>
+   <rect x="587" y="211" width="94" height="32" rx="10"/>
+   <rect x="585"
+         y="209"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="595" y="229">MAXVALUE</text>
+   <rect x="721" y="179" width="26" height="32" rx="10"/>
+   <rect x="719"
+         y="177"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="729" y="197">)</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m170 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-599 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m-684 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m664 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-664 0 h10 m24 0 h10 m0 0 h620 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-751 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h646 m-676 0 h20 m656 0 h20 m-696 0 q10 0 10 10 m676 0 q0 -10 10 -10 m-686 10 v12 m676 0 v-12 m-676 12 q0 10 10 10 m656 0 q10 0 10 -10 m-666 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m94 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="765 193 773 189 773 197"/>
+   <polygon points="765 193 757 189 757 197"/>
+</svg>

--- a/server/.gitbook/assets/select-into-railroad.svg
+++ b/server/.gitbook/assets/select-into-railroad.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="597" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="70" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">SELECT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#col_name"
+      xlink:title="col_name">
+      <rect x="141" y="47" width="80" height="32"/>
+      <rect x="139" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="149" y="65">col_name</text>
+   </a>
+   <rect x="141" y="3" width="24" height="32" rx="10"/>
+   <rect x="139"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="149" y="21">,</text>
+   <rect x="261" y="47" width="56" height="32" rx="10"/>
+   <rect x="259"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="65">INTO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#var_name"
+      xlink:title="var_name">
+      <rect x="357" y="47" width="84" height="32"/>
+      <rect x="355" y="45" width="84" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="365" y="65">var_name</text>
+   </a>
+   <rect x="357" y="3" width="24" height="32" rx="10"/>
+   <rect x="355"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="365" y="21">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#table_expr"
+      xlink:title="table_expr">
+      <rect x="481" y="47" width="88" height="32"/>
+      <rect x="479" y="45" width="88" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="489" y="65">table_expr</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m56 0 h10 m20 0 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m104 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-104 0 h10 m24 0 h10 m0 0 h60 m20 44 h10 m88 0 h10 m3 0 h-3"/>
+   <polygon points="587 61 595 57 595 65"/>
+   <polygon points="587 61 579 57 579 65"/>
+</svg>

--- a/server/.gitbook/assets/set-railroad.svg
+++ b/server/.gitbook/assets/set-railroad.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="315" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="44" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">SET</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#variable_assignment"
+      xlink:title="variable_assignment">
+      <rect x="115" y="47" width="152" height="32"/>
+      <rect x="113" y="45" width="152" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="123" y="65">variable_assignment</text>
+   </a>
+   <rect x="115" y="3" width="24" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m44 0 h10 m20 0 h10 m152 0 h10 m-192 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m172 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-172 0 h10 m24 0 h10 m0 0 h128 m23 44 h-3"/>
+   <polygon points="305 61 313 57 313 65"/>
+   <polygon points="305 61 297 57 297 65"/>
+</svg>

--- a/server/.gitbook/assets/set-variable-assignment-railroad.svg
+++ b/server/.gitbook/assets/set-variable-assignment-railroad.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="289">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user_var_name"
+      xlink:title="user_var_name">
+      <rect x="51" y="3" width="120" height="32"/>
+      <rect x="49" y="1" width="120" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="21">user_var_name</text>
+   </a>
+   <rect x="71" y="79" width="74" height="32" rx="10"/>
+   <rect x="69"
+         y="77"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="97">GLOBAL</text>
+   <rect x="71" y="123" width="82" height="32" rx="10"/>
+   <rect x="69"
+         y="121"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="141">SESSION</text>
+   <rect x="71" y="167" width="90" height="32" rx="10"/>
+   <rect x="69"
+         y="165"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="185">@@global.</text>
+   <rect x="71" y="211" width="98" height="32" rx="10"/>
+   <rect x="69"
+         y="209"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="229">@@session.</text>
+   <rect x="71" y="255" width="44" height="32" rx="10"/>
+   <rect x="69"
+         y="253"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="273">@@</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#system_var_name"
+      xlink:title="system_var_name">
+      <rect x="209" y="47" width="138" height="32"/>
+      <rect x="207" y="45" width="138" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="217" y="65">system_var_name</text>
+   </a>
+   <rect x="387" y="3" width="30" height="32" rx="10"/>
+   <rect x="385"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="395" y="21">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="437" y="3" width="48" height="32"/>
+      <rect x="435" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="445" y="21">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h176 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v24 m336 0 v-24 m-336 24 q0 10 10 10 m316 0 q10 0 10 -10 m-306 10 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m74 0 h10 m0 0 h24 m-128 -10 v20 m138 0 v-20 m-138 20 v24 m138 0 v-24 m-138 24 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m82 0 h10 m0 0 h16 m-128 -10 v20 m138 0 v-20 m-138 20 v24 m138 0 v-24 m-138 24 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m90 0 h10 m0 0 h8 m-128 -10 v20 m138 0 v-20 m-138 20 v24 m138 0 v-24 m-138 24 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m-128 -10 v20 m138 0 v-20 m-138 20 v24 m138 0 v-24 m-138 24 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m44 0 h10 m0 0 h54 m20 -208 h10 m138 0 h10 m20 -44 h10 m30 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"/>
+   <polygon points="503 17 511 13 511 21"/>
+   <polygon points="503 17 495 13 495 21"/>
+</svg>

--- a/server/.gitbook/assets/show-index-railroad.svg
+++ b/server/.gitbook/assets/show-index-railroad.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="861" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="3" width="64" height="32" rx="10"/>
+   <rect x="133"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="21">INDEX</text>
+   <rect x="135" y="47" width="80" height="32" rx="10"/>
+   <rect x="133"
+         y="45"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="65">INDEXES</text>
+   <rect x="135" y="91" width="54" height="32" rx="10"/>
+   <rect x="133"
+         y="89"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="109">KEYS</text>
+   <rect x="255" y="3" width="60" height="32" rx="10"/>
+   <rect x="253"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="263" y="21">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="335" y="3" width="80" height="32"/>
+      <rect x="333" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="343" y="21">tbl_name</text>
+   </a>
+   <rect x="455" y="35" width="60" height="32" rx="10"/>
+   <rect x="453"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="463" y="53">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#db_name"
+      xlink:title="db_name">
+      <rect x="535" y="35" width="80" height="32"/>
+      <rect x="533" y="33" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="543" y="53">db_name</text>
+   </a>
+   <rect x="675" y="35" width="70" height="32" rx="10"/>
+   <rect x="673"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="683" y="53">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="765" y="35" width="48" height="32"/>
+      <rect x="763" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="773" y="53">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m64 0 h10 m0 0 h16 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m54 0 h10 m0 0 h26 m20 -88 h10 m60 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m60 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"/>
+   <polygon points="851 17 859 13 859 21"/>
+   <polygon points="851 17 843 13 843 21"/>
+</svg>

--- a/server/.gitbook/assets/show-variables-railroad.svg
+++ b/server/.gitbook/assets/show-variables-railroad.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="581" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="35" width="74" height="32" rx="10"/>
+   <rect x="133"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="53">GLOBAL</text>
+   <rect x="135" y="79" width="82" height="32" rx="10"/>
+   <rect x="133"
+         y="77"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="97">SESSION</text>
+   <rect x="257" y="3" width="98" height="32" rx="10"/>
+   <rect x="255"
+         y="1"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="21">VARIABLES</text>
+   <rect x="395" y="35" width="52" height="32" rx="10"/>
+   <rect x="393"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="403" y="53">LIKE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#pattern"
+      xlink:title="pattern">
+      <rect x="467" y="35" width="66" height="32"/>
+      <rect x="465" y="33" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="475" y="53">pattern</text>
+   </a>
+   <rect x="395" y="79" width="70" height="32" rx="10"/>
+   <rect x="393"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="403" y="97">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="485" y="79" width="48" height="32"/>
+      <rect x="483" y="77" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="493" y="97">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m74 0 h10 m0 0 h8 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -76 h10 m98 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m52 0 h10 m0 0 h10 m66 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -76 h-3"/>
+   <polygon points="571 17 579 13 579 21"/>
+   <polygon points="571 17 563 13 563 21"/>
+</svg>

--- a/server/reference/sql-statements/administrative-sql-statements/set-commands/set.md
+++ b/server/reference/sql-statements/administrative-sql-statements/set-commands/set.md
@@ -17,6 +17,10 @@ variable_assignment:
     | [@@global. | @@session. | @@]system_var_name = expr
 ```
 
+![Railroad diagram of SET](../../../../.gitbook/assets/set-railroad.svg)
+
+![Railroad diagram of variable_assignment](../../../../.gitbook/assets/set-variable-assignment-railroad.svg)
+
 One can also set a user variable in any expression with this syntax:
 
 ```

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-index.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-index.md
@@ -14,6 +14,8 @@ SHOW {INDEX | INDEXES | KEYS}
  [WHERE expr]
 ```
 
+![Railroad diagram of SHOW INDEX — equivalent to the BNF above](../../../../.gitbook/assets/show-index-railroad.svg)
+
 ## Description
 
 `SHOW INDEX` returns table index information. The format resembles that of the SQLStatistics call in ODBC.

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-variables.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-variables.md
@@ -13,6 +13,8 @@ SHOW [GLOBAL | SESSION] VARIABLES
     [LIKE 'pattern' | WHERE expr]
 ```
 
+![Railroad diagram of SHOW VARIABLES — equivalent to the BNF above](../../../../.gitbook/assets/show-variables-railroad.svg)
+
 ## Description
 
 `SHOW VARIABLES` shows the values of MariaDB [system variables](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md). This does not include user-defined variables - see [here](../../../sql-structure/sql-language-structure/user-defined-variables.md#viewing) for details on viewing those.

--- a/server/reference/sql-statements/programmatic-compound-statements/selectinto.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/selectinto.md
@@ -14,6 +14,8 @@ SELECT col_name [, col_name] ...
     table_expr
 ```
 
+![Railroad diagram of SELECT INTO — equivalent to the BNF above](../../../.gitbook/assets/select-into-railroad.svg)
+
 ## Description
 
 `SELECT ... INTO` enables selected columns to be stored directly into variables. No resultset is produced. The query should return a single row. If the query returns no rows, a warning with error code 1329 occurs (`No data`), and the variable values remain unchanged. If the query returns multiple rows, error 1172 occurs (Result consisted of more than one row). If it is possible that the statement may retrieve multiple rows, you can use`LIMIT 1` to limit the result set to a single row.

--- a/server/server-usage/partitioning-tables/partitioning-types/range-partitioning-type.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/range-partitioning-type.md
@@ -23,6 +23,8 @@ PARTITION BY RANGE (partitioning_expression)
 )
 ```
 
+![Railroad diagram of RANGE partitioning — equivalent to the BNF above](../../../.gitbook/assets/range-partitioning-railroad.svg)
+
 `PARTITION BY RANGE` indicates that the partitioning type is `RANGE`.
 
 * _`partitioning_expression`_ is an SQL expression that returns a value from each row. In the simplest cases, it is a column name. This value is used to determine which partition should contain a row.


### PR DESCRIPTION
## Summary

Batch 9 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continuing from GA ranks 51+.

## Pages

| Page | New rank | Views | Diagrams |
|---|---:|---:|---|
| [SHOW INDEX](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-index) | 19 | 187 | top-level. Completes the SHOW {TABLES | DATABASES | COLUMNS | INDEX} quartet. |
| [SET](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/set-commands/set) | 22 | 166 | top-level + `variable_assignment` |
| [SHOW VARIABLES](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-variables) | 23 | 157 | top-level |
| [RANGE Partitioning Type](https://mariadb.com/docs/server/server-usage/partitioning-tables/partitioning-types/range-partitioning-type) | 26 | 149 | top-level. First partitioning-related diagram in the rollout. |
| [SELECT INTO](https://mariadb.com/docs/server/reference/sql-statements/programmatic-compound-statements/selectinto) | 27 | 148 | top-level. The programmatic `SELECT … INTO var` form, distinct from SELECT INTO OUTFILE (batch 2). |

6 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

No source-BNF cleanups needed this batch — these are all clean.

## Tally and remaining work

After this PR lands: **46 pages diagrammed**.

**4 more to reach ~50.** Remaining obvious candidates from the top of the rank-51+ list: SHOW TABLE STATUS (146 views, 2 lines), CREATE ROLE (144, 3), LAG (142, 4). Plus ~80 lower-ranked candidates with non-trivial BNFs available if we want to keep going.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] SET's `variable_assignment` sub-diagram shows the three alternatives (user var, `[GLOBAL | SESSION]` system var, `@@global.` / `@@session.` / `@@` system var).
- [ ] All 6 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ