### PR TITLE
DOCS-5614 add Railroad diagrams to 5 more SQL pages

### DIFF
--- a/server/.gitbook/assets/check-table-option-railroad.svg
+++ b/server/.gitbook/assets/check-table-option-railroad.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="251" height="257">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">FOR</text>
+   <rect x="119" y="3" width="84" height="32" rx="10"/>
+   <rect x="117"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="21">UPGRADE</text>
+   <rect x="51" y="47" width="64" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">QUICK</text>
+   <rect x="51" y="91" width="54" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">FAST</text>
+   <rect x="51" y="135" width="76" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">MEDIUM</text>
+   <rect x="51" y="179" width="92" height="32" rx="10"/>
+   <rect x="49"
+         y="177"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="197">EXTENDED</text>
+   <rect x="51" y="223" width="86" height="32" rx="10"/>
+   <rect x="49"
+         y="221"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="241">CHANGED</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m48 0 h10 m0 0 h10 m84 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m64 0 h10 m0 0 h88 m-182 -10 v20 m192 0 v-20 m-192 20 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m54 0 h10 m0 0 h98 m-182 -10 v20 m192 0 v-20 m-192 20 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m76 0 h10 m0 0 h76 m-182 -10 v20 m192 0 v-20 m-192 20 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m92 0 h10 m0 0 h60 m-182 -10 v20 m192 0 v-20 m-192 20 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m86 0 h10 m0 0 h66 m23 -220 h-3"/>
+   <polygon points="241 17 249 13 249 21"/>
+   <polygon points="241 17 233 13 233 21"/>
+</svg>

--- a/server/.gitbook/assets/check-table-railroad.svg
+++ b/server/.gitbook/assets/check-table-railroad.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="465" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">CHECK</text>
+   <rect x="115" y="47" width="62" height="32" rx="10"/>
+   <rect x="113"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="65">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="217" y="47" width="80" height="32"/>
+      <rect x="215" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="225" y="65">tbl_name</text>
+   </a>
+   <rect x="217" y="3" width="24" height="32" rx="10"/>
+   <rect x="215"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="225" y="21">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#option"
+      xlink:title="option">
+      <rect x="357" y="13" width="60" height="32"/>
+      <rect x="355" y="11" width="60" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="365" y="31">option</text>
+   </a>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m64 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h70 m-100 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m80 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-80 0 h10 m60 0 h10 m23 34 h-3"/>
+   <polygon points="455 61 463 57 463 65"/>
+   <polygon points="455 61 447 57 447 65"/>
+</svg>

--- a/server/.gitbook/assets/repair-table-railroad.svg
+++ b/server/.gitbook/assets/repair-table-railroad.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="871" height="243">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="72" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">REPAIR</text>
+   <rect x="143" y="79" width="188" height="32" rx="10"/>
+   <rect x="141"
+         y="77"
+         width="188"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="97">NO_WRITE_TO_BINLOG</text>
+   <rect x="143" y="123" width="64" height="32" rx="10"/>
+   <rect x="141"
+         y="121"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="151" y="141">LOCAL</text>
+   <rect x="371" y="47" width="62" height="32" rx="10"/>
+   <rect x="369"
+         y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="379" y="65">TABLE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#tbl_name"
+      xlink:title="tbl_name">
+      <rect x="473" y="47" width="80" height="32"/>
+      <rect x="471" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="481" y="65">tbl_name</text>
+   </a>
+   <rect x="473" y="3" width="24" height="32" rx="10"/>
+   <rect x="471"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="481" y="21">,</text>
+   <rect x="613" y="79" width="64" height="32" rx="10"/>
+   <rect x="611"
+         y="77"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="621" y="97">QUICK</text>
+   <rect x="737" y="79" width="92" height="32" rx="10"/>
+   <rect x="735"
+         y="77"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="745" y="97">EXTENDED</text>
+   <rect x="613" y="209" width="84" height="32" rx="10"/>
+   <rect x="611"
+         y="207"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="621" y="227">USE_FRM</text>
+   <rect x="757" y="209" width="66" height="32" rx="10"/>
+   <rect x="755"
+         y="207"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="765" y="227">FORCE</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h198 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v12 m228 0 v-12 m-228 12 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m-218 -10 v20 m228 0 v-20 m-228 20 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m64 0 h10 m0 0 h124 m20 -76 h10 m62 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m40 44 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-300 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m40 -32 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m23 -32 h-3"/>
+   <polygon points="861 191 869 187 869 195"/>
+   <polygon points="861 191 853 187 853 195"/>
+</svg>

