### PR TITLE
Ignore GitBook-truncated SUMMARY titles in codespell

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -2,3 +2,5 @@ toi
 AKS
 ist
 inout
+numbe
+characte


### PR DESCRIPTION
## Problem

codespell fails on `server/SUMMARY.md`:

```
server/SUMMARY.md:3163: numbe ==> number, numb
server/SUMMARY.md:3678: characte ==> character
```

These are **not authoring typos**. GitBook caps nav/page titles at ~100 characters and truncates them **mid-word**, then re-asserts that truncation on every web-app sync. The two error-code entries land on dictionary-near fragments:

- `e1510` — "…not to change their **numbers**" → truncated to `numbe`
- `e3056` — "…maximum length of 32 **characters**" → truncated to `characte`

The page sources (`e1510.md`, `e3056.md`) are correct — full H1, no frontmatter. The truncation lives only in GitBook's nav state.

## Why not re-fix the titles?

This was already tried twice on 2026-06-18 — DOCS-6242 ("Fix mid-word truncations in SUMMARY error-code titles") and DOCS-6261 ("Complete import-truncated error-code titles"). Both were reverted the same day by GitBook sync commit `af514b759` (GITBOOK-2365). Re-fixing SUMMARY.md is a treadmill; the sync wins.

## Fix

Add the two truncation fragments to `.codespellignore`, alongside the existing `ist` / `inout` / `toi` entries (same class of GitBook-truncation artifact). `.codespellignore` is a repo config file GitBook never touches, so the gate stays stable. A true nav fix would have to happen in the GitBook web app (shorten the titles below the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)