### PR TITLE
Add release notes for Connector/ODBC 3.2.9

### DIFF
--- a/release-notes/connectors/c++/1.0/1.0.7.md
+++ b/release-notes/connectors/c++/1.0/1.0.7.md
@@ -1,0 +1,35 @@
+# Connector/C++ 1.0.7 Release Notes
+
+{% include "../../../.gitbook/includes/latest-cpp.md" %}
+
+<p align="center"><a href="https://mariadb.com/downloads/connectors/connectors-data-access/cpp-connector" class="button primary">Download Now</a></p>
+
+**Release date:** 2 Oct 2025
+
+This is a [_**Stable (GA)**_](../../../community-server/about/release-criteria.md) release of MariaDB Connector/C++.
+
+{% hint style="info" %}
+**For a description of this library see the** [**MariaDB Connector/C++**](https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-cpp) **page.**
+{% endhint %}
+
+MariaDB Connector/C++ is the interface between C++ applications and MariaDB Server. MariaDB Connector/C++ enables development of C++ applications using a JDBC-based API, which is also used by MariaDB Connector/J.
+
+MariaDB Connector/C++ implements the MySQL protocol using the MariaDB Connector/C API. This release depends on [MariaDB Connector/C 3.3.19](../../c/3.3/3.3.19.md).
+
+## Notable Changes
+
+* [CONCPP-153](https://jira.mariadb.org/browse/CONCPP-153) - Query parameters escaping did not consider if parameter data is encoded in multibyte charset. This could permit SQL injection in case of
+  client side statement preparing(default). The problematic character sets are big5, gbk, sjis, cp932
+
+## Bugs Fixed
+
+* [CONCPP-152](https://jira.mariadb.org/browse/CONCPP-152) - CONC-812 side-effect on temporal types - with binary-protocol reads of DATE/TIME/DATETIME/TIMESTAMP columns the connector would return empty strings.
+* [CONCPP-154](https://jira.mariadb.org/browse/CONCPP-154) - Make LOCAL_INFILE_MODE_AUTO used by the connector if LOCAL INFILE commands are allowed(allowLocalInfile set to true). This is safer mode for use of LOCAL INFILE commands 
+
+## Installation
+
+* [Install MariaDB Connector/C++](https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-cpp/install-mariadb-connector-cpp)
+
+{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+
+{% @marketo/form formid="4316" formId="4316" %}

--- a/release-notes/connectors/odbc/3.1/3.1.23.md
+++ b/release-notes/connectors/odbc/3.1/3.1.23.md
@@ -1,0 +1,33 @@
+# Connector/ODBC 3.1.23 Release Notes
+
+<a href="https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector" class="button primary">Download</a> <a href="3.1.23.md" class="button secondary">Release Notes</a> <a href="../changelogs/3.1/3.1.23.md" class="button secondary">Changelog</a> <a href="https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc" class="button secondary">About MariaDB Connector/ODBC</a>
+
+**Release date:** 
+
+This is a [Stable (GA)](../../../community-server/about/release-criteria.md) release of MariaDB Connector/ODBC 3.1.
+
+MariaDB Connector/ODBC 3.1.23 is built on top of [MariaDB Connector/C v.3.3.19](../../c/3.4/3.3.19.md).
+
+## Important Changes
+* [ODBC-494](https://jira.mariadb.org/browse/ODBC-494) - Incorrect string escaping in case of multibyte charsets. This could permit SQL injection in case of
+  client side statement preparing(default for SQLExecDirect). The problematic character sets are big5, gbk, sjis, cp932
+## Bug Fixes
+* [ODBC-490](https://jira.mariadb.org/browse/ODBC-490) - SQLSpecialColumns with iOdbc on MacOS on ARM 
+* [ODBC-496](https://jira.mariadb.org/browse/ODBC-496) - Small negative scale for SQL_C_NUMERIC parameter could cause buffer overflow  
+* [ODBC-489](https://jira.mariadb.org/browse/ODBC-489) - UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset /source/driver/ma_statement.cpp:2295:5
+* [ODBC-493](https://jira.mariadb.org/browse/ODBC-493) - Make LOCAL_INFILE_MODE_AUTO default for the connector - this is enables by default safer mode for LOCAL INFILE commands
+* [ODBC-492](https://jira.mariadb.org/browse/ODBC-492) - Wrong COLUMN_SIZE reported for datetime columns
+* [ODBC-495](https://jira.mariadb.org/browse/ODBC-495) - SQLGetTypeInfo does not return MAXIMUM_SCALE for temporal types with possible fractional part
+* [ODBC-475](https://jira.mariadb.org/browse/ODBC-475) - MariaDB ODBC Driver returns "Invalid information type" when asked for SQL_POSITIONED_STATEMENTS.
+* [ODBC-479](https://jira.mariadb.org/browse/ODBC-479) - Using SQLGetData with column > column count could crash the connector.
+* [ODBC-480](https://jira.mariadb.org/browse/ODBC-480) - Inccorect work of the SQLDescribeCol - it did not return column length if buffer parameter and buffer length were 0.
+
+## Changelog
+
+For a complete list of every change made in this release, with links to detailed information on each push, see the [changelog](../changelogs/3.1/3.1.23.md).
+
+{% include "../../../.gitbook/includes/announce.md" %}
+
+{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+
+{% @marketo/form formid="4316" formId="4316" %}

--- a/release-notes/connectors/odbc/3.2/3.2.9.md
+++ b/release-notes/connectors/odbc/3.2/3.2.9.md
@@ -6,7 +6,7 @@
 
 This is a [Stable (GA)](../../../community-server/about/release-criteria.md) release of MariaDB Connector/ODBC 3.2.
 
-MariaDB Connector/ODBC 3.2.9 is built on top of [MariaDB Connector/C v.3.4.8](../../c/3.4/3.4.9.md).
+MariaDB Connector/ODBC 3.2.9 is built on top of [MariaDB Connector/C v.3.4.9](../../c/3.4/3.4.9.md).
 
 ## Important Changes
 * [ODBC-494](https://jira.mariadb.org/browse/ODBC-494) - Incorrect string escaping in case of multibyte charsets. This could permit SQL injection in case of
@@ -22,7 +22,7 @@ MariaDB Connector/ODBC 3.2.9 is built on top of [MariaDB Connector/C v.3.4.8](..
 
 ## Changelog
 
-For a complete list of every change made in this release, with links to detailed information on each push, see the [changelog](../changelogs/3.2/3.2.8.md).
+For a complete list of every change made in this release, with links to detailed information on each push, see the [changelog](../changelogs/3.2/3.2.9.md).
 
 {% include "../../../.gitbook/includes/announce.md" %}
 

--- a/release-notes/connectors/odbc/3.2/3.2.9.md
+++ b/release-notes/connectors/odbc/3.2/3.2.9.md
@@ -1,0 +1,31 @@
+# Connector/ODBC 3.2.9 Release Notes
+
+<a href="https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector" class="button primary">Download</a> <a href="3.2.9.md" class="button secondary">Release Notes</a> <a href="../changelogs/3.2/3.2.9.md" class="button secondary">Changelog</a> <a href="https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc" class="button secondary">About MariaDB Connector/ODBC</a>
+
+**Release date:** 
+
+This is a [Stable (GA)](../../../community-server/about/release-criteria.md) release of MariaDB Connector/ODBC 3.2.
+
+MariaDB Connector/ODBC 3.2.9 is built on top of [MariaDB Connector/C v.3.4.8](../../c/3.4/3.4.9.md).
+
+## Important Changes
+* [ODBC-494](https://jira.mariadb.org/browse/ODBC-494) - Incorrect string escaping in case of multibyte charsets. This could permit SQL injection in case of
+  client side statement preparing(default for SQLExecDirect). The problematic character sets are big5, gbk, sjis, cp932
+## Bug Fixes
+* [ODBC-491](https://jira.mariadb.org/browse/ODBC-491) - 3.2 packages do not contain parsec auth plugin
+* [ODBC-490](https://jira.mariadb.org/browse/ODBC-490) - SQLSpecialColumns with iOdbc on MacOS on ARM 
+* [ODBC-496](https://jira.mariadb.org/browse/ODBC-496) - Small negative scale for SQL_C_NUMERIC parameter could cause buffer overflow  
+* [ODBC-489](https://jira.mariadb.org/browse/ODBC-489) - UndefinedBehaviorSanitizer: nullptr-with-nonzero-offset /source/driver/ma_statement.cpp:2295:5
+* [ODBC-493](https://jira.mariadb.org/browse/ODBC-493) - Make LOCAL_INFILE_MODE_AUTO default for the connector
+* [ODBC-492](https://jira.mariadb.org/browse/ODBC-492) - Wrong COLUMN_SIZE reported for datetime columns
+* [ODBC-495](https://jira.mariadb.org/browse/ODBC-495) - SQLGetTypeInfo does not return MAXIMUM_SCALE for temporal types with possible fractional part
+
+## Changelog
+
+For a complete list of every change made in this release, with links to detailed information on each push, see the [changelog](../changelogs/3.2/3.2.8.md).
+
+{% include "../../../.gitbook/includes/announce.md" %}
+
+{% include "https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/~/reusable/pNHZQXPP5OEz2TgvhFva/" %}
+
+{% @marketo/form formid="4316" formId="4316" %}


### PR DESCRIPTION
This release includes important changes and bug fixes, such as addressing SQL injection risks and various issues related to the ODBC connector.