--- a/server/.gitbook/assets/start-replica-railroad.svg
+++ b/server/.gitbook/assets/start-replica-railroad.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="903" height="311">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">START</text>
+   <rect x="155" y="47" width="64" height="32" rx="10"/>
+   <rect x="153"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="65">SLAVE</text>
+   <rect x="155" y="91" width="78" height="32" rx="10"/>
+   <rect x="153"
+         y="89"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="109">REPLICA</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#connection_name"
+      xlink:title="connection_name">
+      <rect x="293" y="79" width="132" height="32"/>
+      <rect x="291" y="77" width="132" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="301" y="97">connection_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#thread_type"
+      xlink:title="thread_type">
+      <rect x="505" y="47" width="98" height="32"/>
+      <rect x="503" y="45" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="513" y="65">thread_type</text>
+   </a>
+   <rect x="505" y="3" width="24" height="32" rx="10"/>
+   <rect x="503"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="513" y="21">,</text>
+   <rect x="505" y="123" width="112" height="32" rx="10"/>
+   <rect x="503"
+         y="121"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="513" y="141">SQL_THREAD</text>
+   <rect x="657" y="91" width="62" height="32" rx="10"/>
+   <rect x="655"
+         y="89"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="665" y="109">UNTIL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#until_clause"
+      xlink:title="until_clause">
+      <rect x="739" y="91" width="96" height="32"/>
+      <rect x="737" y="89" width="96" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="747" y="109">until_clause</text>
+   </a>
+   <rect x="135" y="233" width="44" height="32" rx="10"/>
+   <rect x="133"
+         y="231"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="251">ALL</text>
+   <rect x="219" y="233" width="72" height="32" rx="10"/>
+   <rect x="217"
+         y="231"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="227" y="251">SLAVES</text>
+   <rect x="219" y="277" width="88" height="32" rx="10"/>
+   <rect x="217"
+         y="275"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="227" y="295">REPLICAS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#thread_type"
+      xlink:title="thread_type">
+      <rect x="387" y="233" width="98" height="32"/>
+      <rect x="385" y="231" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="395" y="251">thread_type</text>
+   </a>
+   <rect x="387" y="189" width="24" height="32" rx="10"/>
+   <rect x="385"
+         y="187"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="395" y="207">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m64 0 h10 m40 0 h10 m64 0 h10 m0 0 h14 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -44 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m60 -32 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h212 m-390 0 h20 m370 0 h20 m-410 0 q10 0 10 10 m390 0 q0 -10 10 -10 m-400 10 v24 m390 0 v-24 m-390 24 q0 10 10 10 m370 0 q10 0 10 -10 m-360 10 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m112 0 h10 m20 -32 h10 m62 0 h10 m0 0 h10 m96 0 h10 m-380 -10 v20 m390 0 v-20 m-390 20 v46 m390 0 v-46 m-390 46 q0 10 10 10 m370 0 q10 0 10 -10 m-380 10 h10 m0 0 h360 m-740 -110 h20 m740 0 h20 m-780 0 q10 0 10 10 m760 0 q0 -10 10 -10 m-770 10 v166 m760 0 v-166 m-760 166 q0 10 10 10 m740 0 q10 0 10 -10 m-750 10 h10 m44 0 h10 m20 0 h10 m72 0 h10 m0 0 h16 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m60 -44 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m-158 44 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v14 m178 0 v-14 m-178 14 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m0 0 h148 m20 -34 h330 m23 -186 h-3"/>
+   <polygon points="893 61 901 57 901 65"/>
+   <polygon points="893 61 885 57 885 65"/>
+</svg>

