### PR TITLE
DOCS-6272 [TEST] Verify link check passes on a link-free page

### DIFF
--- a/dev-docs/linkcheck-test.md
+++ b/dev-docs/linkcheck-test.md
@@ -1,0 +1,9 @@
+# Link check test
+
+This page deliberately contains no links of any kind. It exists only to verify
+that the PR link checker no longer fails with "No links were found" when a
+changed Markdown file has nothing to link-check.
+
+Expected: the link-check check passes (green) thanks to failIfEmpty: false.
+
+Delete this file before merging — DOCS-6272 test.


### PR DESCRIPTION
Temporary: a Markdown file with no links, to confirm failIfEmpty: false stops the false "No links were found" failure. Expected green. Revert before merge.