### PR TITLE
DOCS-6268: fix "Removed:" typo on storage_engine variable entry

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -2704,7 +2704,7 @@ MariaDB sets the limit with [setrlimit](https://linux.die.net/man/2/setrlimit). 
 
 * Description: See [default\_storage\_engine](server-system-variables.md#default_storage_engine).
 * Deprecated: [MariaDB 5.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/5.5/changes-improvements-in-mariadb-5-5)
-* Remove: [MariaDB 12.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.0/what-is-mariadb-120)
+* Removed: [MariaDB 12.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.0/what-is-mariadb-120)
 
 #### `standard_compliant_cte`
 


### PR DESCRIPTION
Fixes a one-word typo on the `storage_engine` entry of the Server System Variables reference page: the field label read `Remove:` instead of the standard `Removed:` used by every other removed-variable entry.

The removal version (MariaDB 12.0) is unchanged and was verified against server source (`sql/sys_vars.cc`; removal commit `11f6b9d12a7`, present in 11.8 and absent from 12.0 onward).

Context: this surfaced while working DOCS-6268. The bulk of that ticket was already done — all three variables (`big_tables`, `large_page_size`, `storage_engine`) were already documented as `Removed: MariaDB 12.0` — so DOCS-6268 was closed as already-done and this trivial typo is the only residual edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)