--- a/server/.gitbook/assets/start-replica-thread-type-railroad.svg
+++ b/server/.gitbook/assets/start-replica-thread-type-railroad.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="211" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="102" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">IO_THREAD</text>
+   <rect x="51" y="47" width="112" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">SQL_THREAD</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m102 0 h10 m0 0 h10 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v24 m152 0 v-24 m-152 24 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m112 0 h10 m23 -44 h-3"/>
+   <polygon points="201 17 209 13 209 21"/>
+   <polygon points="201 17 193 13 193 21"/>
+</svg>

--- a/server/.gitbook/assets/start-replica-until-clause-railroad.svg
+++ b/server/.gitbook/assets/start-replica-until-clause-railroad.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="797" height="125">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="71" y="3" width="152" height="32" rx="10"/>
+   <rect x="69"
+         y="1"
+         width="152"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="21">MASTER_LOG_FILE</text>
+   <rect x="243" y="3" width="30" height="32" rx="10"/>
+   <rect x="241"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="251" y="21">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#log_name"
+      xlink:title="log_name">
+      <rect x="293" y="3" width="82" height="32"/>
+      <rect x="291" y="1" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="301" y="21">log_name</text>
+   </a>
+   <rect x="395" y="3" width="24" height="32" rx="10"/>
+   <rect x="393"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="403" y="21">,</text>
+   <rect x="439" y="3" width="150" height="32" rx="10"/>
+   <rect x="437"
+         y="1"
+         width="150"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="447" y="21">MASTER_LOG_POS</text>
+   <rect x="71" y="47" width="140" height="32" rx="10"/>
+   <rect x="69"
+         y="45"
+         width="140"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">RELAY_LOG_FILE</text>
+   <rect x="231" y="47" width="30" height="32" rx="10"/>
+   <rect x="229"
+         y="45"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="65">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#log_name"
+      xlink:title="log_name">
+      <rect x="281" y="47" width="82" height="32"/>
+      <rect x="279" y="45" width="82" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="289" y="65">log_name</text>
+   </a>
+   <rect x="383" y="47" width="24" height="32" rx="10"/>
+   <rect x="381"
+         y="45"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="391" y="65">,</text>
+   <rect x="427" y="47" width="138" height="32" rx="10"/>
+   <rect x="425"
+         y="45"
+         width="138"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="435" y="65">RELAY_LOG_POS</text>
+   <rect x="629" y="3" width="30" height="32" rx="10"/>
+   <rect x="627"
+         y="1"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="637" y="21">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#log_pos"
+      xlink:title="log_pos">
+      <rect x="679" y="3" width="70" height="32"/>
+      <rect x="677" y="1" width="70" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="687" y="21">log_pos</text>
+   </a>
+   <rect x="51" y="91" width="156" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="156"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">MASTER_GTID_POS</text>
+   <rect x="227" y="91" width="30" height="32" rx="10"/>
+   <rect x="225"
+         y="89"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="235" y="109">=</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#gtid_position"
+      xlink:title="gtid_position">
+      <rect x="277" y="91" width="102" height="32"/>
+      <rect x="275" y="89" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="285" y="109">gtid_position</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m40 0 h10 m152 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m150 0 h10 m-558 0 h20 m538 0 h20 m-578 0 q10 0 10 10 m558 0 q0 -10 10 -10 m-568 10 v24 m558 0 v-24 m-558 24 q0 10 10 10 m538 0 q10 0 10 -10 m-548 10 h10 m140 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m138 0 h10 m0 0 h24 m20 -44 h10 m30 0 h10 m0 0 h10 m70 0 h10 m-738 0 h20 m718 0 h20 m-758 0 q10 0 10 10 m738 0 q0 -10 10 -10 m-748 10 v68 m738 0 v-68 m-738 68 q0 10 10 10 m718 0 q10 0 10 -10 m-728 10 h10 m156 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m102 0 h10 m0 0 h370 m23 -88 h-3"/>
+   <polygon points="787 17 795 13 795 21"/>
+   <polygon points="787 17 779 13 779 21"/>
+</svg>

