### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more SQL pages — reaches ~50 target

### DIFF
--- a/server/.gitbook/assets/create-event-interval-railroad.svg
+++ b/server/.gitbook/assets/create-event-interval-railroad.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="331" height="653">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#quantity"
+      xlink:title="quantity">
+      <rect x="31" y="3" width="72" height="32"/>
+      <rect x="29" y="1" width="72" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">quantity</text>
+   </a>
+   <rect x="143" y="3" width="56" height="32" rx="10"/>
+   <rect x="141"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="21">YEAR</text>
+   <rect x="143" y="47" width="84" height="32" rx="10"/>
+   <rect x="141"
+         y="45"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="65">QUARTER</text>
+   <rect x="143" y="91" width="70" height="32" rx="10"/>
+   <rect x="141"
+         y="89"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="109">MONTH</text>
+   <rect x="143" y="135" width="48" height="32" rx="10"/>
+   <rect x="141"
+         y="133"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="153">DAY</text>
+   <rect x="143" y="179" width="60" height="32" rx="10"/>
+   <rect x="141"
+         y="177"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="197">HOUR</text>
+   <rect x="143" y="223" width="74" height="32" rx="10"/>
+   <rect x="141"
+         y="221"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="241">MINUTE</text>
+   <rect x="143" y="267" width="60" height="32" rx="10"/>
+   <rect x="141"
+         y="265"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="285">WEEK</text>
+   <rect x="143" y="311" width="76" height="32" rx="10"/>
+   <rect x="141"
+         y="309"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="329">SECOND</text>
+   <rect x="143" y="355" width="114" height="32" rx="10"/>
+   <rect x="141"
+         y="353"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="373">YEAR_MONTH</text>
+   <rect x="143" y="399" width="96" height="32" rx="10"/>
+   <rect x="141"
+         y="397"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="417">DAY_HOUR</text>
+   <rect x="143" y="443" width="110" height="32" rx="10"/>
+   <rect x="141"
+         y="441"
+         width="110"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="461">DAY_MINUTE</text>
+   <rect x="143" y="487" width="114" height="32" rx="10"/>
+   <rect x="141"
+         y="485"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="505">DAY_SECOND</text>
+   <rect x="143" y="531" width="122" height="32" rx="10"/>
+   <rect x="141"
+         y="529"
+         width="122"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="549">HOUR_MINUTE</text>
+   <rect x="143" y="575" width="126" height="32" rx="10"/>
+   <rect x="141"
+         y="573"
+         width="126"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="593">HOUR_SECOND</text>
+   <rect x="143" y="619" width="140" height="32" rx="10"/>
+   <rect x="141"
+         y="617"
+         width="140"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="637">MINUTE_SECOND</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m56 0 h10 m0 0 h84 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m84 0 h10 m0 0 h56 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h70 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m48 0 h10 m0 0 h92 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m60 0 h10 m0 0 h80 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m74 0 h10 m0 0 h66 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m60 0 h10 m0 0 h80 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m76 0 h10 m0 0 h64 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m114 0 h10 m0 0 h26 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m96 0 h10 m0 0 h44 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m110 0 h10 m0 0 h30 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m114 0 h10 m0 0 h26 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m122 0 h10 m0 0 h18 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m126 0 h10 m0 0 h14 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m140 0 h10 m23 -616 h-3"/>
+   <polygon points="321 17 329 13 329 21"/>
+   <polygon points="321 17 313 13 313 21"/>
+</svg>

