### PR TITLE
Update binary log file name in PITR instructions

### DIFF
--- a/server/server-usage/backup-and-restore/mariadb-backup/point-in-time-recovery-pitr-mariadb-backup.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/point-in-time-recovery-pitr-mariadb-backup.md
@@ -16,7 +16,7 @@ Run the following commands as root unless indicated otherwise.
 {% step %}
 **Find the binary log position to restore to.**
 
-When MariaDB Backup runs on a MariaDB Server with binary logs enabled (which is a prerequisite for PITR), it stores binary log information in the `mariadb_backup_binlog_info` (or `xtrabackup_binlog_info` in [older release](files-created-by-mariadb-backup.md)) file. Consult this file to find the name of the binary log position to use. In the following example, the log position is 321:
+When MariaDB Backup runs on a MariaDB Server with binary logs enabled (which is a prerequisite for PITR), it stores binary log information in the `mariadb_backup_binlog_info` (or `xtrabackup_binlog_info` in [older releases](files-created-by-mariadb-backup.md)) file. Consult this file to find the name of the binary log position to use. In the following example, the log position is 321:
 
 ```bash
 cat /data/backups/full/mariadb_backup_binlog_info

--- a/server/server-usage/backup-and-restore/mariadb-backup/point-in-time-recovery-pitr-mariadb-backup.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/point-in-time-recovery-pitr-mariadb-backup.md
@@ -16,10 +16,10 @@ Run the following commands as root unless indicated otherwise.
 {% step %}
 **Find the binary log position to restore to.**
 
-When MariaDB Backup runs on a MariaDB Server with binary logs enabled (which is a prerequisite for PITR), it stores binary log information in the `xtrabackup_binlog_info` file. Consult this file to find the name of the binary log position to use. In the following example, the log position is 321:
+When MariaDB Backup runs on a MariaDB Server with binary logs enabled (which is a prerequisite for PITR), it stores binary log information in the `mariadb_backup_binlog_info` (or `xtrabackup_binlog_info` in [older release](files-created-by-mariadb-backup.md)) file. Consult this file to find the name of the binary log position to use. In the following example, the log position is 321:
 
 ```bash
-cat /data/backups/full/xtraback_binlog_info
+cat /data/backups/full/mariadb_backup_binlog_info
 
 mariadb-node4.00001     321
 ```


### PR DESCRIPTION
Hello MariaDB team,

Starting with MariaDB 11.1, the mariadb_backup_binlog_info file replaces the former xtrabackup_binlog_info file, as documented here: [Files created by MariaDB Backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/files-created-by-mariadb-backup#current).

This PR updates all references to mariadb_backup_binlog_info in the point-in-time-recovery-pitr-mariadb-backup.md documentation.

Related to MDEV-18931.

Regards,