--- a/server/.gitbook/assets/stop-replica-railroad.svg
+++ b/server/.gitbook/assets/stop-replica-railroad.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="965" height="323">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="56" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">STOP</text>
+   <rect x="65" y="113" width="64" height="32" rx="10"/>
+   <rect x="63"
+         y="111"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="131">SLAVE</text>
+   <rect x="65" y="157" width="78" height="32" rx="10"/>
+   <rect x="63"
+         y="155"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="175">REPLICA</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#connection_name"
+      xlink:title="connection_name">
+      <rect x="203" y="145" width="132" height="32"/>
+      <rect x="201" y="143" width="132" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="211" y="163">connection_name</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#thread_type"
+      xlink:title="thread_type">
+      <rect x="415" y="113" width="98" height="32"/>
+      <rect x="413" y="111" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="423" y="131">thread_type</text>
+   </a>
+   <rect x="415" y="69" width="24" height="32" rx="10"/>
+   <rect x="413"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="423" y="87">,</text>
+   <rect x="593" y="145" width="48" height="32" rx="10"/>
+   <rect x="591"
+         y="143"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="601" y="163">FOR</text>
+   <rect x="661" y="145" width="84" height="32" rx="10"/>
+   <rect x="659"
+         y="143"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="669" y="163">CHANNEL</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#connection_name"
+      xlink:title="connection_name">
+      <rect x="765" y="145" width="132" height="32"/>
+      <rect x="763" y="143" width="132" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="773" y="163">connection_name</text>
+   </a>
+   <rect x="45" y="245" width="44" height="32" rx="10"/>
+   <rect x="43"
+         y="243"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="263">ALL</text>
+   <rect x="129" y="245" width="72" height="32" rx="10"/>
+   <rect x="127"
+         y="243"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="137" y="263">SLAVES</text>
+   <rect x="129" y="289" width="88" height="32" rx="10"/>
+   <rect x="127"
+         y="287"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="137" y="307">REPLICAS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#thread_type"
+      xlink:title="thread_type">
+      <rect x="297" y="245" width="98" height="32"/>
+      <rect x="295" y="243" width="98" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="305" y="263">thread_type</text>
+   </a>
+   <rect x="297" y="201" width="24" height="32" rx="10"/>
+   <rect x="295"
+         y="199"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="305" y="219">,</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-108 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m64 0 h10 m0 0 h14 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -44 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m60 -32 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m-158 44 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v14 m178 0 v-14 m-178 14 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m0 0 h148 m40 -34 h10 m0 0 h314 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v12 m344 0 v-12 m-344 12 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m132 0 h10 m-892 -32 h20 m892 0 h20 m-932 0 q10 0 10 10 m912 0 q0 -10 10 -10 m-922 10 v112 m912 0 v-112 m-912 112 q0 10 10 10 m892 0 q10 0 10 -10 m-902 10 h10 m44 0 h10 m20 0 h10 m72 0 h10 m0 0 h16 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m60 -44 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m-158 44 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v14 m178 0 v-14 m-178 14 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m0 0 h148 m20 -34 h482 m23 -132 h-3"/>
+   <polygon points="955 127 963 123 963 131"/>
+   <polygon points="955 127 947 123 947 131"/>
+</svg>

