### PR TITLE
dev-docs: carry-over from pre-#571 CLAUDE.md

### DIFF
--- a/.claude/skills/gitbook-format/SKILL.md
+++ b/.claude/skills/gitbook-format/SKILL.md
@@ -108,7 +108,7 @@ content inline rather than inventing an include.
 ### 6. Links
 
 - **Same space** → relative `.md` path: `[CREATE TABLE](reference/.../create-table.md)`.
-- **Other space** → alias: `[MaxScale]({maxscale}/readme)`. Alias table:
+- **Other space** → alias: `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. Alias table:
   `dev-docs/link-aliases.md`.
 - **Convert** raw `https://app.gitbook.com/...` URLs and hard-coded cross-space URLs into the
   appropriate alias. **Never** expand an existing `{alias}` into a URL — the CI Action does that.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,4 @@ canonical MariaDB style guide: `dev-docs/style-guide.md`.
    Keep agent docs clean too.
 6. Server alone is ~4,540 files — scope searches and bulk edits to a space/path, never the whole repo.
 7. Both GitBook-UI and Git edits are live; don't assume Git is the only writer.
+8. **`server/reference/**/*.md` heading invariant.** Pages under `server/reference/` must keep the `# Title` / `## Syntax` / `## Description` (or `## Overview`) / `## Examples` / `## See Also` heading shape — `help-tables/markdown_extractor.py` parses these to build the MariaDB CLI's `HELP` content. Full detail: `help-tables/HELP_TABLES_PIPELINE.md`.

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -40,6 +40,10 @@ tool that isn't installed (CI still runs it).
   contain a brace would be skipped too. Don't rely on lychee to catch braced URLs; just don't
   hand-expand aliases.
 
+> **CI failure notices.** When a workflow run fails on GitHub, the run summary may link to
+> internal Atlassian SOP pages (`mariadbcorp.atlassian.net/...`) for fix steps. Those URLs
+> require MariaDB SSO — they're not public and won't open from an external browser session.
+
 > **Hook vs. PR scope.** The pre-commit hook and `/precommit` check only **staged** files; CI
 > checks the **full PR diff**. Passing the hook is not a guarantee CI passes — run the
 > whole-branch command above before opening the PR. (See `.claude/README.md`.)

--- a/dev-docs/gitbook-syntax.md
+++ b/dev-docs/gitbook-syntax.md
@@ -188,5 +188,5 @@ Markdown tables. Notes from the GitBook Editing guide:
 
 - **Within the same space:** relative Markdown link to the `.md` file
   — `[CREATE TABLE](reference/.../create-table.md)`.
-- **To another space:** a link alias — `[MaxScale]({maxscale}/readme)`. See `link-aliases.md`.
+- **To another space:** a link alias — `[MaxScale](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/readme)`. See `link-aliases.md`.
 - Never paste raw `https://app.gitbook.com/...` URLs.

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -13,10 +13,10 @@ to the real URL when the PR is merged.
 Example:
 
 ```
-[Securing Communications]({galera}/galera-security/securing-communications-in-galera-cluster)
+[Securing Communications](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/galera-security/securing-communications-in-galera-cluster)
 ```
 
-The `expand-gitbook-aliases.yml` Action rewrites `{galera}` to the full
+The `expand-gitbook-aliases.yml` Action rewrites `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` to the full
 `https://app.gitbook.com/...` URL on the PR branch automatically. The expansion is committed
 back to the PR branch as `docs: expand GitBook aliases` from the `github-actions` bot — expect
 that follow-up commit to appear shortly after opening or pushing to a PR.
@@ -25,19 +25,19 @@ that follow-up commit to appear shortly after opening or pushing to a PR.
 
 | Alias | Target space |
 |-------|--------------|
-| `{home}` | Home / Landing |
-| `{server}` | MariaDB Server |
-| `{maxscale}` | MariaDB MaxScale |
-| `{galera}` | Galera Cluster |
-| `{analytics}` | Analytics (ColumnStore) |
-| `{columnstore}` | ColumnStore |
-| `{connectors}` | Connectors (Java, ODBC, etc.) |
-| `{skysql}` | SkySQL |
-| `{platform}` | MariaDB Enterprise Platform |
-| `{mariadb-cloud}` | MariaDB Cloud |
-| `{tools}` | Tools |
-| `{release-notes}` | Release Notes |
-| `{general-resources}` | General Resources |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/gmXC0YXB3rRhXvpg5mb1` | Home / Landing |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV` | MariaDB Server |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX` | MariaDB MaxScale |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7` | Galera Cluster |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14` | Analytics (ColumnStore) |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/2I4jZ8pGq8bT4w5n3q6r` | ColumnStore |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L` | Connectors (Java, ODBC, etc.) |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb` | SkySQL |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/JqgUabdZsoY5EiaJmqgn` | MariaDB Enterprise Platform |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/vPz15Lz0Iw3P3yKR3Prd` | MariaDB Cloud |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/kuTXWg0NDbRx6XUeYpGD` | Tools |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb` | Release Notes |
+| `https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/WCInJQ9cmGjq1lsTG91E/about/readme` | General Resources |
 
 ## Rules for agents
 

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -17,7 +17,9 @@ Example:
 ```
 
 The `expand-gitbook-aliases.yml` Action rewrites `{galera}` to the full
-`https://app.gitbook.com/...` URL on the PR branch automatically.
+`https://app.gitbook.com/...` URL on the PR branch automatically. The expansion is committed
+back to the PR branch as `docs: expand GitBook aliases` from the `github-actions` bot — expect
+that follow-up commit to appear shortly after opening or pushing to a PR.
 
 ## Available aliases
 


### PR DESCRIPTION
## Summary

Three small operational notes carried over from a workstation-only `CLAUDE.md` that predated #571. Each fills a real gap in the new tree:

- **`dev-docs/link-aliases.md`** — names the `github-actions` bot's commit-back behavior so new contributors aren't confused when a follow-up `docs: expand GitBook aliases` commit appears on their freshly-opened PR.
- **`dev-docs/cookbook-pre-pr.md`** — flags that workflow-failure summaries link to internal Atlassian SOP pages (`mariadbcorp.atlassian.net/...`) requiring MariaDB SSO, so contributors don't bounce off the SSO wall expecting public links.
- **`AGENTS.md`** "Common gotchas" — adds a heading-shape invariant for `server/reference/**/*.md` (`# Title` / `## Syntax` / `## Description` / `## Examples` / `## See Also`). A reference-page editor who reorders or renames these headings can silently break the help-tables extractor without ever opening `help-tables/`.

The rest of the prior workstation `CLAUDE.md` was already covered — and in deeper form — by `AGENTS.md`, the `dev-docs/` cookbooks, and `help-tables/HELP_TABLES_PIPELINE.md`.

No DOCS ticket; this is housekeeping after #571 (precedent: the two preceding post-#571 commits on `main` are also no-ticket).

## Test plan

- [ ] Diff review: 3 files, 8 insertions, 1 deletion — no functional changes, only `dev-docs/` and `AGENTS.md` prose.
- [ ] CI: codespell + lychee pass on changed files.
- [ ] expand-gitbook-aliases: no aliases added/removed in this PR, so no expansion commit expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)