### PR TITLE
DOCS-6232 Document when innodb_log_file_buffering/write_through changes are ignored

### DIFF
--- a/server/server-usage/storage-engines/innodb/innodb-flush-method.md
+++ b/server/server-usage/storage-engines/innodb/innodb-flush-method.md
@@ -69,6 +69,10 @@ From MariaDB 11.0, the flushing behavior of InnoDB should no longer be controlle
 2. `innodb_data_file_buffering`: The default is `OFF`; set it to `ON` if you encounter read performance problems.
 3. `innodb_log_file_write_through`, `innodb_data_file_write_through`: The default is `OFF` for both variables; setting them to `ON` can improve or degrade write performance, depending on whether or not the hardware supports FUA (Forced Unit Access).
 
+{% hint style="info" %}
+A `SET GLOBAL` change to `innodb_log_file_buffering` or `innodb_log_file_write_through` can be silently ignored — for example, while an `innodb_log_file_size` resize is in progress, or when the log is mapped to persistent memory (PMEM). Confirm the change took effect by reading the value back, as described for [`innodb_log_file_buffering`](innodb-system-variables.md#innodb_log_file_buffering) and [`innodb_log_file_write_through`](innodb-system-variables.md#innodb_log_file_write_through).
+{% endhint %}
+
 ### FUA (Forced Unit Access)
 
 FUA is a hardware-level flag used during write operations to ensure data integrity. When InnoDB sends a write command with the FUA flag, it tells the storage device (SSD or HDD) that the write must be written directly to the non-volatile, stable media before the device can report that the task is finished.

--- a/server/server-usage/storage-engines/innodb/innodb-system-variables.md
+++ b/server/server-usage/storage-engines/innodb/innodb-system-variables.md
@@ -1798,6 +1798,16 @@ Automatic upward dynamic resizing is not yet implemented ([MDEV-36197](https://j
 * Default Value: `OFF`
 * Introduced: [MariaDB 10.8.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/changelogs/10.8/10.8.4), [MariaDB 10.9.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/changelogs/10.9/10.9.2)
 
+{% hint style="info" %}
+A change requested with `SET GLOBAL innodb_log_file_buffering` is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress. From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored whenever InnoDB has more than one log file open on a circular-format log (`ib_logfile0`), such as during the tail of a resize or an `innodb_log_archive=ON` log-file switch. The change takes effect when InnoDB holds only one log file open, which is the case most of the time. The setting has no effect when the log is mapped to persistent memory (PMEM).
+
+Because the request can be silently ignored, confirm that it took effect by reading the value back:
+
+```sql
+SELECT @@GLOBAL.innodb_log_file_buffering;
+```
+{% endhint %}
+
 #### `innodb_log_file_mmap`
 
 * Description: Whether ib\_logfile0 resides in persistent memory or should initially be memory-mapped. When using the default innodb\_log\_buffer\_size=2m, mariadb-backup --backup would spend a lot of time re-reading and re-parsing the log. For reading the log file during mariadb-backup --backup, it is beneficial to memory-map the entire ib\_logfile0 to the address space (typically 48 bits or 256 TiB) and read it from there,\
@@ -1831,6 +1841,16 @@ Automatic upward dynamic resizing is not yet implemented ([MDEV-36197](https://j
 * Data Type: `boolean`
 * Default Value: `OFF`
 * Introduced: [MariaDB 11.0.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.0)
+
+{% hint style="info" %}
+A change requested with `SET GLOBAL innodb_log_file_write_through` is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress. From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored whenever InnoDB has more than one log file open on a circular-format log (`ib_logfile0`), such as during the tail of a resize or an `innodb_log_archive=ON` log-file switch. The change takes effect when InnoDB holds only one log file open, which is the case most of the time. The setting has no effect when the log is mapped to persistent memory (PMEM).
+
+Because the request can be silently ignored, confirm that it took effect by reading the value back:
+
+```sql
+SELECT @@GLOBAL.innodb_log_file_write_through;
+```
+{% endhint %}
 
 #### `innodb_log_files_in_group`
 

--- a/server/server-usage/storage-engines/innodb/innodb-system-variables.md
+++ b/server/server-usage/storage-engines/innodb/innodb-system-variables.md
@@ -1799,7 +1799,7 @@ Automatic upward dynamic resizing is not yet implemented ([MDEV-36197](https://j
 * Introduced: [MariaDB 10.8.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/changelogs/10.8/10.8.4), [MariaDB 10.9.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/changelogs/10.9/10.9.2)
 
 {% hint style="info" %}
-A change requested with `SET GLOBAL innodb_log_file_buffering` is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress. From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored whenever InnoDB has more than one log file open on a circular-format log (`ib_logfile0`), such as during the tail of a resize or an `innodb_log_archive=ON` log-file switch. The change takes effect when InnoDB holds only one log file open, which is the case most of the time. The setting has no effect when the log is mapped to persistent memory (PMEM).
+A change requested with `SET GLOBAL innodb_log_file_buffering` takes effect only when InnoDB is holding a single log file open, which is the case most of the time. It is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress on a circular-format log (`ib_logfile0`). From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored while a log file switch is in progress with [`innodb_log_archive`](innodb-system-variables.md#innodb_log_archive) set to `ON`, because InnoDB then has more than one log file open; when this occurs, and how long it lasts, is hard to predict, as it depends on `innodb_log_file_size` and the workload. The setting also has no effect when the log is mapped to persistent memory (PMEM).
 
 Because the request can be silently ignored, confirm that it took effect by reading the value back:
 
@@ -1843,7 +1843,7 @@ SELECT @@GLOBAL.innodb_log_file_buffering;
 * Introduced: [MariaDB 11.0.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.0/11.0.0)
 
 {% hint style="info" %}
-A change requested with `SET GLOBAL innodb_log_file_write_through` is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress. From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored whenever InnoDB has more than one log file open on a circular-format log (`ib_logfile0`), such as during the tail of a resize or an `innodb_log_archive=ON` log-file switch. The change takes effect when InnoDB holds only one log file open, which is the case most of the time. The setting has no effect when the log is mapped to persistent memory (PMEM).
+A change requested with `SET GLOBAL innodb_log_file_write_through` takes effect only when InnoDB is holding a single log file open, which is the case most of the time. It is ignored while a `SET GLOBAL innodb_log_file_size` resize is in progress on a circular-format log (`ib_logfile0`). From MariaDB 13.0 ([MDEV-39862](https://jira.mariadb.org/browse/MDEV-39862)), it is also ignored while a log file switch is in progress with [`innodb_log_archive`](innodb-system-variables.md#innodb_log_archive) set to `ON`, because InnoDB then has more than one log file open; when this occurs, and how long it lasts, is hard to predict, as it depends on `innodb_log_file_size` and the workload. The setting also has no effect when the log is mapped to persistent memory (PMEM).
 
 Because the request can be silently ignored, confirm that it took effect by reading the value back:
 


### PR DESCRIPTION
Resolves [DOCS-6232](https://mariadbcorp.atlassian.net/browse/DOCS-6232). Source: [server PR #5224](https://github.com/MariaDB/server/pull/5224) / MDEV-39862.

A `SET GLOBAL` change to `innodb_log_file_buffering` or `innodb_log_file_write_through` can be silently ignored, so the requested value may not take effect. This documents when, and how to confirm the change landed.

## Changes

- **`innodb-system-variables.md`** — a hint on each of the `innodb_log_file_buffering` and `innodb_log_file_write_through` entries: the change is ignored while an `innodb_log_file_size` resize is in progress; from **MariaDB 13.0 (MDEV-39862)** also whenever InnoDB has more than one log file open on a circular-format log (`ib_logfile0`); and it has no effect when the log is on persistent memory (PMEM). Each hint shows the `SELECT @@GLOBAL.…` read-back to verify the change.
- **`innodb-flush-method.md`** — a cross-reference hint after the `SET GLOBAL`-modifiable variable list, pointing back to both reference entries.

## Verification

Claims verified against `mariadb-server` main @ `c6e8dad6424d363ca6c3a58e47a6c6903a231962`:

- `log_t::set_buffered()` / `set_write_through()` (`storage/innobase/log/log0log.cc`) return early on `is_mmap()` (PMEM) and only apply the change when `!resize_in_progress() && is_opened() && !resize_log.is_opened()`.
- The `!resize_log.is_opened()` clause ("more than one log file open") is the part **added by MDEV-39862** (commit `abaef32ac15`); the `resize_in_progress()` and `is_mmap()` guards predate 13.0, so the version qualifier is scoped to the new clause only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6232]: https://mariadbcorp.atlassian.net/browse/DOCS-6232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