--- a/server/.gitbook/assets/stop-replica-thread-type-railroad.svg
+++ b/server/.gitbook/assets/stop-replica-thread-type-railroad.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="211" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="3" width="102" height="32" rx="10"/>
+   <rect x="49"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="21">IO_THREAD</text>
+   <rect x="51" y="47" width="112" height="32" rx="10"/>
+   <rect x="49"
+         y="45"
+         width="112"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="65">SQL_THREAD</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m102 0 h10 m0 0 h10 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v24 m152 0 v-24 m-152 24 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m112 0 h10 m23 -44 h-3"/>
+   <polygon points="201 17 209 13 209 21"/>
+   <polygon points="201 17 193 13 193 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-commit-railroad.svg
+++ b/server/.gitbook/assets/xa-commit-railroad.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="447" height="69">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="89" y="3" width="78" height="32" rx="10"/>
+   <rect x="87"
+         y="1"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="21">COMMIT</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#xid"
+      xlink:title="xid">
+      <rect x="187" y="3" width="38" height="32"/>
+      <rect x="185" y="1" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="195" y="21">xid</text>
+   </a>
+   <rect x="265" y="35" width="48" height="32" rx="10"/>
+   <rect x="263"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="53">ONE</text>
+   <rect x="333" y="35" width="66" height="32" rx="10"/>
+   <rect x="331"
+         y="33"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="53">PHASE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m48 0 h10 m0 0 h10 m66 0 h10 m23 -32 h-3"/>
+   <polygon points="437 17 445 13 445 21"/>
+   <polygon points="437 17 429 13 429 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-end-railroad.svg
+++ b/server/.gitbook/assets/xa-end-railroad.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="577" height="101">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="89" y="3" width="48" height="32" rx="10"/>
+   <rect x="87"
+         y="1"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="21">END</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#xid"
+      xlink:title="xid">
+      <rect x="157" y="3" width="38" height="32"/>
+      <rect x="155" y="1" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="165" y="21">xid</text>
+   </a>
+   <rect x="235" y="35" width="84" height="32" rx="10"/>
+   <rect x="233"
+         y="33"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="53">SUSPEND</text>
+   <rect x="359" y="67" width="48" height="32" rx="10"/>
+   <rect x="357"
+         y="65"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="367" y="85">FOR</text>
+   <rect x="427" y="67" width="82" height="32" rx="10"/>
+   <rect x="425"
+         y="65"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="435" y="85">MIGRATE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h304 m-334 0 h20 m314 0 h20 m-354 0 q10 0 10 10 m334 0 q0 -10 10 -10 m-344 10 v12 m334 0 v-12 m-334 12 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m84 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m48 0 h10 m0 0 h10 m82 0 h10 m43 -64 h-3"/>
+   <polygon points="567 17 575 13 575 21"/>
+   <polygon points="567 17 559 13 559 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-prepare-railroad.svg
+++ b/server/.gitbook/assets/xa-prepare-railroad.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="257" height="37">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="89" y="3" width="82" height="32" rx="10"/>
+   <rect x="87"
+         y="1"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="21">PREPARE</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#xid"
+      xlink:title="xid">
+      <rect x="191" y="3" width="38" height="32"/>
+      <rect x="189" y="1" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="199" y="21">xid</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m38 0 h10 m3 0 h-3"/>
+   <polygon points="247 17 255 13 255 21"/>
+   <polygon points="247 17 239 13 239 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-recover-railroad.svg
+++ b/server/.gitbook/assets/xa-recover-railroad.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="507" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="89" y="3" width="84" height="32" rx="10"/>
+   <rect x="87"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="21">RECOVER</text>
+   <rect x="213" y="35" width="76" height="32" rx="10"/>
+   <rect x="211"
+         y="33"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="53">FORMAT</text>
+   <rect x="309" y="35" width="30" height="32" rx="10"/>
+   <rect x="307"
+         y="33"
+         width="30"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="317" y="53">=</text>
+   <rect x="379" y="35" width="60" height="32" rx="10"/>
+   <rect x="377"
+         y="33"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="387" y="53">'RAW'</text>
+   <rect x="379" y="79" width="56" height="32" rx="10"/>
+   <rect x="377"
+         y="77"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="387" y="97">'SQL'</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m76 0 h10 m0 0 h10 m30 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m56 0 h10 m0 0 h4 m43 -76 h-3"/>
+   <polygon points="497 17 505 13 505 21"/>
+   <polygon points="497 17 489 13 489 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-rollback-railroad.svg
+++ b/server/.gitbook/assets/xa-rollback-railroad.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="267" height="37">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="89" y="3" width="92" height="32" rx="10"/>
+   <rect x="87"
+         y="1"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="21">ROLLBACK</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#xid"
+      xlink:title="xid">
+      <rect x="201" y="3" width="38" height="32"/>
+      <rect x="199" y="1" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="209" y="21">xid</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m3 0 h-3"/>
+   <polygon points="257 17 265 13 265 21"/>
+   <polygon points="257 17 249 13 249 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-start-begin-railroad.svg
+++ b/server/.gitbook/assets/xa-start-begin-railroad.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="415" height="113">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="38" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">XA</text>
+   <rect x="109" y="3" width="64" height="32" rx="10"/>
+   <rect x="107"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="117" y="21">START</text>
+   <rect x="109" y="47" width="64" height="32" rx="10"/>
+   <rect x="107"
+         y="45"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="117" y="65">BEGIN</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#xid"
+      xlink:title="xid">
+      <rect x="213" y="3" width="38" height="32"/>
+      <rect x="211" y="1" width="38" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="221" y="21">xid</text>
+   </a>
+   <rect x="291" y="35" width="54" height="32" rx="10"/>
+   <rect x="289"
+         y="33"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="299" y="53">JOIN</text>
+   <rect x="291" y="79" width="76" height="32" rx="10"/>
+   <rect x="289"
+         y="77"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="299" y="97">RESUME</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m38 0 h10 m20 0 h10 m64 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -44 h10 m38 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m54 0 h10 m0 0 h22 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -76 h-3"/>
+   <polygon points="405 17 413 13 413 21"/>
+   <polygon points="405 17 397 13 397 21"/>
+</svg>

