### PR TITLE
DOCS-6206 Scaffold agent-skills/ directory (DX project)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -1,0 +1,31 @@
+{
+  "$comment": "Index of all MariaDB agent skills for DOCS-6206. Hand-maintained for now; a CI step can regenerate it from the directory tree + frontmatter once the layout is final.",
+  "baseline": "11.8 LTS",
+  "layers": {
+    "granular-statements": {
+      "tier": 1,
+      "path": "granular/statements",
+      "author": "docs-team",
+      "skills": [
+        { "name": "mariadb-create-table", "path": "granular/statements/mariadb-create-table/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-alter-table", "path": "granular/statements/mariadb-alter-table/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-select", "path": "granular/statements/mariadb-select/SKILL.md", "status": "pilot" }
+      ]
+    },
+    "granular-functions": {
+      "tier": 2,
+      "path": "granular/functions",
+      "author": "docs-team+extractor",
+      "skills": [
+        { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" }
+      ]
+    },
+    "topical": {
+      "path": "topical",
+      "author": "mariadb-foundation",
+      "vendored_from": "https://github.com/MariaDB/skills",
+      "vendored_ref": null,
+      "skills": []
+    }
+  }
+}

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -1,0 +1,65 @@
+# MariaDB agent skills
+
+`SKILL.md` files that teach a coding agent (Claude Code, Codex, and others) the
+MariaDB-specific deltas from standard SQL — and from what an LLM tends to write
+by default. Loading the relevant skill saves the agent from retrieving and
+parsing the full `mariadb.com/docs` content on every task: fewer tokens, faster
+responses, less traffic.
+
+This directory is the **single consumption point** for the MariaDB DX project.
+Pull (or receive a push of) `agent-skills/` and you have the complete set —
+nothing here depends on a submodule fetch or a separate repository.
+
+> This directory is **not** rendered on `mariadb.com/docs`. It is deliberately
+> excluded from every GitBook space's `SUMMARY.md`, the same way
+> [`help-tables/`](../help-tables/) is. Treat it as a build/handoff artifact,
+> not documentation pages.
+
+## Layers
+
+| Path | Layer | Author | Maintained |
+| --- | --- | --- | --- |
+| `granular/statements/` | **Tier 1** — one skill per SQL statement family (`mariadb-create-table`, `mariadb-alter-table`, `mariadb-select`, …) | Docs team, hand-curated | Source of truth, here |
+| `granular/functions/` | **Tier 2** — one skill per function category (`mariadb-json-functions`, …); machine-extracted entries wrapped in a hand-written scaffold | Docs team + `extractor/` | Source of truth, here |
+| `topical/` | **Topical** — feature-area deep dives (`mariadb-features`, `mariadb-vector`, …) | Robert Silen / MariaDB Foundation | **Vendored** from [`MariaDB/skills`](https://github.com/MariaDB/skills) — see `topical/VENDORED.md`; do not hand-edit |
+
+Each skill is a directory containing a `SKILL.md` (Claude Code skill convention),
+so all three layers ingest uniformly.
+
+## How to consume
+
+Every layer materializes as real files under `agent-skills/`, so any of these
+works — no `--recurse-submodules` required:
+
+- **Sparse checkout** of just this directory:
+  ```bash
+  git clone --filter=blob:none --sparse https://github.com/mariadb-corporation/mariadb-docs
+  cd mariadb-docs && git sparse-checkout set agent-skills
+  ```
+- **Tarball** of the directory at a pinned tag.
+- **Push model** (if chosen): a workflow assembles `agent-skills/` and pushes it
+  into the DX tool's own repo. The directory layout is identical either way, so
+  push vs. pull does not change anything downstream.
+
+`.skills-manifest.json` enumerates every skill and its version for tools that
+want an index rather than a directory walk.
+
+## Provenance and versioning
+
+- Granular skills carry a `*Last updated: YYYY-MM-DD*` line and assume the
+  **11.8 LTS** baseline (stated in each skill's header).
+- Topical skills are pinned to a specific upstream release; see
+  `topical/VENDORED.md` for the source commit/tag, license, and sync date.
+
+## Maintenance
+
+See `dev-docs/` (TODO: link the DX skill maintenance doc once written) for the
+authoring and per-LTS update workflows. In short:
+
+- **Tier 1** — hand-authored, human-verified against `server/reference/**` and
+  `mariadb-server/sql/`. Reviewed per LTS release.
+- **Tier 2** — `extractor/` re-runs when the relevant `server/reference/**`
+  function pages change (CI), regenerating the per-function entries inside the
+  hand-written scaffold.
+- **Topical** — re-vendored from upstream; file content bugs against
+  `MariaDB/skills`, not here.

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -53,8 +53,8 @@ want an index rather than a directory walk.
 
 ## Maintenance
 
-See `dev-docs/` (TODO: link the DX skill maintenance doc once written) for the
-authoring and per-LTS update workflows. In short:
+See [`dev-docs/agent-skills-maintenance.md`](../dev-docs/agent-skills-maintenance.md)
+for the authoring and per-LTS update workflows. In short:
 
 - **Tier 1** — hand-authored, human-verified against `server/reference/**` and
   `mariadb-server/sql/`. Reviewed per LTS release.

--- a/agent-skills/extractor/README.md
+++ b/agent-skills/extractor/README.md
@@ -1,0 +1,34 @@
+# Tier 2 function-skill extractor
+
+Generates the per-function entries for `granular/functions/*/SKILL.md` from the
+canonical MariaDB function reference pages. The hand-written parts of each skill
+(frontmatter, intro, the category-level "What LLMs Often Miss" table) are
+**not** generated — they wrap the extractor's output via a template.
+
+This mirrors the minimalism of [`help-tables/markdown_extractor.py`](../../help-tables/markdown_extractor.py):
+regex-based, no markdown-library dependency, reads the canonical doc template.
+
+## Usage
+
+```bash
+./extract_function_category.py \
+  ../../server/reference/sql-functions/special-functions/json-functions \
+  [--exclude FUNCTION ...]
+```
+
+Output is Markdown on stdout — the dense per-function listing. Assemble it into
+a `SKILL.md` by wrapping it with `templates/function-category.scaffold.md`.
+
+## Workflow (CI, stub)
+
+`.github/workflows/extract-function-skills.yml` (not yet written) re-runs the
+extractor when the relevant `server/reference/**` function pages change and
+opens a PR regenerating the affected `granular/functions/*/SKILL.md` body, with
+the hand-written scaffold sections preserved.
+
+## Files
+
+- `extract_function_category.py` — the extractor (Tier 2 pilot, used for
+  `mariadb-json-functions`).
+- `templates/function-category.scaffold.md` — the hand-written wrapper into
+  which extracted entries are spliced.

--- a/agent-skills/extractor/extract_function_category.py
+++ b/agent-skills/extractor/extract_function_category.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Tier 2 extractor for MariaDB DX skill files.
+
+Walks a single SQL-function category directory under
+`mariadb-docs/server/reference/sql-functions/.../<category>/` and emits a
+dense per-function listing suitable for embedding in a SKILL.md.
+
+Usage:
+    extract_function_category.py <category-dir> [--exclude name [name ...]]
+
+Output: Markdown on stdout. Hand-curated frontmatter, intro, and
+"What LLMs Often Miss" sections must be assembled around it by a wrapping
+SKILL.md template.
+
+The extractor is regex-based (no markdown library dependency) and follows
+the same minimalism as mariadb-docs/help-tables/markdown_extractor.py.
+
+Pages are expected to use the canonical MariaDB doc template:
+    ---
+    description: >-
+      <one or two lines>
+    ---
+    # FUNCTION_NAME
+    [optional {% hint style="info" %}...available from MariaDB X.Y...{% endhint %}]
+    ## Syntax
+    ```sql
+    <signature>
+    ```
+    ## Description
+    ...
+Pages that don't match are reported on stderr and skipped.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ----------------------------------------------------------------------
+# Regex extractors
+# ----------------------------------------------------------------------
+
+# Pull the YAML `description: >- ... ---` block at the top of the file.
+FRONTMATTER_RE = re.compile(
+    r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL
+)
+DESC_RE = re.compile(
+    r"^description:\s*>-?\s*\n((?:  .*\n)+)", re.MULTILINE
+)
+
+# Title line: `# NAME` — names sometimes have GitBook-escaped underscores
+# (e.g. `JSON\_EXTRACT`).
+TITLE_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+
+# First fenced SQL code block under the Syntax heading.
+# Tolerates `## Syntax` and `### Syntax` (some pages are inconsistent).
+SYNTAX_BLOCK_RE = re.compile(
+    r"^#{2,3}\s+Syntax\s*\n+```sql\s*\n(.*?)\n```",
+    re.DOTALL | re.MULTILINE,
+)
+
+# First non-empty paragraph under the `## Description` heading. Skips
+# leading blank lines, captures until the next blank line or heading.
+DESCRIPTION_BODY_RE = re.compile(
+    r"^##\s+Description\s*\n+(.+?)(?:\n\n|\n#{2,})",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Alias-only stub: pages like JSON_PRETTY whose body is just
+# "FOO is an alias for [BAR](bar.md)." with no Syntax section.
+ALIAS_RE = re.compile(
+    r"`?\w+`?\s+is\s+an\s+alias\s+for\s+\[?`?(\w+)`?\]?",
+    re.IGNORECASE,
+)
+
+# Available-from-version hint: GitBook hint blocks that say
+# "available from MariaDB X.Y" or "added in MariaDB X.Y".
+SINCE_RE = re.compile(
+    r"(?:available\s+from|added\s+in|introduced\s+in)\s+MariaDB\s+(\d+\.\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
+
+# GitBook markup that we want to strip from extracted prose so the agent
+# isn't reading workflow noise.
+GITBOOK_HINT_RE = re.compile(
+    r"\{%\s*hint[^%]*%\}.*?\{%\s*endhint\s*%\}", re.DOTALL
+)
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+MULTISPACE_RE = re.compile(r"\s+")
+
+
+def unescape_title(s: str) -> str:
+    """GitBook escapes `_` as `\\_` inside Markdown headings. Undo it."""
+    return s.replace("\\_", "_").strip()
+
+
+def clean_description(raw: str) -> str:
+    """Normalize a multi-line YAML folded-scalar description into one line."""
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    return " ".join(lines)
+
+
+def first_signature(syntax_block: str) -> str:
+    """Take the first non-blank line of the syntax code block as the signature."""
+    for line in syntax_block.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def clean_prose(s: str) -> str:
+    """Strip GitBook markup and collapse whitespace for one-line display."""
+    s = GITBOOK_HINT_RE.sub("", s)
+    s = MARKDOWN_LINK_RE.sub(r"\1", s)
+    s = s.replace("\\_", "_")
+    s = MULTISPACE_RE.sub(" ", s)
+    return s.strip()
+
+
+def first_sentence(paragraph: str) -> str:
+    """Return the first sentence (ending in '.', '!', or '?') of a paragraph."""
+    paragraph = paragraph.strip()
+    m = re.match(r"(.+?[.!?])(?:\s|$)", paragraph, re.DOTALL)
+    return m.group(1) if m else paragraph
+
+
+# ----------------------------------------------------------------------
+# Per-page extraction
+# ----------------------------------------------------------------------
+
+
+class ExtractionError(Exception):
+    pass
+
+
+def extract_function(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+
+    title_match = TITLE_RE.search(text)
+    if not title_match:
+        raise ExtractionError(f"no `# Title` heading in {path.name}")
+    name = unescape_title(title_match.group(1))
+
+    # Editorial pages (e.g. "Differences between X and Y") don't look like
+    # function names. Function names are uppercase with underscores/digits.
+    if not re.match(r"^[A-Z][A-Z0-9_]*$", name):
+        raise ExtractionError(
+            f"{path.name}: title `{name}` doesn't look like a function — editorial page?"
+        )
+
+    since_match = SINCE_RE.search(text)
+    since = since_match.group(1) if since_match else ""
+
+    # Strip GitBook hints before scanning for alias / description so the
+    # hint text doesn't pollute the prose extraction.
+    body = GITBOOK_HINT_RE.sub("", text)
+
+    # Alias-only stub path: no Syntax block, body says "X is an alias for Y".
+    syntax_match = SYNTAX_BLOCK_RE.search(text)
+    if not syntax_match:
+        alias = ALIAS_RE.search(body)
+        if alias:
+            return {
+                "path": path,
+                "name": name,
+                "signature": "",
+                "alias_of": alias.group(1).upper(),
+                "description": "",
+                "since": since,
+            }
+        raise ExtractionError(f"no Syntax SQL code block in {path.name}")
+
+    signature = first_signature(syntax_match.group(1))
+
+    # Prefer the first sentence of `## Description` (reference-quality prose)
+    # over the YAML frontmatter description (often SEO-y).
+    description = ""
+    desc_match = DESCRIPTION_BODY_RE.search(body)
+    if desc_match:
+        description = first_sentence(clean_prose(desc_match.group(1)))
+
+    # Fall back to frontmatter description if no Description body found.
+    if not description:
+        fm = FRONTMATTER_RE.search(text)
+        if fm:
+            d = DESC_RE.search(fm.group(1) + "\n")
+            if d:
+                description = clean_prose(clean_description(d.group(1)))
+
+    return {
+        "path": path,
+        "name": name,
+        "signature": signature,
+        "alias_of": None,
+        "description": description,
+        "since": since,
+    }
+
+
+# ----------------------------------------------------------------------
+# Rendering
+# ----------------------------------------------------------------------
+
+
+def render_entry(fn: dict) -> str:
+    """Render one function as a tight per-function block.
+
+    Standard form:
+        ### NAME
+        `signature`
+        Description. *(since X.Y)*
+
+    Alias form:
+        ### NAME
+        Alias for `OTHER`. *(since X.Y)*
+    """
+    since = f" *(since {fn['since']})*" if fn["since"] else ""
+
+    if fn.get("alias_of"):
+        return f"### {fn['name']}\nAlias for `{fn['alias_of']}`.{since}\n"
+
+    desc = fn["description"] or "(no description in source)"
+    return (
+        f"### {fn['name']}\n"
+        f"`{fn['signature']}`  \n"
+        f"{desc}{since}\n"
+    )
+
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("category_dir", type=Path,
+                        help="Directory of function reference pages")
+    parser.add_argument("--exclude", nargs="*", default=[],
+                        help="Filenames (without .md) to skip")
+    args = parser.parse_args()
+
+    excluded = set(args.exclude) | {"README", "SUMMARY"}
+
+    pages = sorted(p for p in args.category_dir.glob("*.md")
+                   if p.stem not in excluded)
+
+    extracted: list[dict] = []
+    errors: list[str] = []
+
+    for page in pages:
+        try:
+            extracted.append(extract_function(page))
+        except ExtractionError as e:
+            errors.append(str(e))
+
+    extracted.sort(key=lambda fn: fn["name"])
+
+    print(f"<!-- Extracted from {args.category_dir} -->")
+    print(f"<!-- {len(extracted)} functions, "
+          f"{len(errors)} pages skipped on extraction failure -->")
+    print()
+    for fn in extracted:
+        print(render_entry(fn))
+
+    if errors:
+        print("=" * 60, file=sys.stderr)
+        print("Extraction errors (these pages were skipped):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent-skills/extractor/templates/function-category.scaffold.md
+++ b/agent-skills/extractor/templates/function-category.scaffold.md
@@ -1,0 +1,34 @@
+---
+name: mariadb-<category>-functions
+description: "MariaDB <category> functions — <one-line catalog of the notable functions>. Use when writing SQL that <uses this category> in MariaDB."
+---
+
+# MariaDB <Category> Functions
+
+*Last updated: YYYY-MM-DD*
+
+Catalog of every built-in <category> function in MariaDB, with signature and a
+one-line semantic summary per entry. For a function not listed here, fall back
+to the canonical reference at `server/reference/sql-functions/.../<category>/`.
+
+> **Default context:** Assume MariaDB **11.8 LTS** unless the user specifies
+> another version. Functions with a `*(since X.Y)*` annotation are only
+> available from that version onward; everything else is in every current LTS
+> branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+<!-- HAND-WRITTEN. The highest-value section: rows of "if the agent writes X,
+     prefer the MariaDB form Y." Do not name MySQL — state the MariaDB form
+     directly (see DOCS-6206). -->
+
+| If the agent writes… | Prefer (MariaDB) | Why |
+| --- | --- | --- |
+| … | … | … |
+
+## Functions
+
+<!-- BEGIN GENERATED: replaced by `extract_function_category.py` output on each
+     CI run. Do not hand-edit between these markers. -->
+
+<!-- END GENERATED -->

--- a/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: mariadb-json-functions
+description: "MariaDB JSON functions — complete catalog of JSON_*, JSON_ARRAY/OBJECT constructors and aggregates (JSON_ARRAYAGG, JSON_OBJECTAGG), extraction (JSON_EXTRACT, JSON_VALUE, JSON_QUERY, JSON_TABLE, ->, ->>), modification (JSON_SET, JSON_INSERT, JSON_REPLACE, JSON_REMOVE, JSON_ARRAY_APPEND, JSON_ARRAY_INSERT), merge variants (JSON_MERGE, JSON_MERGE_PATCH, JSON_MERGE_PRESERVE), validation (JSON_VALID, JSON_SCHEMA_VALID, IS JSON), introspection (JSON_TYPE, JSON_DEPTH, JSON_LENGTH, JSON_KEYS, JSON_CONTAINS, JSON_EQUALS), formatting (JSON_DETAILED/PRETTY, JSON_COMPACT, JSON_LOOSE, JSON_QUOTE, JSON_UNQUOTE), and JSON_TABLE for relational projection. Use when writing SQL that constructs, queries, or modifies JSON data in MariaDB."
+---
+
+# MariaDB JSON Functions
+
+*Last updated: 2026-06-02*
+
+Catalog of every built-in JSON function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at `server/reference/sql-functions/special-functions/json-functions/`. For JSONPath syntax (used by `JSON_EXTRACT`, `JSON_QUERY`, `JSON_VALUE`, `JSON_TABLE`, etc.), see the JSONPath reference page in the same directory.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `CREATE TABLE t (j JSON)` and expects a binary JSON column type | MariaDB's `JSON` is an **alias for `LONGTEXT`** with an automatic `CHECK (JSON_VALID(j))` constraint — there's no binary JSON storage type. Operations parse the text at query time |
+| `JSON_VALUE` and `JSON_QUERY` are interchangeable | They aren't. `JSON_VALUE` returns a **scalar** (or `NULL`); `JSON_QUERY` returns a **JSON object or array** (or `NULL`). Using the wrong one is a frequent bug. There's a dedicated "Differences between JSON_QUERY and JSON_VALUE" doc page if you need details |
+| Using `JSON_EXTRACT` to read a scalar and getting `"value"` with the quotes | `JSON_EXTRACT` returns the JSON representation, including string quotes. Wrap in `JSON_UNQUOTE`, use the `->>` operator (which does both), or use `JSON_VALUE` |
+| Treating `JSON_EXTRACT('[1,2,3]', '$[*]')` as returning a single value | When a path matches multiple values, the result is **autowrapped as a JSON array** — `[1, 2, 3]` here. Use specific paths (`$[0]`) for single-value extraction |
+| Calling `JSON_TABLE(...)` in the `SELECT` list | `JSON_TABLE` is a **table function** — goes in the `FROM` clause (or as a derived table). It projects a JSON document into a relational form. Available since 10.6 |
+| `SELECT j -> '$.x' FROM t` returning unquoted scalars | `->` is a shorthand for `JSON_EXTRACT` (still quoted). `->>` is `JSON_EXTRACT` + `JSON_UNQUOTE`. Use `->>` when you want raw scalar values |
+| `JSON_OBJECT('a', 1, 'b', 2)` getting reordered output | Key order is preserved as written in MariaDB. Don't rely on the same behavior across other databases |
+| Adding `CHECK (JSON_VALID(c))` on a `JSON`-typed column | The auto-constraint on the `JSON` alias type already does this — adding it again is redundant but harmless |
+| `JSON_SCHEMA_VALID` returning a useful error when validation fails | It only returns `0` or `1`. There is no "what failed" diagnostic — use a dedicated JSON-schema tool if you need that. Available since 11.1 |
+| Reaching for `JSON_PRETTY` | Works — it's an alias for `JSON_DETAILED` in MariaDB. Either spelling is fine; `JSON_DETAILED` is the canonical name |
+
+## Functions
+
+The list below is **auto-generated** from `server/reference/sql-functions/special-functions/json-functions/` by `_extractors/extract_function_category.py`. Regenerate when the doc tree changes.
+
+
+### JSON_ARRAY
+`JSON_ARRAY([value[, value2] ...])`  
+Returns a JSON array containing the listed values.
+
+### JSON_ARRAYAGG
+`JSON_ARRAYAGG(column_or_expression)`  
+`JSON_ARRAYAGG` returns a JSON array containing an element for each value in a given set of JSON or SQL values. *(since 10.5)*
+
+### JSON_ARRAY_APPEND
+`JSON_ARRAY_APPEND(json_doc, path, value[, path, value] ...)`  
+Appends values to the end of the specified arrays within a JSON document, returning the result, or `NULL` if any of the arguments are `NULL`.
+
+### JSON_ARRAY_INSERT
+`JSON_ARRAY_INSERT(json_doc, path, value[, path, value] ...)`  
+Inserts a value into a JSON document, returning the modified document, or `NULL` if any of the arguments are `NULL`.
+
+### JSON_ARRAY_INTERSECT
+`JSON_ARRAY_INTERSECT(arr1, arr2)`  
+Finds intersection between two json arrays and returns an array of items found in both array. *(since 11.2)*
+
+### JSON_COMPACT
+`JSON_COMPACT(json_doc)`  
+Removes all unnecessary spaces so the json document is as short as possible.
+
+### JSON_CONTAINS
+`JSON_CONTAINS(json_doc, val[, path])`  
+Returns whether or not the specified value is found in the given JSON document or, optionally, at the specified path within the document.
+
+### JSON_CONTAINS_PATH
+`JSON_CONTAINS_PATH(json_doc, return_arg, path[, path] ...)`  
+Indicates whether the given JSON document contains data at the specified path or paths.
+
+### JSON_DEPTH
+`JSON_DEPTH(json_doc)`  
+Returns the maximum depth of the given JSON document, or `NULL` if the argument is null.
+
+### JSON_DETAILED
+`JSON_DETAILED(json_doc[, tab_size])`  
+Represents JSON in the most understandable way emphasizing nested structures.
+
+### JSON_EQUALS
+`JSON_EQUALS(json1, json2)`  
+Checks if there is equality between two json objects. *(since 10.7)*
+
+### JSON_EXISTS
+`JSON_EXISTS(json_doc, json_path)`  
+Determines whether `json_doc` has an element pointed to by path `json_path`.
+
+### JSON_EXTRACT
+`JSON_EXTRACT(json_doc, path[, path] ...)`  
+Extracts data from a JSON document.
+
+### JSON_INSERT
+`JSON_INSERT(json_doc, path, val[, path, val] ...)`  
+Inserts data into a JSON document, returning the resulting document or `NULL` if either of the _json_doc_ or _path_ arguments are null.
+
+### JSON_KEYS
+`JSON_KEYS(json_doc[, path])`  
+Returns the keys as a JSON array from the top-level value of a JSON object or, if the optional path argument is provided, the top-level keys from the path.
+
+### JSON_KEY_VALUE
+`JSON_KEY_VALUE(obj, json_path)`  
+`JSON_KEY_VALUE` extracts key/value pairs from a JSON object. *(since 11.2)*
+
+### JSON_LENGTH
+`JSON_LENGTH(json_doc[, path])`  
+Returns the length of a JSON document, or, if the optional path argument is given, the length of the value within the document specified by the path.
+
+### JSON_LOOSE
+`JSON_LOOSE(json_doc)`  
+Adds spaces to a JSON document to make it look more readable.
+
+### JSON_MERGE
+`JSON_MERGE(json_doc, json_doc[, json_doc] ...)`  
+Merges the given JSON documents.
+
+### JSON_MERGE_PATCH
+`JSON_MERGE_PATCH(json_doc, json_doc[, json_doc] ...)`  
+Merges the given JSON documents, returning the merged result, or `NULL` if any argument is `NULL`.
+
+### JSON_MERGE_PRESERVE
+`JSON_MERGE_PRESERVE(json_doc, json_doc[, json_doc] ...)`  
+Merges the given JSON documents, returning the merged result, or `NULL` if any argument is `NULL`.
+
+### JSON_NORMALIZE
+`JSON_NORMALIZE(json)`  
+Recursively sorts keys and removes spaces, allowing comparison of json documents for equality. *(since 10.7)*
+
+### JSON_OBJECT
+`JSON_OBJECT([key, value[, key, value] ...])`  
+Returns a JSON object containing the given key/value pairs.
+
+### JSON_OBJECTAGG
+`JSON_OBJECTAGG(key, value)`  
+`JSON_OBJECTAGG` returns a JSON object containing key-value pairs. *(since 10.5)*
+
+### JSON_OBJECT_FILTER_KEYS
+`JSON_OBJECT_FILTER_KEYS(obj, array_keys)`  
+`JSON_OBJECT_FILTER_KEYS` returns a JSON object with keys from the object that are also present in the array as string. *(since 11.2)*
+
+### JSON_OBJECT_TO_ARRAY
+`JSON_OBJECT_TO_ARRAY(Obj)`  
+It is used to convert all JSON objects found in a JSON document to JSON arrays where each item in the outer array represents a single key-value pair from the object. *(since 11.2)*
+
+### JSON_OVERLAPS
+`JSON_OVERLAPS(json_doc1, json_doc2)`  
+`JSON_OVERLAPS()` compares two json documents and returns true if they have at least one common\ key-value pair between two objects, array element common between two arrays, or array element common with scalar if one of the arguments is a scalar and other is an array. *(since 10.9)*
+
+### JSON_PRETTY
+Alias for `JSON_DETAILED`. *(since 10.10.3)*
+
+### JSON_QUERY
+`JSON_QUERY(json_doc, path)`  
+Given a JSON document, returns an object or array specified by the path.
+
+### JSON_QUOTE
+`JSON_QUOTE(json_value)`  
+Quotes a string as a JSON value, usually for producing valid JSON string literals for inclusion in JSON documents.
+
+### JSON_REMOVE
+`JSON_REMOVE(json_doc, path[, path] ...)`  
+Removes data from a JSON document returning the result, or `NULL` if any of the arguments are null.
+
+### JSON_REPLACE
+`JSON_REPLACE(json_doc, path, val[, path, val] ...)`  
+Replaces existing values in a JSON document, returning the result, or `NULL` if any of the arguments are `NULL`.
+
+### JSON_SCHEMA_VALID
+`JSON_SCHEMA_VALID(schema, json);`  
+`JSON_SCHEMA_VALID` allows MariaDB to support JSON schema validation. *(since 11.1)*
+
+### JSON_SEARCH
+`JSON_SEARCH(json_doc, return_arg, search_str[, escape_char[, path] ...])`  
+Returns the path to the given string within a JSON document, or `NULL` if any of _json_doc_, _search_str_ or a path argument is `NULL`; if the search string is not found, or if no path exists within the document.
+
+### JSON_SET
+`JSON_SET(json_doc, path, val[, path, val] ...)`  
+Updates or inserts data into a JSON document, returning the result, or `NULL` if any of the arguments are `NULL` or the optional path fails to find an object.
+
+### JSON_TABLE
+`JSON_TABLE(json_doc,`  
+`JSON_TABLE` can be used in contexts where a table reference can be used; in the `FROM` clause of a SELECT statement, and in multi-table UPDATE/DELETE statements. *(since 10.6)*
+
+### JSON_TYPE
+`JSON_TYPE(json_val)`  
+Returns the type of a JSON value (as a string), or `NULL` if the argument is null.
+
+### JSON_UNQUOTE
+`JSON_UNQUOTE(val)`  
+Unquotes a JSON value, returning a string, or `NULL` if the argument is null.
+
+### JSON_VALID
+`JSON_VALID(value)`  
+Indicates whether the given value is a valid JSON document or not.
+
+### JSON_VALUE
+`JSON_VALUE(json_doc, path)`  
+Given a JSON document, returns the scalar specified by the path.
+
+
+## Related Operators (Not Covered Above)
+
+- **`->`** — Shorthand for `JSON_EXTRACT(json_doc, path)`
+- **`->>`** — Shorthand for `JSON_UNQUOTE(JSON_EXTRACT(json_doc, path))`
+- **`IS [NOT] JSON`** — Test whether a value parses as valid JSON. See the operator reference for the full form
+
+## See Also
+
+- **`mariadb-create-table`** — declaring `JSON`-typed columns (alias for `LONGTEXT` with auto `CHECK`)
+- **`mariadb-select`** — `JSON_TABLE` in the `FROM` clause for relational projection of JSON documents
+- Canonical reference: `server/reference/sql-functions/special-functions/json-functions/` (41 pages); JSONPath syntax at `…/jsonpath-expressions.md`

--- a/agent-skills/granular/statements/mariadb-alter-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-alter-table/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: mariadb-alter-table
+description: "MariaDB-specific syntax and behavior for ALTER TABLE — online DDL with ALGORITHM (DEFAULT/COPY/INPLACE/NOCOPY/INSTANT) and LOCK clauses, ALTER ONLINE TABLE shorthand, WAIT/NOWAIT lock timeouts, IF EXISTS/IF NOT EXISTS on subclauses, ADD/DROP SYSTEM VERSIONING, ADD PERIOD FOR, DROP CONSTRAINT, FORCE rebuild, CONVERT PARTITION/TABLE, DISCARD/IMPORT TABLESPACE, atomic ALTER, two-phase replication. Use when writing, generating, or reviewing ALTER TABLE statements that target MariaDB, or planning schema migrations against MariaDB."
+---
+
+# ALTER TABLE in MariaDB
+
+*Last updated: 2026-06-02*
+
+This skill covers the **delta between standard SQL `ALTER TABLE` and MariaDB's**. It assumes the agent already knows the standard form (`ALTER TABLE name ADD/DROP/MODIFY …`). Everything below documents MariaDB-specific syntax, lock/algorithm behavior, and online-DDL nuances. For column attributes and index options themselves, defer to the **`mariadb-create-table`** skill — both statements share them.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| Several `ALTER TABLE t …;` statements in a row | **Combine into one** `ALTER TABLE t ADD …, DROP …, MODIFY …;` — MariaDB rebuilds the table only once for the whole list, vs. once per statement |
+| Reaching for `gh-ost` / `pt-online-schema-change` | Not needed for InnoDB on MariaDB — `ALTER TABLE` defaults to `ALGORITHM=DEFAULT, LOCK=DEFAULT`, which already does online DDL where the operation supports it. For copy-algorithm operations, `LOCK=NONE` is supported since 11.2 |
+| `LOCK TABLES … WRITE; ALTER TABLE …; UNLOCK TABLES;` to "make it safe" | The opposite — that *blocks* concurrent reads/writes. Use `ALTER ONLINE TABLE …` or `ALTER TABLE … LOCK=NONE` instead |
+| `ALTER TABLE` on a system-versioned table failing with a duplicate-row error | Set `system_versioning_alter_history = KEEP` (session) before altering — see the `mariadb-system-versioned-tables` skill |
+| Migration script that fails if a column already exists / a column doesn't exist | Use the subclause-level `IF NOT EXISTS` / `IF EXISTS` (see "IF EXISTS" below) for idempotent migrations — emits a warning instead of erroring |
+| `ALTER TABLE t DROP CHECK constraint_name` | `ALTER TABLE t DROP CONSTRAINT constraint_name` — MariaDB uses the standard `DROP CONSTRAINT` form for check constraints (and others) |
+| Big `DELETE` to shrink a table, no follow-up | `ALTER TABLE t FORCE;` rebuilds the table and reclaims unused space (requires `innodb_file_per_table=ON`, default) |
+| Setting `ALGORITHM=INPLACE` blindly to avoid copy | If the operation rebuilds the clustered index, `INPLACE` may still be slow. Use `ALGORITHM=NOCOPY` to *require* no clustered-index rebuild — it errors out if the operation can't do that |
+| Schema migration on a replication primary causing replica lag | Set `binlog_alter_two_phase=ON` (since 10.8) so replicas begin applying when the primary *starts* the ALTER, not when it finishes |
+
+## Online DDL — `ALGORITHM` and `LOCK`
+
+`ALTER TABLE t … , ALGORITHM=…, LOCK=…;`
+
+### ALGORITHM values
+
+| Algorithm | Meaning | Use case |
+|---|---|---|
+| `DEFAULT` | Pick the most efficient algorithm the operation supports | Almost always the right choice; named for explicit override |
+| `COPY` | Build a new table + copy all rows + rename. Generic, works for any engine | Old / fallback path. As of 11.2 supports `LOCK=NONE` for most operations |
+| `INPLACE` | Engine-specific in-place operation; *may* still rebuild | Most InnoDB add/drop column / index operations land here |
+| `NOCOPY` | **MariaDB-specific.** Like `INPLACE` but errors out if the operation would rebuild the clustered index | Use to guarantee fast schema change on large tables — fail fast if it would be slow |
+| `INSTANT` | Metadata-only operation, no data files touched | Add column at end (InnoDB), some column renames, some default-value changes |
+
+> `alter_algorithm` (and the older `old_alter_table`) system variable was **removed in 11.5** — set `ALGORITHM=…` explicitly per statement if you need to override.
+
+### LOCK values
+
+| Lock | Effect |
+|---|---|
+| `DEFAULT` | Least restrictive lock the operation supports |
+| `NONE` | All concurrent DML allowed. As of 11.2, supported for most operations under any algorithm; before 11.2, restricted to certain `ALGORITHM=INPLACE` operations |
+| `SHARED` | Concurrent reads only |
+| `EXCLUSIVE` | No concurrent DML |
+
+### `ALTER ONLINE TABLE` shorthand
+
+```sql
+ALTER ONLINE TABLE t ADD COLUMN c INT;
+-- equivalent to:
+ALTER TABLE t ADD COLUMN c INT, LOCK=NONE;
+```
+
+Fails with an error if the operation can't actually run with `LOCK=NONE`. Use this when you want the migration to refuse rather than silently block writers.
+
+## WAIT / NOWAIT — Lock Timeout per Statement
+
+```sql
+ALTER TABLE t WAIT 5 ADD COLUMN c INT;     -- wait up to 5s for MDL, then ER_LOCK_WAIT_TIMEOUT
+ALTER TABLE t NOWAIT ADD COLUMN c INT;     -- fail immediately if MDL can't be acquired
+```
+
+Bounds how long the statement will wait for the metadata lock. Indispensable for safe migration tooling — without these the statement may queue indefinitely behind a long-running transaction. Applies to many other statements too (`SELECT … FOR UPDATE WAIT N`, `LOCK TABLES … NOWAIT`, etc.).
+
+## IF EXISTS / IF NOT EXISTS on Subclauses
+
+MariaDB allows `IF EXISTS` / `IF NOT EXISTS` on individual subclauses, not just on the table:
+
+```sql
+ALTER TABLE t
+  ADD COLUMN IF NOT EXISTS c INT,
+  ADD INDEX IF NOT EXISTS idx_c (c),
+  DROP COLUMN IF EXISTS legacy_col,
+  DROP FOREIGN KEY IF EXISTS fk_old;
+```
+
+When the condition isn't met (column already exists, column doesn't exist, …), the statement emits a **warning** and skips that subclause, continuing to the next. This is how idempotent migrations are written in MariaDB. Supported subclauses: `ADD COLUMN`, `ADD INDEX`, `ADD FOREIGN KEY`, `ADD PARTITION`, `CREATE INDEX`, `DROP COLUMN`, `DROP INDEX`, `DROP FOREIGN KEY`, `DROP PARTITION`, `CHANGE COLUMN`, `MODIFY COLUMN`.
+
+`ALTER TABLE IF EXISTS t …` (on the table itself) emits a warning if the table is missing rather than erroring.
+
+## System Versioning Operations
+
+```sql
+ALTER TABLE t ADD SYSTEM VERSIONING;     -- start versioning an existing table
+ALTER TABLE t DROP SYSTEM VERSIONING;    -- stop versioning; DELETES ALL HISTORY
+ALTER TABLE t ADD PERIOD FOR effective (valid_from, valid_to);   -- application-time period
+```
+
+**Trap:** any other `ALTER` on an already-system-versioned table requires `system_versioning_alter_history = KEEP` (session-level), otherwise the statement errors out. Setting this preserves existing history rows under the new schema — querying historical data may return rows that don't match the new column definitions, which is documented behavior.
+
+See the `mariadb-system-versioned-tables` skill for the full versioning model.
+
+## DROP CONSTRAINT
+
+```sql
+ALTER TABLE t DROP CONSTRAINT c_name;
+```
+
+Single statement drops any kind of constraint by name — check constraints, named foreign keys, named unique constraints. Use this rather than older form-specific clauses like `DROP CHECK`.
+
+## FORCE — Rebuild the Table
+
+```sql
+ALTER TABLE t FORCE;
+```
+
+Rebuilds the table without changing its definition. Two main use cases:
+
+- **Reclaim space** after large `DELETE` operations (requires `innodb_file_per_table=ON`, the default).
+- **Re-validate data** under a stricter `sql_mode` — e.g. setting `NO_ZERO_DATE` and then `FORCE` will surface existing rows that violate the new mode.
+
+## Partition Operations
+
+Standard SQL partition-management clauses are supported. MariaDB-specific or version-specific points:
+
+| Clause | Notes |
+|---|---|
+| `CONVERT PARTITION p TO TABLE t2` | Detach a partition into a standalone table |
+| `CONVERT TABLE t2 TO PARTITION p VALUES …` | Attach a standalone table as a new partition |
+| `EXCHANGE PARTITION p WITH TABLE t2` | Swap data between a partition and a table |
+| `REMOVE PARTITIONING` | Convert a partitioned table back to a regular table |
+
+For partitioning by `SYSTEM_TIME` (auto-rotating history partitions for system-versioned tables), see the `mariadb-system-versioned-tables` skill.
+
+## DISCARD / IMPORT TABLESPACE — InnoDB Transportable Tablespaces
+
+```sql
+-- On the source server:
+FLUSH TABLES t FOR EXPORT;     -- creates t.cfg alongside t.ibd
+-- copy t.ibd and t.cfg to the destination datadir
+-- On the destination:
+ALTER TABLE t DISCARD TABLESPACE;
+-- ...place the .ibd file in the destination's datadir...
+ALTER TABLE t IMPORT TABLESPACE;
+```
+
+InnoDB-only. Aria, MyISAM, etc. don't need this — they pick up data files placed in the datadir directly.
+
+## Atomic ALTER and Replication
+
+- `ALTER TABLE` is **atomic** for InnoDB, MyRocks, MyISAM, and Aria — crash recovery leaves either the old or the new table intact, never partial `#sql-*` files. (Since 10.6.)
+- DDL still triggers an implicit commit; no transactional rollback of an `ALTER`.
+- Set `binlog_alter_two_phase=ON` (since 10.8) to start replicating ALTER when it *begins* on the primary rather than when it finishes. Eliminates the replication lag of a long-running schema change.
+
+## See Also
+
+- **`mariadb-create-table`** — column definitions, index definitions, and table options (shared syntax surface)
+- **`mariadb-system-versioned-tables`** — versioning model, `system_versioning_alter_history`, history-row semantics
+- Canonical reference: `server/reference/sql-statements/data-definition/alter/alter-table/README.md` (~870 lines) plus `…/alter-table/online-schema-change.md` — consult only for edge cases not covered here

--- a/agent-skills/granular/statements/mariadb-create-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-table/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: mariadb-create-table
+description: "MariaDB-specific syntax and behavior for CREATE TABLE — atomic CREATE OR REPLACE, INVISIBLE / COMPRESSED columns, system-versioned and application-time PERIOD clauses, IGNORED indexes, table-level encryption, page compression, sequence and Aria table options, and the utf8/utf8mb4 trap. Use when writing, generating, or reviewing CREATE TABLE statements that target MariaDB."
+---
+
+# CREATE TABLE in MariaDB
+
+*Last updated: 2026-06-01*
+
+This skill covers the **delta between standard SQL `CREATE TABLE` and MariaDB's**. It assumes the agent already knows standard `CREATE TABLE name (col type, …)`. Everything below documents MariaDB-specific syntax, table options, column attributes, and behaviors.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user specifies another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `DROP TABLE x; CREATE TABLE x …` | `CREATE OR REPLACE TABLE x …` (atomic equivalent, no window where the table is missing) |
+| `CHARSET = utf8` | `CHARSET = utf8mb4` — `utf8` is an alias for the legacy 3-byte form (`utf8mb3`) and cannot store 4-byte characters (most emoji, some CJK) |
+| Manual `created_at` / `updated_at` audit columns | `CREATE TABLE … WITH SYSTEM VERSIONING` — see the `mariadb-system-versioned-tables` skill |
+| `ROW_FORMAT = COMPRESSED` for "modern" disk savings | That's the older InnoDB compressed row format. For new tables on modern InnoDB/Aria, prefer `PAGE_COMPRESSED = 1` plus optional `PAGE_COMPRESSION_LEVEL = N` |
+| Generated column with `STORED` | Works, but MariaDB's historical keyword is `PERSISTENT`. Both are accepted; `PERSISTENT` shows up in older code and in `SHOW CREATE TABLE` output |
+| Foreign keys on a MyISAM / Aria table | Silently parsed and discarded — only InnoDB enforces foreign keys |
+| `IF NOT EXISTS` on a table with a different schema | Skips creation and emits a **warning** (not error); the existing table is left untouched even if its definition differs |
+| Wrapping `CREATE TABLE` in a transaction | DDL triggers an implicit commit. There is no way to roll back a `CREATE TABLE`; rely on atomic DDL (below) for crash safety instead |
+
+## CREATE OR REPLACE
+
+```sql
+CREATE OR REPLACE TABLE t (id INT PRIMARY KEY);
+```
+
+- Atomic equivalent of `DROP TABLE IF EXISTS t; CREATE TABLE t …`.
+- Cannot be combined with `IF NOT EXISTS`.
+- Crash-safe but **not fully atomic** in the strict sense — recovery picks one side cleanly, but observers mid-statement may see the table missing. Plain `CREATE TABLE` *is* fully atomic (since 10.6.1).
+
+## Temporal Tables — `PERIOD FOR …`
+
+MariaDB supports three temporal forms via the `PERIOD FOR` clause:
+
+```sql
+-- System-versioned (transaction time, automatic history):
+CREATE TABLE t (id INT, val INT) WITH SYSTEM VERSIONING;
+
+-- Application-time period (business-valid time, application-managed):
+CREATE TABLE t (
+  id INT, val INT,
+  valid_from DATE, valid_to DATE,
+  PERIOD FOR effective (valid_from, valid_to)
+);
+
+-- Bitemporal (both at once):
+CREATE TABLE t (
+  id INT, val INT,
+  valid_from DATE, valid_to DATE,
+  PERIOD FOR effective (valid_from, valid_to)
+) WITH SYSTEM VERSIONING;
+```
+
+For querying history, partitioning by `SYSTEM_TIME`, or removing old history, defer to the **`mariadb-system-versioned-tables`** skill.
+
+Specific columns can be excluded from versioning:
+
+```sql
+CREATE TABLE t (
+  id INT,
+  login_counter INT WITHOUT SYSTEM VERSIONING
+) WITH SYSTEM VERSIONING;
+```
+
+> **UPDATE behavior note:** for timestamp-based system versioning, a new history row is created for every `UPDATE` that touches a versioned column, even if no column value actually changes. See `mariadb-system-versioned-tables` for details.
+
+## Column-Level MariaDB Extensions
+
+| Clause | Effect |
+|---|---|
+| `col VARCHAR(N) COMPRESSED` | Per-value zlib compression on the column (transparent to clients) |
+| `col INT INVISIBLE` | Excluded from `SELECT *`; explicit `SELECT col` still works; `INSERT` without column list skips it |
+| `DEFAULT (expr)` | Defaults can be any deterministic expression — `DEFAULT (1+1)`, `DEFAULT(NOW() + INTERVAL 1 YEAR)`, `DEFAULT USER()` |
+| `col INT GENERATED ALWAYS AS (expr) PERSISTENT` | Stored generated column. `PERSISTENT` is MariaDB's keyword; `STORED` is also accepted as an alias. Use `VIRTUAL` (default) for computed-on-read |
+| `col INT GENERATED ALWAYS AS (expr) VIRTUAL` | Computed-on-read generated column (no storage cost, evaluated per query) |
+| `col VECTOR(N)` *(since 11.7)* | Fixed-length float vector column — see the `mariadb-vector` skill |
+
+## Index Definitions — MariaDB-Specific Options
+
+```sql
+INDEX idx_name (col1, col2) [index_type] [index_option …]
+```
+
+| Option | Meaning |
+|---|---|
+| `IGNORED` / `NOT IGNORED` *(since 10.6)* | Optimizer pretends the index doesn't exist (still maintained on writes). Use to "soft-disable" an index before dropping it |
+| `INVISIBLE` / `VISIBLE` | Optimizer ignores the index; DML still updates it |
+| `COMMENT '…'` | Free-text annotation, visible in `INFORMATION_SCHEMA.STATISTICS` |
+| `WITH PARSER name` | Fulltext indexes only — pluggable parser |
+| `CLUSTERING=YES` | Spider engine only |
+
+Keywords `INDEX` and `KEY` are interchangeable in MariaDB.
+
+## Table Options — MariaDB-Specific or Often-Confused
+
+| Option | Meaning |
+|---|---|
+| `ENGINE = InnoDB` | Default engine. Set globally via `default_storage_engine`. If an engine isn't installed, substitution happens silently unless `sql_mode` includes `NO_ENGINE_SUBSTITUTION` |
+| `ENCRYPTED = YES` | Per-table at-rest encryption. Requires an encryption key-management plugin (e.g. `file_key_management`) and `innodb_encrypt_tables`. Combine with `ENCRYPTION_KEY_ID = N` |
+| `PAGE_COMPRESSED = 1` | InnoDB / Aria page-level compression (LZ4 / zstd / lzma / lz4hc / bzip2 / snappy, depending on which compression provider plugins are loaded). **Distinct from `ROW_FORMAT = COMPRESSED`** (older InnoDB zlib mechanism). Add `PAGE_COMPRESSION_LEVEL = 0..9` |
+| `ROW_FORMAT = …` | Per-engine row layout. InnoDB: `COMPACT \| DYNAMIC \| COMPRESSED \| REDUNDANT`. Aria: `PAGE \| FIXED \| DYNAMIC`. MyISAM: `FIXED \| DYNAMIC \| COMPRESSED` |
+| `SEQUENCE = 1` | Makes this `CREATE TABLE` produce a sequence instead of a regular table. Prefer the dedicated `CREATE SEQUENCE` statement |
+| `TRANSACTIONAL = 1` | Crash-safe Aria. Aria-only; ignored on other engines |
+| `IETF_QUOTES = YES` | Aria's IETF-style identifier quoting. Aria-only |
+| `WITH SYSTEM VERSIONING` | Table-level versioning (see temporal section) |
+| `UNION = (t1, t2, …)` | MERGE engine table list |
+| `CONNECTION = '…'` | Connection string for FederatedX / CONNECT engines |
+| `DATA DIRECTORY = '…'` / `INDEX DIRECTORY = '…'` | Place table data or indexes on a different filesystem. Absolute paths only |
+
+## Atomic DDL
+
+- Plain `CREATE TABLE` is **atomic** since 10.6.1 — crash recovery either has the table fully created or not at all.
+- `CREATE OR REPLACE TABLE` is **crash-safe but not fully atomic** — see above.
+- All DDL still triggers an implicit commit; there is no way to roll back a `CREATE TABLE` from inside a transaction.
+
+## See Also
+
+- **`mariadb-system-versioned-tables`** — full system-versioning, application-time, bitemporal, querying history, partitioning, removing history
+- **`mariadb-vector`** — `VECTOR(N)` columns and vector indexes
+- Canonical reference: `server/reference/sql-statements/data-definition/create/create-table.md` (~980 lines) — consult only for edge cases not covered here

--- a/agent-skills/granular/statements/mariadb-select/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-select/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: mariadb-select
+description: "MariaDB-specific syntax and behavior for SELECT — optimizer hints (/*+ ... */, JOIN_PREFIX/JOIN_ORDER/JOIN_FIXED_ORDER/JOIN_SUFFIX, MAX_EXECUTION_TIME) and legacy query-level hints, LIMIT extensions (comma-form, ROWS EXAMINED), OFFSET … FETCH … ONLY/WITH TIES, FOR UPDATE / LOCK IN SHARE MODE with WAIT/NOWAIT/SKIP LOCKED, PARTITION pruning, FOR SYSTEM_TIME temporal queries, SELECT INTO OUTFILE/DUMPFILE/variable, WITH ROLLUP, max_statement_time, FROM DUAL. Covers SELECT, SELECT INTO OUTFILE, SELECT INTO DUMPFILE, SELECT … OFFSET … FETCH, and SELECT WITH ROLLUP. Use when writing, generating, or reviewing SELECT statements that target MariaDB."
+---
+
+# SELECT in MariaDB
+
+*Last updated: 2026-06-02*
+
+This skill covers the **delta between standard SQL `SELECT` and MariaDB's**. It assumes the agent already knows the standard form (`SELECT … FROM … WHERE … GROUP BY … HAVING … ORDER BY … LIMIT …`). Everything below documents MariaDB-specific syntax, locking semantics, file output, optimizer-hint variants, and the most common LLM traps. Consolidates **SELECT**, **SELECT INTO OUTFILE**, **SELECT INTO DUMPFILE**, **SELECT … OFFSET … FETCH**, and **SELECT WITH ROLLUP** into a single lookup.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `SELECT SQL_CALC_FOUND_ROWS …` + `SELECT FOUND_ROWS()` for paginated total | Run a separate `SELECT COUNT(*) …` instead. `SQL_CALC_FOUND_ROWS` is legacy and typically *slower* than a dedicated count on modern InnoDB, because it materializes the full result set ignoring `LIMIT` |
+| `LIMIT 100, 10` (comma form: offset first, count second) | Prefer `LIMIT 10 OFFSET 100` — both work, but the comma form puts offset and count in the opposite order from most other databases and is a common source of off-by-N bugs |
+| `SELECT … FOR UPDATE` in a worker queue | Add `SKIP LOCKED` so workers don't block each other: `SELECT … FOR UPDATE SKIP LOCKED`. *InnoDB only* — silently ignored on other engines (no error, just sequential locking behavior) |
+| `SELECT … INTO OUTFILE '/tmp/x'` and the file already exists | Will error — `INTO OUTFILE` and `INTO DUMPFILE` **never overwrite**. Either delete first or write to a fresh path. Also requires the `FILE` privilege and the path must satisfy `secure_file_priv` |
+| `SELECT … WITH ROLLUP ORDER BY x` | `WITH ROLLUP` is incompatible with `ORDER BY` — use `ASC`/`DESC` on the `GROUP BY` columns instead. The super-aggregate rows always come last regardless |
+| Worrying about a long query running forever | Either `SELECT /*+ MAX_EXECUTION_TIME(5000) */ …` (since 12.0) or `SET STATEMENT max_statement_time = 5 FOR SELECT …` (older) — both bound the statement at the server level |
+| Unbounded `SELECT` that might scan too much during exploration | `LIMIT 1000 ROWS EXAMINED 100000` — caps both rows returned *and* rows examined (a MariaDB-specific safety net not in standard SQL) |
+| `JOIN_PREFIX(t1, t2)` written as an old-style optimizer hint | The join-order hints (`JOIN_PREFIX`, `JOIN_ORDER`, `JOIN_FIXED_ORDER`, `JOIN_SUFFIX`) are *only* valid inside the `/*+ … */` hint comment syntax (since 12.0). The legacy hint keywords (`STRAIGHT_JOIN`, `HIGH_PRIORITY`, etc.) sit between `SELECT` and the column list and don't use the `/*+ */` form |
+| `SQL_CACHE` / `SQL_NO_CACHE` hints | The query cache is **off by default** (`query_cache_type=0`) and is generally counter-productive on modern InnoDB workloads (high write concurrency invalidates cached entries constantly). Drop these hints from generated SQL unless the user has explicitly enabled the cache and is on a read-mostly workload |
+
+## Optimizer Hints
+
+Two distinct surfaces. Both exist; they're not interchangeable.
+
+### 1. Hint-comment form (newer, recommended)
+
+```sql
+SELECT /*+ MAX_EXECUTION_TIME(5000) JOIN_ORDER(t2, t1) */
+  t1.a, t2.b FROM t1 JOIN t2 ON t1.id = t2.id;
+```
+
+| Hint | Effect | Since |
+|---|---|---|
+| `MAX_EXECUTION_TIME(N)` | Cap statement at N milliseconds | 12.0 |
+| `JOIN_PREFIX(t, …)` | Force these tables to be joined first | 12.0 |
+| `JOIN_ORDER(t, …)` | Hint join order without making it absolute | 12.0 |
+| `JOIN_FIXED_ORDER(t, …)` | Hard-fix the join order to exactly this | 12.0 |
+| `JOIN_SUFFIX(t, …)` | Force these tables to be joined last | 12.0 |
+
+The hint-comment block must come **immediately after `SELECT`**, before any other modifiers. Multiple hints can share one comment. Available since **11.8** as syntax; specific hints listed above shipped in 12.0.
+
+### 2. Legacy keyword form (still supported)
+
+These sit as bare keywords between `SELECT` and the column list:
+
+| Keyword | Effect |
+|---|---|
+| `STRAIGHT_JOIN` | Join tables in the order they appear in `FROM` |
+| `HIGH_PRIORITY` | Give this `SELECT` higher priority than competing writes (MyISAM-era; minimal effect on modern InnoDB) |
+| `SQL_SMALL_RESULT` / `SQL_BIG_RESULT` | Optimizer hint about expected result-set size (drives temp-table choice) |
+| `SQL_BUFFER_RESULT` | Force result buffering to release table locks earlier |
+| `SQL_CALC_FOUND_ROWS` | Counts rows ignoring `LIMIT` for `FOUND_ROWS()` — see "What LLMs Often Miss" |
+| `SQL_CACHE` / `SQL_NO_CACHE` | Per-statement override of the query cache. The cache is off by default and typically harmful on modern workloads; the hints are still parsed but rarely useful |
+
+## LIMIT, OFFSET, FETCH
+
+Three syntaxes for pagination — all valid:
+
+```sql
+-- Comma form (offset first, count second):
+SELECT … FROM t LIMIT 100, 10;
+
+-- With explicit OFFSET keyword:
+SELECT … FROM t LIMIT 10 OFFSET 100;
+
+-- Standard SQL OFFSET … FETCH (since 10.6):
+SELECT … FROM t ORDER BY id OFFSET 100 ROWS FETCH NEXT 10 ROWS ONLY;
+```
+
+Notes:
+
+- `LIMIT row_count OFFSET offset` is the safer, less ambiguous form. The comma form puts offset first; the `OFFSET` keyword form puts count first.
+- `FETCH … WITH TIES` (also since 10.6) returns extra rows that tie for the last spot — **requires an `ORDER BY` clause** or errors out (ER 4180).
+- `FIRST` and `NEXT` are interchangeable; `ROW` and `ROWS` are interchangeable.
+- **`LIMIT … ROWS EXAMINED N`** is MariaDB-specific:
+
+  ```sql
+  SELECT … FROM t WHERE … LIMIT 10 ROWS EXAMINED 100000;
+  ```
+
+  Stops the scan once N rows have been examined (not just returned). Useful as a safety bound during exploration, or to enforce a soft SLA on a query.
+
+## Row Locking — `FOR UPDATE`, `LOCK IN SHARE MODE`
+
+```sql
+SELECT … FROM t WHERE … FOR UPDATE       [WAIT n | NOWAIT | SKIP LOCKED];
+SELECT … FROM t WHERE … LOCK IN SHARE MODE [WAIT n | NOWAIT | SKIP LOCKED];
+```
+
+| Modifier | Effect |
+|---|---|
+| `WAIT n` | Wait up to *n* seconds for the lock, then error with lock-wait-timeout |
+| `NOWAIT` | Fail immediately if the lock can't be acquired |
+| `SKIP LOCKED` | Skip rows currently locked by other transactions — return only what can be locked. Implicit `NOWAIT`. **InnoDB only**; silently ignored on other engines |
+
+`FOR UPDATE` acquires write locks; `LOCK IN SHARE MODE` acquires read locks. The standard SQL synonym `FOR SHARE` is also accepted.
+
+Worker-queue idiom (the canonical `SKIP LOCKED` use case):
+
+```sql
+START TRANSACTION;
+SELECT id, payload FROM jobs
+  WHERE status = 'pending'
+  ORDER BY priority, id
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+-- ... process the job, then UPDATE its status ...
+COMMIT;
+```
+
+## Temporal Queries — `FOR SYSTEM_TIME`
+
+Available on tables created `WITH SYSTEM VERSIONING`:
+
+```sql
+SELECT * FROM t FOR SYSTEM_TIME AS OF TIMESTAMP '2026-01-01 00:00:00';
+SELECT * FROM t FOR SYSTEM_TIME BETWEEN ts1 AND ts2;
+SELECT * FROM t FOR SYSTEM_TIME FROM ts1 TO ts2;
+SELECT * FROM t FOR SYSTEM_TIME ALL;
+```
+
+The clause goes immediately after the table name (before any alias). The system variable `system_versioning_asof` applies a default `FOR SYSTEM_TIME AS OF` to every query in the session.
+
+Full versioning model, transaction-precise vs. timestamp-precise variants, query-time-vs-transaction-time, etc.: see the **`mariadb-system-versioned-tables`** skill.
+
+## `INTO OUTFILE`, `INTO DUMPFILE`, `INTO @var`
+
+```sql
+SELECT … INTO OUTFILE 'file_name'
+    [CHARACTER SET charset_name]
+    [{FIELDS | COLUMNS} [TERMINATED BY 's'] [[OPTIONALLY] ENCLOSED BY 'c'] [ESCAPED BY 'c']]
+    [LINES [STARTING BY 's'] [TERMINATED BY 's']];
+
+SELECT … INTO DUMPFILE 'file_name';
+
+SELECT col1, col2 INTO @var1, @var2 FROM t WHERE …;
+```
+
+| Form | What it does |
+|---|---|
+| `INTO OUTFILE` | Writes the resultset as text, one row per line, with configurable field/line separators. Inverse of `LOAD DATA INFILE`. Defaults: tab-separated fields, newline-terminated lines |
+| `INTO DUMPFILE` | Writes a **single row** (must be one) as raw bytes — no separators, no escaping. Use for `BLOB` extraction (images, etc.) |
+| `INTO @var, …` | Assigns the row's column values to user variables. The query must return exactly one row |
+
+Common constraints (apply to both `OUTFILE` and `DUMPFILE`):
+
+- **The file must not exist.** No overwrite, ever — delete or rotate beforehand.
+- The connecting user needs the **`FILE`** global privilege.
+- The path is constrained by `secure_file_priv` — if it's set (it usually is), files can only be written under that directory. `secure_file_priv = NULL` disables file I/O entirely.
+- The file path is a **string literal**, not a variable. Workaround: build the statement dynamically and `PREPARE`/`EXECUTE` it.
+
+ANSI placement of `INTO OUTFILE` (between the column list and `FROM`) is supported for simple `SELECT`s only. For a `UNION` or set operation, place `INTO OUTFILE` on a wrapping `SELECT * FROM ( … )`:
+
+```sql
+SELECT * INTO OUTFILE '/path/out.tsv'
+FROM (SELECT * FROM t1 UNION SELECT * FROM t2);
+```
+
+## `WITH ROLLUP`
+
+```sql
+SELECT country, year, SUM(sales) FROM sales
+  GROUP BY country, year WITH ROLLUP;
+```
+
+Adds super-aggregate rows: one per group prefix, then a grand total. The super-aggregated columns appear as `NULL` in the extra rows.
+
+Constraints and traps:
+
+- **Cannot be combined with `ORDER BY`.** Use `ASC` / `DESC` on the `GROUP BY` columns to control ordering; super-aggregate rows always come last regardless.
+- **`LIMIT` applies *after* rollup rows are added** — so `LIMIT 4` on a rollup result may cut off the grand-total row.
+- **`NULL` ambiguity**: super-aggregate rows have `NULL` in grouped columns. If your data also contains genuine `NULL`s in those columns, the result is ambiguous; use `GROUPING()` (where available) or an explicit sentinel during display.
+
+## Other MariaDB-specific Bits
+
+| Clause | Notes |
+|---|---|
+| `PARTITION (p1, p2, …)` after a table name | Limit scan to specified partitions; combines with `WHERE` |
+| `FROM DUAL` | Optional placeholder when no `FROM` clause is needed: `SELECT 1 + 1 FROM DUAL;` |
+| `NEXT VALUE FOR seq_name` | Get the next sequence value in a `SELECT` (see CREATE SEQUENCE) |
+| `JSON_TABLE(json, '$[*]' COLUMNS (…))` in `FROM` | Treat a JSON document as a derived table |
+| `INTERSECT`, `EXCEPT` | Full standard set operators; not just `UNION` |
+| `VALUES (…), (…), …` standalone | Can be used in place of `SELECT` in many contexts: `VALUES (1, 'a'), (2, 'b')` |
+| Recursive CTEs (`WITH RECURSIVE x AS (…)`) | Full standard support |
+
+## See Also
+
+- **`mariadb-system-versioned-tables`** — full `FOR SYSTEM_TIME` semantics, transaction-precise history, versioning-aware partitioning
+- **`mariadb-create-table`** / **`mariadb-alter-table`** — shared column, index, and table-option surface
+- Canonical references:
+  - `server/reference/sql-statements/data-manipulation/selecting-data/select.md` (~220 lines)
+  - `…/select-into-outfile.md` (~80 lines)
+  - `…/select-into-dumpfile.md` (~60 lines)
+  - `…/select-offset-fetch.md` (~120 lines)
+  - `…/select-with-rollup.md` (~155 lines)
+
+  Consult only for edge cases not covered here.

--- a/agent-skills/topical/VENDORED.md
+++ b/agent-skills/topical/VENDORED.md
@@ -1,0 +1,33 @@
+# Vendored topical skills — provenance
+
+The skills in this directory are **vendored** (copied verbatim) from the
+MariaDB Foundation's topical skill set. They are **not** maintained here — do
+not hand-edit them. A sync workflow overwrites this directory from upstream;
+local edits would be lost. File content bugs against the upstream repository.
+
+| Field | Value |
+| --- | --- |
+| Upstream repository | https://github.com/MariaDB/skills |
+| Pinned ref (tag/commit) | _TBD — set when first vendored_ |
+| Upstream license | **PENDING** — confirmation requested from Robert Silen (MariaDB Foundation); do not vendor until confirmed |
+| Last synced | _not yet synced_ |
+| Synced by | `.github/workflows/sync-topical-skills.yml` (stub) |
+
+## Why vendored rather than a submodule
+
+The DX consumer must be able to pull **one directory** (`agent-skills/`) and get
+every layer, including from a plain sparse checkout or tarball. A git submodule
+would leave this directory as an empty gitlink unless the consumer runs
+`--recurse-submodules`, which defeats that goal. Vendoring materializes the real
+files here; pinning to a release tag keeps it reproducible.
+
+## Before the first sync
+
+1. Confirm the upstream license and how it must be reproduced (LICENSE file,
+   per-file header, attribution line). Record it in the table above.
+2. Decide the subset to vendor. Per DOCS-6206, the application-developer
+   "keepers" are: `mariadb-features`, `mariadb-query-optimization`,
+   `mariadb-system-versioned-tables`, `mysql-to-mariadb`, `mariadb-vector`.
+   (`mariadb-mcp`, `mariadb-replication-and-ha`, `oracle-to-mariadb` are lower
+   priority for this use case.)
+3. Pin the upstream ref and fill in the table.

--- a/dev-docs/agent-skills-maintenance.md
+++ b/dev-docs/agent-skills-maintenance.md
@@ -1,0 +1,115 @@
+# Maintaining the agent skills (DX project)
+
+How the `agent-skills/` directory is authored and kept current. This is the
+human-facing companion to `agent-skills/README.md` (which covers layout and
+consumption) and the per-tier `README.md` / `VENDORED.md` files. Tracked under
+DOCS-6206.
+
+The artifact is a **delta from what an LLM writes by default** — MariaDB
+knowledge minus the typical LLM prior. That delta exists nowhere in the source
+docs, so the high-value parts are editorial, not extractable.
+
+> **Editorial rule (do not skip):** never name MySQL in a skill. The LLM's
+> default is MySQL-shaped because its training data is MySQL-heavy, so the
+> "What LLMs Often Miss" tables correct a MySQL-shaped prior — but state the
+> MariaDB form directly, don't frame it as a comparison.
+> - Don't: *"PERSISTENT is historical; STORED (MySQL-compat) also works."*
+> - Do: *"MariaDB's keyword is PERSISTENT. STORED is also accepted as an alias."*
+
+## The three layers, and who maintains them
+
+| Layer | Path | Maintenance |
+| --- | --- | --- |
+| Tier 1 (statements) | `granular/statements/` | Hand-authored + human-verified, here |
+| Tier 2 (functions) | `granular/functions/` | Extractor-generated body + hand-written scaffold, here |
+| Topical | `topical/` | Vendored from `MariaDB/skills`; file bugs upstream, do not edit here |
+
+## Where "what LLMs miss" knowledge comes from
+
+Five sources, in roughly increasing order of reliability. The first four are
+desk research; the fifth is the most reliable and removes the "must be a MariaDB
+expert" gate from the author.
+
+1. **Robert's `mysql-to-mariadb` topical skill, reverse-engineered.** Anything
+   flagged "different in MariaDB" is by construction a candidate trap.
+2. **`mariadb-features` "Defaults Changed" / "Behavior Changed" sections.**
+   Anything listed is a trap by definition — training data predates it
+   (e.g. `innodb_snapshot_isolation` default flip, `latin1`→`utf8mb4`, query
+   cache off/removed).
+3. **Docs `{% hint %}` blocks and inline warnings.** An inline warning is the
+   docs team saying "people get this wrong" (e.g. `IF NOT EXISTS` warns rather
+   than errors; FKs silently ignored on MyISAM).
+4. **Version-conditional content** — GitBook `{% tabs %}` contrasting Current
+   vs `< X.Y` is the team admitting behavior changed at X.Y. A trap if the LLM's
+   training reflects the old behavior.
+5. **Empirical testing (most reliable).** Open a fresh agent session with no
+   MariaDB skill loaded, ask it to write the statement for a representative
+   task, and diff its output against MariaDB-correct output. Repeat for 3–4
+   prompts per statement; the same misconceptions recur. You observe traps
+   rather than having to predict them.
+
+## Tier 1 authoring workflow (per statement family)
+
+1. **Author — Claude.** Draft the skill and a candidate "What LLMs Often Miss"
+   table (8–10 rows) from sources 1–4 above. ~5–10 min.
+2. **Verify — human.** Walk each row; spot-check against `mariadb-server/sql/`
+   source or the canonical `server/reference/**` page. **Non-negotiable**, and
+   does not require MariaDB expertise — willingness to grep is enough. ~30–45 min.
+3. **Empirical confirmation — either.** Source 5: drop traps that aren't
+   actually traps in current LLM output; add ones the human missed.
+
+Realistic cost: **35–55 min per skill.**
+
+**Why verification is non-negotiable:** at scale (100 skills × ~10 rows × a
+1–2% error rate on "X works differently in MariaDB" claims) that's 10–20
+factually wrong rows shipping — and they look authoritative because they sit in
+a "What LLMs Often Miss" table. The query-cache slip caught during the SELECT
+pilot is the cautionary tale.
+
+### Skill conventions
+
+- One directory per skill, containing `SKILL.md` (Claude Code skill convention).
+- Frontmatter `name:` + a triage `description:` (when the skill should fire).
+- Header line `*Last updated: YYYY-MM-DD*` and the **11.8 LTS** baseline note.
+- Features in every current LTS branch (10.6, 10.11, 11.4, 11.8) carry no
+  "since" annotation; only newer-than-10.6 features get `*(since X.Y)*`.
+- Cross-link to a topical skill for feature depth rather than duplicating it
+  (e.g. `mariadb-alter-table` defers column attributes to `mariadb-create-table`).
+- Target ~8–12 KB. Absolute size matters, not compression ratio — it has to fit
+  cheaply in agent context.
+
+## Tier 2 maintenance (function categories)
+
+The per-function entries are generated; the scaffold around them is not.
+
+- Scaffold (frontmatter, intro, category-level "What LLMs Often Miss" table) is
+  hand-written from `agent-skills/extractor/templates/function-category.scaffold.md`.
+- The body between the `BEGIN/END GENERATED` markers is produced by
+  `agent-skills/extractor/extract_function_category.py` against the canonical
+  `server/reference/sql-functions/**/<category>/` pages.
+- CI (`extract-function-skills.yml`, stub) re-runs the extractor when those
+  pages change and opens a regeneration PR, preserving the scaffold sections.
+
+## Per-LTS update workflow
+
+Roughly annually, per LTS release:
+
+1. **Structured review per Tier 1 skill** against its `server/reference/**`
+   page(s) and `mariadb-server/sql/` source. For every "since X.Y" / "removed in
+   X.Y" claim, verify. For every trap-table row, confirm the trap is still real.
+   Flag new doc content not yet reflected. ~15–30 min per skill — cheaper than
+   authoring.
+2. **Targeted review** for releases with notable removals/deprecations
+   (e.g. query cache removed in 13.0): review only the affected skills.
+3. **Tier 2:** re-run the extractor (CI handles this on doc change).
+4. **Topical:** re-vendor from upstream at the new pinned ref; update
+   `topical/VENDORED.md`.
+5. **Empirical-fresh-session sweep every 12–18 months.** As LLMs improve, some
+   traps stop being traps; prune them so the tables don't accumulate dead weight.
+
+## Scope discipline ("good enough" over "perfect")
+
+- Skip differences that don't matter for application development (e.g.
+  optimizer-hint deltas rarely surface in app-dev contexts).
+- Cover high-use cases — DDL, DML, common SQL functions. For everything else,
+  let the agent fall through to `mariadb.com/docs`.


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — the coding-agent skill-files track.

Creates `agent-skills/` as the **single consumption point** the DX tool can pull (or receive a push of) in full: every layer materializes as real files, so a plain sparse checkout or tarball gets everything (no submodule recursion needed).

## What's in this PR

- **`granular/statements/`** — Tier 1 pilots: `mariadb-create-table`, `mariadb-alter-table`, `mariadb-select` (hand-curated, source of truth).
- **`granular/functions/`** — Tier 2 pilot: `mariadb-json-functions`.
- **`extractor/`** — the Tier 2 function-skill extractor + scaffold template + README.
- **`topical/VENDORED.md`** — provenance stub for skills to be vendored from [`MariaDB/skills`](https://github.com/MariaDB/skills). **Not vendored yet** — gated on upstream license confirmation.
- **`README.md` + `.skills-manifest.json`** — eng-handoff doc and skill index.
- **`dev-docs/agent-skills-maintenance.md`** — authoring workflow, the five sources of "what LLMs miss" knowledge, Tier 2 maintenance, per-LTS update workflow, and the no-MySQL editorial rule.

## Notes for review

- **Not rendered in GitBook** — `agent-skills/` (and `dev-docs/`) appear in no `SUMMARY.md`, matching how `help-tables/` is handled. Treat as a build/handoff artifact, not doc pages.
- **Topical layer follows separately** once the `MariaDB/skills` license is confirmed; the sync workflow (`sync-topical-skills.yml`) and the Tier 2 extractor CI (`extract-function-skills.yml`) are documented stubs, not yet written.
- **Push vs. pull** handoff to the DX tool is still open; the layout supports both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)