--- a/server/.gitbook/assets/create-event-railroad.svg
+++ b/server/.gitbook/assets/create-event-railroad.svg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="801" height="555">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="343" y="35" width="80" height="32" rx="10"/>
+   <rect x="341"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="53">DEFINER</text>
+   <rect x="443" y="35" width="30" height="32" rx="10"/>
+   <rect x="441"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="451" y="53">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="513" y="35" width="48" height="32"/>
+      <rect x="511" y="33" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="53">user</text>
+   </a>
+   <rect x="513" y="79" width="128" height="32" rx="10"/>
+   <rect x="511"
+         y="77"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="97">CURRENT_USER</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="513" y="123" width="44" height="32"/>
+      <rect x="511" y="121" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="521" y="141">role</text>
+   </a>
+   <rect x="513" y="167" width="130" height="32" rx="10"/>
+   <rect x="511"
+         y="165"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="521" y="185">CURRENT_ROLE</text>
+   <rect x="703" y="3" width="64" height="32" rx="10"/>
+   <rect x="701"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="711" y="21">EVENT</text>
+   <rect x="112" y="265" width="34" height="32" rx="10"/>
+   <rect x="110"
+         y="263"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="120" y="283">IF</text>
+   <rect x="166" y="265" width="48" height="32" rx="10"/>
+   <rect x="164"
+         y="263"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="174" y="283">NOT</text>
+   <rect x="234" y="265" width="70" height="32" rx="10"/>
+   <rect x="232"
+         y="263"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="242" y="283">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#event_name"
+      xlink:title="event_name">
+      <rect x="344" y="233" width="100" height="32"/>
+      <rect x="342" y="231" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="352" y="251">event_name</text>
+   </a>
+   <rect x="464" y="233" width="40" height="32" rx="10"/>
+   <rect x="462"
+         y="231"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="472" y="251">ON</text>
+   <rect x="524" y="233" width="92" height="32" rx="10"/>
+   <rect x="522"
+         y="231"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="532" y="251">SCHEDULE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#schedule"
+      xlink:title="schedule">
+      <rect x="636" y="233" width="76" height="32"/>
+      <rect x="634" y="231" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="644" y="251">schedule</text>
+   </a>
+   <rect x="45" y="347" width="40" height="32" rx="10"/>
+   <rect x="43"
+         y="345"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="365">ON</text>
+   <rect x="105" y="347" width="112" height="32" rx="10"/>
+   <rect x="103"
+         y="345"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="365">COMPLETION</text>
+   <rect x="257" y="379" width="48" height="32" rx="10"/>
+   <rect x="255"
+         y="377"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="397">NOT</text>
+   <rect x="345" y="347" width="90" height="32" rx="10"/>
+   <rect x="343"
+         y="345"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="365">PRESERVE</text>
+   <rect x="495" y="347" width="72" height="32" rx="10"/>
+   <rect x="493"
+         y="345"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="365">ENABLE</text>
+   <rect x="495" y="391" width="80" height="32" rx="10"/>
+   <rect x="493"
+         y="389"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="409">DISABLE</text>
+   <rect x="615" y="423" width="40" height="32" rx="10"/>
+   <rect x="613"
+         y="421"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="623" y="441">ON</text>
+   <rect x="675" y="423" width="64" height="32" rx="10"/>
+   <rect x="673"
+         y="421"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="683" y="441">SLAVE</text>
+   <rect x="375" y="521" width="88" height="32" rx="10"/>
+   <rect x="373"
+         y="519"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="539">COMMENT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#comment"
+      xlink:title="comment">
+      <rect x="483" y="521" width="78" height="32"/>
+      <rect x="481" y="519" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="491" y="539">comment</text>
+   </a>
+   <rect x="601" y="489" width="40" height="32" rx="10"/>
+   <rect x="599"
+         y="487"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="609" y="507">DO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#sql_statement"
+      xlink:title="sql_statement">
+      <rect x="661" y="489" width="112" height="32"/>
+      <rect x="659" y="487" width="112" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="669" y="507">sql_statement</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m40 -32 h10 m0 0 h330 m-360 0 h20 m340 0 h20 m-380 0 q10 0 10 10 m360 0 q0 -10 10 -10 m-370 10 v12 m360 0 v-12 m-360 12 q0 10 10 10 m340 0 q10 0 10 -10 m-350 10 h10 m80 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m48 0 h10 m0 0 h82 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -164 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-719 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m100 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-731 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h400 m-430 0 h20 m410 0 h20 m-450 0 q10 0 10 10 m430 0 q0 -10 10 -10 m-440 10 v12 m430 0 v-12 m-430 12 q0 10 10 10 m410 0 q10 0 10 -10 m-420 10 h10 m40 0 h10 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m90 0 h10 m40 -32 h10 m0 0 h274 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v12 m304 0 v-12 m-304 12 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m72 0 h10 m0 0 h192 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m40 0 h10 m0 0 h10 m64 0 h10 m42 -108 l2 0 m2 0 l2 0 m2 0 l2 0 m-468 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m88 0 h10 m0 0 h10 m78 0 h10 m20 -32 h10 m40 0 h10 m0 0 h10 m112 0 h10 m3 0 h-3"/>
+   <polygon points="791 503 799 499 799 507"/>
+   <polygon points="791 503 783 499 783 507"/>
+</svg>