--- a/server/.gitbook/assets/xa-transactions-xid-railroad.svg
+++ b/server/.gitbook/assets/xa-transactions-xid-railroad.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="445" height="101">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#gtrid"
+      xlink:title="gtrid">
+      <rect x="31" y="3" width="48" height="32"/>
+      <rect x="29" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">gtrid</text>
+   </a>
+   <rect x="119" y="35" width="24" height="32" rx="10"/>
+   <rect x="117"
+         y="33"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="127" y="53">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#bqual"
+      xlink:title="bqual">
+      <rect x="163" y="35" width="54" height="32"/>
+      <rect x="161" y="33" width="54" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="171" y="53">bqual</text>
+   </a>
+   <rect x="257" y="67" width="24" height="32" rx="10"/>
+   <rect x="255"
+         y="65"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="85">,</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#formatID"
+      xlink:title="formatID">
+      <rect x="301" y="67" width="76" height="32"/>
+      <rect x="299" y="65" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="309" y="85">formatID</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h288 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v12 m318 0 v-12 m-318 12 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m24 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m24 0 h10 m0 0 h10 m76 0 h10 m43 -64 h-3"/>
+   <polygon points="435 17 443 13 443 21"/>
+   <polygon points="435 17 427 13 427 21"/>
+</svg>

--- a/server/reference/sql-statements/administrative-sql-statements/replication-statements/start-replica.md
+++ b/server/reference/sql-statements/administrative-sql-statements/replication-statements/start-replica.md
@@ -19,6 +19,12 @@ START ALL { SLAVES | REPLICAS } [thread_type [, thread_type]]
 thread_type: IO_THREAD | SQL_THREAD
 ```
 
+![Railroad diagram of START REPLICA — equivalent to the BNF above](../../../../.gitbook/assets/start-replica-railroad.svg)
+
+![Railroad diagram of until_clause](../../../../.gitbook/assets/start-replica-until-clause-railroad.svg)
+
+![Railroad diagram of thread_type](../../../../.gitbook/assets/start-replica-thread-type-railroad.svg)
+
 ## Description
 
 {% tabs %}

--- a/server/reference/sql-statements/administrative-sql-statements/replication-statements/stop-replica.md
+++ b/server/reference/sql-statements/administrative-sql-statements/replication-statements/stop-replica.md
@@ -7,17 +7,17 @@ The terms _master_ and _slave_ have historically been used in replication, and M
 ## Syntax
 
 ```bnf
