### PR TITLE
DOCS-6272 [TEST] Verify codespell ignores SUMMARY.md

### DIFF
--- a/dev-docs/codespell-test/SUMMARY.md
+++ b/dev-docs/codespell-test/SUMMARY.md
@@ -1,0 +1,9 @@
+# Codespell exclusion test
+
+This SUMMARY.md contains a deliberate misspelling that codespell normally
+flags: recieve.
+
+If the codespell check passes (green), the files_ignore rule for SUMMARY.md is
+working. If it fails on "recieve", the exclusion is NOT working.
+
+Delete this file (and control.md beside it) before merging — DOCS-6272 test.

--- a/dev-docs/codespell-test/control.md
+++ b/dev-docs/codespell-test/control.md
@@ -1,0 +1,7 @@
+# Codespell control file
+
+This page is intentionally free of spelling mistakes. It exists only so that
+codespell has a non-ignored changed file to scan on this PR. If codespell runs
+and this PR's check stays green, the SUMMARY.md exclusion is working.
+
+Delete this file (and the SUMMARY.md beside it) before merging — DOCS-6272 test.


### PR DESCRIPTION
Temporary test files to confirm the files_ignore rule on a live PR:
- dev-docs/codespell-test/SUMMARY.md contains a real codespell hit (recieve)
- dev-docs/codespell-test/control.md is clean, to keep codespell running

Expected: codespell check passes (green) because the only misspelling is in the excluded SUMMARY.md. Revert before merge.