--- a/server/.gitbook/assets/create-event-schedule-railroad.svg
+++ b/server/.gitbook/assets/create-event-schedule-railroad.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1367" height="167">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 33 1 29 1 37"/>
+   <polygon points="17 33 9 29 9 37"/>
+   <rect x="51" y="19" width="38" height="32" rx="10"/>
+   <rect x="49"
+         y="17"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="37">AT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#timestamp"
+      xlink:title="timestamp">
+      <rect x="109" y="19" width="88" height="32"/>
+      <rect x="107" y="17" width="88" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="117" y="37">timestamp</text>
+   </a>
+   <rect x="257" y="19" width="30" height="32" rx="10"/>
+   <rect x="255"
+         y="17"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="37">+</text>
+   <rect x="307" y="19" width="88" height="32" rx="10"/>
+   <rect x="305"
+         y="17"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="315" y="37">INTERVAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="415" y="19" width="68" height="32"/>
+      <rect x="413" y="17" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="423" y="37">interval</text>
+   </a>
+   <rect x="51" y="101" width="64" height="32" rx="10"/>
+   <rect x="49"
+         y="99"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="119">EVERY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="135" y="101" width="68" height="32"/>
+      <rect x="133" y="99" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="143" y="119">interval</text>
+   </a>
+   <rect x="243" y="101" width="72" height="32" rx="10"/>
+   <rect x="241"
+         y="99"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="251" y="119">STARTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#timestamp"
+      xlink:title="timestamp">
+      <rect x="335" y="101" width="88" height="32"/>
+      <rect x="333" y="99" width="88" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="343" y="119">timestamp</text>
+   </a>
+   <rect x="483" y="101" width="30" height="32" rx="10"/>
+   <rect x="481"
+         y="99"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="491" y="119">+</text>
+   <rect x="533" y="101" width="88" height="32" rx="10"/>
+   <rect x="531"
+         y="99"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="541" y="119">INTERVAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="641" y="101" width="68" height="32"/>
+      <rect x="639" y="99" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="649" y="119">interval</text>
+   </a>
+   <rect x="809" y="101" width="56" height="32" rx="10"/>
+   <rect x="807"
+         y="99"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="817" y="119">ENDS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#timestamp"
+      xlink:title="timestamp">
+      <rect x="885" y="101" width="88" height="32"/>
+      <rect x="883" y="99" width="88" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="893" y="119">timestamp</text>
+   </a>
+   <rect x="1033" y="101" width="30" height="32" rx="10"/>
+   <rect x="1031"
+         y="99"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1041" y="119">+</text>
+   <rect x="1083" y="101" width="88" height="32" rx="10"/>
+   <rect x="1081"
+         y="99"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="1091" y="119">INTERVAL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#interval"
+      xlink:title="interval">
+      <rect x="1191" y="101" width="68" height="32"/>
+      <rect x="1189" y="99" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1199" y="119">interval</text>
+   </a>
+   <path class="line"
+         d="m17 33 h2 m20 0 h10 m38 0 h10 m0 0 h10 m88 0 h10 m40 0 h10 m30 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m68 0 h10 m-266 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m246 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-246 0 h10 m0 0 h236 m-286 32 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v14 m306 0 v-14 m-306 14 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m20 -34 h796 m-1308 0 h20 m1288 0 h20 m-1328 0 q10 0 10 10 m1308 0 q0 -10 10 -10 m-1318 10 v62 m1308 0 v-62 m-1308 62 q0 10 10 10 m1288 0 q10 0 10 -10 m-1298 10 h10 m64 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m72 0 h10 m0 0 h10 m88 0 h10 m40 0 h10 m30 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m68 0 h10 m-266 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m246 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-246 0 h10 m0 0 h236 m-286 32 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v14 m306 0 v-14 m-306 14 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m-526 -34 h20 m526 0 h20 m-566 0 q10 0 10 10 m546 0 q0 -10 10 -10 m-556 10 v30 m546 0 v-30 m-546 30 q0 10 10 10 m526 0 q10 0 10 -10 m-536 10 h10 m0 0 h516 m40 -50 h10 m56 0 h10 m0 0 h10 m88 0 h10 m40 0 h10 m30 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m68 0 h10 m-266 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m246 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-246 0 h10 m0 0 h236 m-286 32 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v14 m306 0 v-14 m-306 14 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m0 0 h276 m-510 -34 h20 m510 0 h20 m-550 0 q10 0 10 10 m530 0 q0 -10 10 -10 m-540 10 v30 m530 0 v-30 m-530 30 q0 10 10 10 m510 0 q10 0 10 -10 m-520 10 h10 m0 0 h500 m43 -132 h-3"/>
+   <polygon points="1357 33 1365 29 1365 37"/>
+   <polygon points="1357 33 1349 29 1349 37"/>
+</svg>