-STOP { SLAVE | REPLICA } ["connection_name"] [thread_type [, thread_type] ... ] 
-[FOR CHANNEL "connection_name"]
+STOP { SLAVE | REPLICA } ["connection_name"] [thread_type [, thread_type] ... ]
+    [FOR CHANNEL "connection_name"]
 
 STOP ALL { SLAVES | REPLICAS } [thread_type [, thread_type]]
 
-STOP { SLAVE | REPLICA } ["connection_name"] [thread_type [, thread_type] ... ]
-
-STOP ALL { SLAVES | REPLICAS } [thread_type [, thread_type]] 
-
 thread_type: IO_THREAD | SQL_THREAD
 ```
+
+![Railroad diagram of STOP REPLICA — equivalent to the BNF above](../../../../.gitbook/assets/stop-replica-railroad.svg)
+
+![Railroad diagram of thread_type](../../../../.gitbook/assets/stop-replica-thread-type-railroad.svg)
 
 ## Description
 

--- a/server/reference/sql-statements/table-statements/check-table.md
+++ b/server/reference/sql-statements/table-statements/check-table.md
@@ -14,6 +14,10 @@ CHECK TABLE tbl_name [, tbl_name] ... [option] ...
 option = {FOR UPGRADE | QUICK | FAST | MEDIUM | EXTENDED | CHANGED}
 ```
 
+![Railroad diagram of CHECK TABLE](../../../.gitbook/assets/check-table-railroad.svg)
+
+![Railroad diagram of option](../../../.gitbook/assets/check-table-option-railroad.svg)
+
 ## Description
 
 `CHECK TABLE` checks a table or tables for errors. `CHECK TABLE` works for [Archive](../../../server-usage/storage-engines/archive.md), [Aria](../../../server-usage/storage-engines/aria/), [CSV](../../../server-usage/storage-engines/csv/), [InnoDB](../../../server-usage/storage-engines/innodb/), [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/), and, from [MariaDB 12.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.0), [Sequence](../../../server-usage/storage-engines/sequence-storage-engine.md) tables. For Aria and MyISAM tables, the key statistics are updated as well. For CSV, see also [Checking and Repairing CSV Tables](../../../server-usage/storage-engines/csv/checking-and-repairing-csv-tables.md).

--- a/server/reference/sql-statements/table-statements/repair-table.md
+++ b/server/reference/sql-statements/table-statements/repair-table.md
@@ -13,8 +13,10 @@ description: >-
 ```bnf
 REPAIR [NO_WRITE_TO_BINLOG | LOCAL] TABLE
     tbl_name [, tbl_name] ...
-    [QUICK] [EXTENDED] [USE_FRM] [FORCE
+    [QUICK] [EXTENDED] [USE_FRM] [FORCE]
 ```
+
+![Railroad diagram of REPAIR TABLE — equivalent to the BNF above](../../../.gitbook/assets/repair-table-railroad.svg)
 {% endtab %}
 
 {% tab title="< 11.5" %}

