### PR TITLE
DOCS-6284: Fix cross-links to the Windows mariadb-install-db page

### DIFF
--- a/server/clients-and-utilities/deployment-tools/mariadb-install-db.md
+++ b/server/clients-and-utilities/deployment-tools/mariadb-install-db.md
@@ -10,7 +10,7 @@ description: >-
 {% hint style="warning" %}
 **This page is for the `mariadb-install-db` script for Linux/Unix only.**
 
-For the Windows specific tool of similar name and purpose see [mysql\_install\_db.exe](../legacy-clients-and-utilities/mysql_install_db.md).
+For the Windows-specific tool of similar name and purpose, see [Installing System Tables on Windows](../../server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/mariadb-install-db-exe.md).
 
 The Windows version shares the common theme (creating system tables), yet has a lot of functionality specific to Windows systems, for example creating a Windows service. The Windows version does _not_ share command line parameters with the Unix shell script.
 {% endhint %}
@@ -75,7 +75,7 @@ _Password_ for [catalog-user](../../security/user-account-management/catalogs/).
 
 #### --catalog-client-arg=_argument_
 
-Other _arguments_ to `mariadb` when adding new [catalogs](https://github.com/mariadb-corporation/docs-server/blob/test/server/clients-and-utilities/security/user-account-management/catalogs/README.md). This option is available from MariaDB 11.7.
+Other _arguments_ to `mariadb` when adding new [catalogs](../../security/user-account-management/catalogs/). This option is available from MariaDB 11.7.
 
 #### --cross-bootstrap
 

--- a/server/clients-and-utilities/legacy-clients-and-utilities/mysql_install_db.md
+++ b/server/clients-and-utilities/legacy-clients-and-utilities/mysql_install_db.md
@@ -4,7 +4,7 @@
 
 From [MariaDB 10.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.5/what-is-mariadb-105), the client is called `mariadb-install-db`. It can still be accessed under its original `mysql_install_db` name via a symlink in Linux, or an alternate binary in Windows.
 
-See [mariadb-install-db](../deployment-tools/mariadb-install-db.md) for details.
+See [mariadb-install-db](../deployment-tools/mariadb-install-db.md) for details on Linux/Unix. For the Windows tool, see [Installing System Tables on Windows](../../server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/mariadb-install-db-exe.md).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/mariadb-install-db-exe.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/mariadb-install-db-exe.md
@@ -32,6 +32,10 @@ The functionality of `mariadb-install-db.exe` is comparable with the shell scrip
 | `-c`, `--config`                   | `my.ini` config template file, since `MariaDB 10.6.1` |
 
 {% hint style="info" %}
+`--config` takes a **template** option file: `mariadb-install-db.exe` copies it into the data directory as `my.ini` and then appends the server settings it generates (such as `datadir` and `port`). The template must be a valid option file. Note that `config` is a command-line option of this tool, not a server variable, so it must not appear as a setting inside the template.
+{% endhint %}
+
+{% hint style="info" %}
 **T**o create a Windows service, `mariadb-install-db.exe` should be run\
 by a user with full administrator privileges (which means elevated command\
 prompt on systems with UAC).


### PR DESCRIPTION
## What

Resolves [DOCS-6284](https://mariadbcorp.atlassian.net/browse/DOCS-6284), which traces to [MDEV-40135](https://jira.mariadb.org/browse/MDEV-40135).

A reader following the **Windows tool** link from the Linux/Unix `mariadb-install-db` page was sent to the legacy `mysql_install_db` stub — which links straight back to the Linux/Unix page. That loop never reaches the real Windows documentation, so the reporter concluded no Windows docs existed (they do: *Installing System Tables on Windows*).

## Changes

- **`deployment-tools/mariadb-install-db.md`** — point the Windows warning at the actual *Installing System Tables on Windows* page instead of the looping legacy stub. Also fix a stale, 404ing `github.com/.../docs-server/...` link in the `--catalog-client-arg` description (reuses the relative path already used elsewhere on the page).
- **`legacy-clients-and-utilities/mysql_install_db.md`** — route Windows readers to the Windows page instead of dead-ending on the Unix page.
- **`mariadb-install-db-exe.md`** (Windows) — clarify that `--config` is a *template* copied into the data directory as `my.ini` and must be a valid option file; `config` is a command-line option of the tool, not a server variable (the exact misuse that triggered MDEV-40135).

## Verification

The Windows tool's behavior and option set were verified against `mariadb-server` `main` @ `2bd0af7349b3896ef88c1731db5261520bfa4a00`:
- Separate C++ program (`sql/mysql_install_db.cc`), built as target `mariadb-install-db` (`sql/CMakeLists.txt`).
- `--config`/`-c` copies the file into the datadir as `my.ini` (`CopyFile(opt_config, my_ini_path)`).
- `codespell` + `lychee` pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6284]: https://mariadbcorp.atlassian.net/browse/DOCS-6284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