--- a/server/.gitbook/assets/create-role-railroad.svg
+++ b/server/.gitbook/assets/create-role-railroad.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="717" height="287">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="143" y="35" width="40" height="32" rx="10"/>
+   <rect x="141"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="53">OR</text>
+   <rect x="203" y="35" width="80" height="32" rx="10"/>
+   <rect x="201"
+         y="33"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="211" y="53">REPLACE</text>
+   <rect x="323" y="3" width="56" height="32" rx="10"/>
+   <rect x="321"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="331" y="21">ROLE</text>
+   <rect x="419" y="35" width="34" height="32" rx="10"/>
+   <rect x="417"
+         y="33"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="427" y="53">IF</text>
+   <rect x="473" y="35" width="48" height="32" rx="10"/>
+   <rect x="471"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="481" y="53">NOT</text>
+   <rect x="541" y="35" width="70" height="32" rx="10"/>
+   <rect x="539"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="549" y="53">EXISTS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="651" y="3" width="44" height="32"/>
+      <rect x="649" y="1" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="659" y="21">role</text>
+   </a>
+   <rect x="335" y="121" width="58" height="32" rx="10"/>
+   <rect x="333"
+         y="119"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="139">WITH</text>
+   <rect x="413" y="121" width="66" height="32" rx="10"/>
+   <rect x="411"
+         y="119"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="421" y="139">ADMIN</text>
+   <rect x="519" y="121" width="128" height="32" rx="10"/>
+   <rect x="517"
+         y="119"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="527" y="139">CURRENT_USER</text>
+   <rect x="519" y="165" width="130" height="32" rx="10"/>
+   <rect x="517"
+         y="163"
+         width="130"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="527" y="183">CURRENT_ROLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#user"
+      xlink:title="user">
+      <rect x="519" y="209" width="48" height="32"/>
+      <rect x="517" y="207" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="527" y="227">user</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#role"
+      xlink:title="role">
+      <rect x="519" y="253" width="44" height="32"/>
+      <rect x="517" y="251" width="44" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="527" y="271">role</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-424 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m128 0 h10 m0 0 h2 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m48 0 h10 m0 0 h82 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m44 0 h10 m0 0 h86 m43 -164 h-3"/>
+   <polygon points="707 103 715 99 715 107"/>
+   <polygon points="707 103 699 99 699 107"/>
+</svg>

