### PR TITLE
DOCS-6267: Add 12.x reserved words (CONVERSION, ST_COLLECT, TO_DATE)

### DIFF
--- a/server/reference/sql-structure/sql-language-structure/reserved-words.md
+++ b/server/reference/sql-structure/sql-language-structure/reserved-words.md
@@ -38,6 +38,7 @@ The definitive list of reserved words for each version can be found by examining
 | CONDITION                         |
 | CONSTRAINT                        |
 | CONTINUE                          |
+| CONVERSION (> 12.2)               |
 | CONVERT                           |
 | CREATE                            |
 | CROSS                             |
@@ -224,6 +225,7 @@ The definitive list of reserved words for each version can be found by examining
 | STATS\_PERSISTENT                 |
 | STATS\_SAMPLE\_PAGES              |
 | STRAIGHT\_JOIN                    |
+| ST\_COLLECT (> 11.8)              |
 | TABLE                             |
 | TERMINATED                        |
 | THEN                              |
@@ -231,6 +233,7 @@ The definitive list of reserved words for each version can be found by examining
 | TINYINT                           |
 | TINYTEXT                          |
 | TO                                |
+| TO\_DATE (> 12.2)                 |
 | TRAILING                          |
 | TRIGGER                           |
 | TRUE                              |


### PR DESCRIPTION
Adds the three keywords that became reserved words to the [Reserved Words](https://mariadb.com/docs/server/reference/sql-structure/sql-language-structure/reserved-words) reference page, using the page's existing `(> X.Y)` version-note style.

| Word | Reserved from | Annotation |
|------|---------------|------------|
| `CONVERSION` | MariaDB 12.3 | `(> 12.2)` |
| `TO_DATE` | MariaDB 12.3 | `(> 12.2)` |
| `ST_COLLECT` | **MariaDB 12.0** | `(> 11.8)` |

**Source verification** (`mariadb-server`, across the 11.8–12.3 branches): all three appear only as `%token` declarations plus grammar productions in `sql/sql_yacc.yy` — never in a non-reserved `keyword_*` bucket — so they are reserved. `CONVERSION` and `TO_DATE` are absent until 12.3. `ST_COLLECT` has been present and reserved since **12.0**.

**Correction vs DOCS-6267:** the ticket lists `ST_COLLECT` as new in 12.3, based on an 11.8-vs-12.3 comparison. Checking the intermediate branches shows it was already reserved in 12.0, so it is annotated `(> 11.8)` (reserved from the release after 11.8 = 12.0), consistent with the calibration of the page's `(> X.Y)` convention against `VECTOR (> 11.6)`.

Passes `docs-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)