--- a/server/reference/sql-statements/transactions/xa-transactions.md
+++ b/server/reference/sql-statements/transactions/xa-transactions.md
@@ -60,6 +60,22 @@ XA RECOVER [FORMAT=['RAW'|'SQL']]
 xid: gtrid [, bqual [, formatID ]]
 ```
 
+The BNF documents six XA statements together; each gets its own diagram.
+
+![Railroad diagram of XA START / XA BEGIN](../../../.gitbook/assets/xa-start-begin-railroad.svg)
+
+![Railroad diagram of XA END](../../../.gitbook/assets/xa-end-railroad.svg)
+
+![Railroad diagram of XA PREPARE](../../../.gitbook/assets/xa-prepare-railroad.svg)
+
+![Railroad diagram of XA COMMIT](../../../.gitbook/assets/xa-commit-railroad.svg)
+
+![Railroad diagram of XA ROLLBACK](../../../.gitbook/assets/xa-rollback-railroad.svg)
+
+![Railroad diagram of XA RECOVER](../../../.gitbook/assets/xa-recover-railroad.svg)
+
+![Railroad diagram of xid](../../../.gitbook/assets/xa-transactions-xid-railroad.svg)
+
 The interface to XA transactions is a set of SQL statements starting with `XA`. Each statement changes a transaction's state, determining which actions it can perform. A transaction which does not exist is in the `NON-EXISTING` state.
 
 When trying to execute an operation which is not allowed for the transaction's current state, an error is produced:


### PR DESCRIPTION
## Summary

Batch 11 of the [DOCS-5614](https://mariadbcorp.atlassian.net/browse/DOCS-5614) Railroad-diagram rollout. Continuing past the ~50 target reached in batch 10. The fun continues.

## Pages

| Page | Views | Diagrams |
|---|---:|---|
| [XA Transactions](https://mariadb.com/docs/server/reference/sql-statements/transactions/xa-transactions) | 112 | 6 top-level XA forms (`XA START`/`XA BEGIN`, `XA END`, `XA PREPARE`, `XA COMMIT`, `XA ROLLBACK`, `XA RECOVER`) + `xid` |
| [START REPLICA](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/replication-statements/start-replica) | 99 | top-level + `until_clause` + `thread_type` |
| [STOP REPLICA](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/replication-statements/stop-replica) | 99 | top-level + `thread_type` |
| [CHECK TABLE](https://mariadb.com/docs/server/reference/sql-statements/table-statements/check-table) | 142 | top-level + `option` |
| [REPAIR TABLE](https://mariadb.com/docs/server/reference/sql-statements/table-statements/repair-table) | 125 | top-level |

15 SVGs total. EBNF sources under `/Users/stefanhinz/maria/railroad-draft/`.

CHECK TABLE + REPAIR TABLE complete the **table-maintenance quartet** with ANALYZE TABLE (batch 6) and OPTIMIZE TABLE (batch 3).

## START REPLICA — consolidated UNTIL forms

The source BNF listed 4 separate forms of `START SLAVE/REPLICA` (basic + 3 UNTIL variants for MASTER_LOG_FILE, RELAY_LOG_FILE, MASTER_GTID_POS). Consolidated into one top-level rule with the UNTIL alternatives factored into `until_clause`, keeping the top-level diagram readable.

## Source-BNF cleanups folded in

- **STOP REPLICA**: the source listed four forms, but forms 3 and 4 were accidental copy-paste duplicates of forms 1 and 2 (form 3 was form 1 sans the `FOR CHANNEL` clause; form 4 was identical to form 2). Removed the duplicates; the BNF now lists just the two distinct forms.
- **REPAIR TABLE**: the source BNF was **literally truncated mid-token**, ending `[FORCE` with no closing bracket. Verified against `mariadb-server/sql/sql_yacc.yy:8653` that FORCE is a valid REPAIR TABLE option. Completed the BNF to `[QUICK] [EXTENDED] [USE_FRM] [FORCE]`.

## Tally

After this PR lands: **56 pages diagrammed under DOCS-5614** — past the ~50 target by a comfortable margin.

~65 more non-trivial undone candidates from the GA report remain available if we want to keep going.

## Test plan

- [ ] GitBook preview renders each diagram inline.
- [ ] STOP REPLICA BNF now lists 2 forms (not 4 with duplicates).
- [ ] REPAIR TABLE BNF ends with `[FORCE]` (closing bracket).
- [ ] All 15 SVG references resolve (verified locally).
- [ ] codespell, lychee, alias-expand CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5614]: https://mariadbcorp.atlassian.net/browse/DOCS-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