--- a/server/.gitbook/assets/lag-railroad.svg
+++ b/server/.gitbook/assets/lag-railroad.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="929" height="135">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="46" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">LAG</text>
+   <rect x="97" y="3" width="26" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="143" y="3" width="48" height="32"/>
+      <rect x="141" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="151" y="21">expr</text>
+   </a>
+   <rect x="231" y="35" width="24" height="32" rx="10"/>
+   <rect x="229"
+         y="33"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="53">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#offset"
+      xlink:title="offset">
+      <rect x="275" y="35" width="56" height="32"/>
+      <rect x="273" y="33" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="283" y="53">offset</text>
+   </a>
+   <rect x="371" y="3" width="26" height="32" rx="10"/>
+   <rect x="369"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="379" y="21">)</text>
+   <rect x="417" y="3" width="58" height="32" rx="10"/>
+   <rect x="415"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="21">OVER</text>
+   <rect x="495" y="3" width="26" height="32" rx="10"/>
+   <rect x="493"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="503" y="21">(</text>
+   <rect x="561" y="35" width="98" height="32" rx="10"/>
+   <rect x="559"
+         y="33"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="569" y="53">PARTITION</text>
+   <rect x="679" y="35" width="38" height="32" rx="10"/>
+   <rect x="677"
+         y="33"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="687" y="53">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_expression"
+      xlink:title="partition_expression">
+      <rect x="737" y="35" width="150" height="32"/>
+      <rect x="735" y="33" width="150" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="745" y="53">partition_expression</text>
+   </a>
+   <rect x="629" y="101" width="68" height="32" rx="10"/>
+   <rect x="627"
+         y="99"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="637" y="119">ORDER</text>
+   <rect x="717" y="101" width="38" height="32" rx="10"/>
+   <rect x="715"
+         y="99"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="725" y="119">BY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#order_list"
+      xlink:title="order_list">
+      <rect x="775" y="101" width="80" height="32"/>
+      <rect x="773" y="99" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="783" y="119">order_list</text>
+   </a>
+   <rect x="875" y="101" width="26" height="32" rx="10"/>
+   <rect x="873"
+         y="99"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="883" y="119">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m24 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m26 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m150 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-322 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="919 115 927 111 927 119"/>
+   <polygon points="919 115 911 111 911 119"/>
+</svg>

--- a/server/.gitbook/assets/show-table-status-railroad.svg
+++ b/server/.gitbook/assets/show-table-status-railroad.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="755" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="62" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">TABLE</text>
+   <rect x="197" y="3" width="72" height="32" rx="10"/>
+   <rect x="195"
+         y="1"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="205" y="21">STATUS</text>
+   <rect x="329" y="35" width="60" height="32" rx="10"/>
+   <rect x="327"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="337" y="53">FROM</text>
+   <rect x="329" y="79" width="36" height="32" rx="10"/>
+   <rect x="327"
+         y="77"
+         width="36"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="337" y="97">IN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#db_name"
+      xlink:title="db_name">
+      <rect x="429" y="35" width="80" height="32"/>
+      <rect x="427" y="33" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="437" y="53">db_name</text>
+   </a>
+   <rect x="569" y="35" width="52" height="32" rx="10"/>
+   <rect x="567"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="53">LIKE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#pattern"
+      xlink:title="pattern">
+      <rect x="641" y="35" width="66" height="32"/>
+      <rect x="639" y="33" width="66" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="649" y="53">pattern</text>
+   </a>
+   <rect x="569" y="79" width="70" height="32" rx="10"/>
+   <rect x="567"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="97">WHERE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#expr"
+      xlink:title="expr">
+      <rect x="659" y="79" width="48" height="32"/>
+      <rect x="657" y="77" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="667" y="97">expr</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h210 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v12 m240 0 v-12 m-240 12 q0 10 10 10 m220 0 q10 0 10 -10 m-210 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m36 0 h10 m0 0 h24 m20 -44 h10 m80 0 h10 m40 -32 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m52 0 h10 m0 0 h10 m66 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m23 -76 h-3"/>
+   <polygon points="745 17 753 13 753 21"/>
+   <polygon points="745 17 737 13 737 21"/>
+</svg>

--- a/server/.gitbook/assets/truncate-table-railroad.svg
+++ b/server/.gitbook/assets/truncate-table-railroad.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="539" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="92" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">TRUNCATE</text>
+   <rect x="163" y="35" width="62" height="32" rx="10"/>
+   <rect x="161"
+         y="33"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="171" y="53">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="265" y="3" width="80" height="32"/>
+      <rect x="263" y="1" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="273" y="21">tbl_name</text>
+   </a>
+   <rect x="385" y="35" width="58" height="32" rx="10"/>
+   <rect x="383"
+         y="33"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="393" y="53">WAIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#n"
+      xlink:title="n">
+      <rect x="463" y="35" width="28" height="32"/>
+      <rect x="461" y="33" width="28" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="471" y="53">n</text>
+   </a>
+   <rect x="385" y="79" width="78" height="32" rx="10"/>
+   <rect x="383"
+         y="77"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="393" y="97">NOWAIT</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -32 h10 m80 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h10 m28 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m78 0 h10 m0 0 h28 m23 -76 h-3"/>
+   <polygon points="529 17 537 13 537 21"/>
+   <polygon points="529 17 521 13 521 21"/>
+</svg>

--- a/server/reference/sql-functions/special-functions/window-functions/lag.md
+++ b/server/reference/sql-functions/special-functions/window-functions/lag.md
@@ -15,6 +15,8 @@ LAG (expr[, offset]) OVER (
 )
 ```
 
+![Railroad diagram of LAG — equivalent to the BNF above](../../../../.gitbook/assets/lag-railroad.svg)
+
 ## Description
 
 The `LAG` function accesses data from a previous row according to the `ORDER BY` clause without the need for a self-join. The specific row is determined by the _offset_ (default _1_), which specifies the number of rows behind the current row to use. An offset of _0_ is the current row.

--- a/server/reference/sql-statements/account-management-sql-statements/create-role.md
+++ b/server/reference/sql-statements/account-management-sql-statements/create-role.md
@@ -14,6 +14,8 @@ CREATE [OR REPLACE] ROLE [IF NOT EXISTS] role
     {CURRENT_USER | CURRENT_ROLE | user | role}]
 ```
 
+![Railroad diagram of CREATE ROLE — equivalent to the BNF above](../../../.gitbook/assets/create-role-railroad.svg)
+
 ## Description
 
 The `CREATE ROLE` statement creates one or more MariaDB [roles](../../../security/user-account-management/roles/). To use it, you must have the global [CREATE USER](grant.md#create-user) privilege or the [INSERT](grant.md#table-privileges) privilege for the mysql database. For each account, `CREATE ROLE` creates a new row in the [mysql.user](../../system-tables/the-mysql-database-tables/mysql-user-table.md) table that has no privileges, and with the corresponding `is_role` field set to `Y`. It also creates a record in the [mysql.roles\_mapping](../../system-tables/the-mysql-database-tables/mysql-roles_mapping-table.md) table.

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-table-status.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-table-status.md
@@ -13,6 +13,8 @@ SHOW TABLE STATUS [{FROM | IN} db_name]
     [LIKE 'pattern' | WHERE expr]
 ```
 
+![Railroad diagram of SHOW TABLE STATUS — equivalent to the BNF above](../../../../.gitbook/assets/show-table-status-railroad.svg)
+
 ## Description
 
 {% tabs %}

--- a/server/reference/sql-statements/data-definition/create/create-event.md
+++ b/server/reference/sql-statements/data-definition/create/create-event.md
@@ -18,7 +18,7 @@ CREATE [OR REPLACE]
     [ON COMPLETION [NOT] PRESERVE]
     [ENABLE | DISABLE | DISABLE ON SLAVE]
     [COMMENT 'comment']
-    DO sql_statement;
+    DO sql_statement
 
 schedule:
     AT timestamp [+ INTERVAL interval] ...
@@ -31,6 +31,12 @@ interval:
               WEEK | SECOND | YEAR_MONTH | DAY_HOUR | DAY_MINUTE |
               DAY_SECOND | HOUR_MINUTE | HOUR_SECOND | MINUTE_SECOND}
 ```
+
+![Railroad diagram of CREATE EVENT — equivalent to the BNF above](../../../../.gitbook/assets/create-event-railroad.svg)
+
+![Railroad diagram of schedule](../../../../.gitbook/assets/create-event-schedule-railroad.svg)
+
+![Railroad diagram of interval](../../../../.gitbook/assets/create-event-interval-railroad.svg)
 
 ## Description
 

--- a/server/reference/sql-statements/table-statements/truncate-table.md
+++ b/server/reference/sql-statements/table-statements/truncate-table.md
@@ -14,6 +14,8 @@ TRUNCATE [TABLE] tbl_name
   [WAIT n | NOWAIT]
 ```
 
+![Railroad diagram of TRUNCATE TABLE — equivalent to the BNF above](../../../.gitbook/assets/truncate-table-railroad.svg)
+
 ## Description
 
 `TRUNCATE TABLE` empties a table completely. It requires the `DROP` privilege. See [GRANT](../account-management-sql-statements/grant.md).


### PR DESCRIPTION
## Summary

Batch 10 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. **This is the batch that reaches the ~50-page target outlined in the ticket.** Continuing from GA ranks 51+.

## Pages

| Page | Views | Diagrams |
|---|---:|---|
| [TRUNCATE TABLE](https://mariadb.com/docs/server/reference/sql-statements/table-statements/truncate-table) | 207 | top-level |
| [SHOW TABLE STATUS](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-table-status) | 146 | top-level |
| [CREATE ROLE](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-role) | 144 | top-level |
| [LAG](https://mariadb.com/docs/server/reference/sql-functions/special-functions/window-functions/lag) | 142 | top-level |
| [CREATE EVENT](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-event) | 142 | top-level + `schedule` + `interval` |

7 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

## LAG vs ROW_NUMBER — the ORDER BY distinction

The LAG page's source BNF uses angle brackets `< ORDER BY order_list >`, contrasting with the square brackets `[ … ]` used for the optional `PARTITION BY` clause directly above it. The convention on the page: angle brackets mark a **required** clause. LAG needs `ORDER BY` to be deterministic (it lags by row position); ROW_NUMBER does not.

Diagrammed with `ORDER BY` mandatory for LAG, matching the source. ROW_NUMBER's diagram from batch 8 has `ORDER BY` optional — different shapes are correct.

## Source-BNF cleanup folded in (CREATE EVENT)

The source ended with `DO sql_statement;`. Dropped the trailing `;`, same convention applied to CREATE TRIGGER (batch 2) and the IF statement (batch 8).

## Tally — the ~50-page target

After this PR lands: **51 pages diagrammed under DOCS-5614.**

| Batch | PR | Pages |
|---|---|---|
| Prototype | #545 | ALTER TABLE |
| 1 | #552 | CREATE DATABASE, INSERT, UPDATE, DELETE, CREATE VIEW |
| 2 | #561 | SET PASSWORD, LOAD DATA INFILE, CREATE TRIGGER, SELECT INTO OUTFILE, INSERT … ON DUPLICATE KEY UPDATE *(cross-ref)* |
| 3 | #562 | OPTIMIZE TABLE, INSERT … ON DUPLICATE KEY UPDATE *(real)*, FLUSH, Generated Columns, PURGE BINARY LOGS, CASE statement |
| 4 | #563 | CREATE PROCEDURE, CHANGE MASTER TO, CREATE INDEX, CONSTRAINT, CREATE FUNCTION |
| 5 | #564 | GRANT, CREATE USER, ALTER USER, SELECT |
| 6 | #565 | SHOW TABLES, SHOW DATABASES, ANALYZE TABLE, REPLACE, START TRANSACTION |
| 7 | #566 | JSON_TABLE, SHOW COLUMNS, RENAME TABLE, LOCK TABLES, INSERT RETURNING *(reuse)*, CREATE SEQUENCE |
| 8 | #567 | CASE operator, NOW, ROW_NUMBER, INSERT SELECT, IF statement |
| 9 | #568 | SHOW INDEX, SET, SHOW VARIABLES, RANGE Partitioning Type, SELECT INTO |
| **10** | **this PR** | **TRUNCATE TABLE, SHOW TABLE STATUS, CREATE ROLE, LAG, CREATE EVENT** |

CREATE TABLE remains the only top-50 candidate deferred for a structural reason (no top-level BNF on the page). Further candidates from GA ranks 51+ are available (~70 non-trivial undone pages remain) if you want to keep going past ~50.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] CREATE EVENT's BNF block ends with `DO sql_statement` (no trailing `;`).
- [ ] LAG's diagram shows ORDER BY as a required clause (no outer optional wrapper).
- [ ] All 7 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