### PR TITLE
DOCS-6206 Vendor topical agent-skills from MariaDB/skills

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -27,6 +27,11 @@ jobs:
           files_ignore: |
             **/SUMMARY.md
             SUMMARY.md
+            # agent-skills/topical/ is vendored verbatim from MariaDB/skills
+            # (see agent-skills/topical/VENDORED.md). We don't hand-edit it, so
+            # spelling fixes go upstream, not here. Our own authored skills under
+            # agent-skills/granular/ stay in scope.
+            agent-skills/topical/**
 
       - name: Scan for for common misspellings in text files
         if: steps.changes.outputs.any_changed == 'true'

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -20,6 +20,11 @@ jobs:
           files: |
             **.md
             **.html
+          # agent-skills/topical/ is vendored verbatim from MariaDB/skills
+          # (see agent-skills/topical/VENDORED.md). Link fixes go upstream, not
+          # here. Our own authored skills under agent-skills/granular/ stay in scope.
+          files_ignore: |
+            agent-skills/topical/**
 
       - name: Scan for broken links
         if: steps.changes.outputs.any_changed == 'true'

--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -24,8 +24,15 @@
       "path": "topical",
       "author": "mariadb-foundation",
       "vendored_from": "https://github.com/MariaDB/skills",
-      "vendored_ref": null,
-      "skills": []
+      "vendored_ref": "86623494f8051e766c973d35c1f07368c3b4c267",
+      "vendored_license": "MIT",
+      "skills": [
+        { "name": "mariadb-features", "path": "topical/mariadb-features/SKILL.md", "status": "vendored" },
+        { "name": "mariadb-query-optimization", "path": "topical/mariadb-query-optimization/SKILL.md", "status": "vendored" },
+        { "name": "mariadb-system-versioned-tables", "path": "topical/mariadb-system-versioned-tables/SKILL.md", "status": "vendored" },
+        { "name": "mysql-to-mariadb", "path": "topical/mysql-to-mariadb/SKILL.md", "status": "vendored" },
+        { "name": "mariadb-vector", "path": "topical/mariadb-vector/SKILL.md", "status": "vendored" }
+      ]
     }
   }
 }

--- a/agent-skills/topical/LICENSE
+++ b/agent-skills/topical/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Robert Silén
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent-skills/topical/VENDORED.md
+++ b/agent-skills/topical/VENDORED.md
@@ -8,10 +8,28 @@ local edits would be lost. File content bugs against the upstream repository.
 | Field | Value |
 | --- | --- |
 | Upstream repository | https://github.com/MariaDB/skills |
-| Pinned ref (tag/commit) | _TBD — set when first vendored_ |
-| Upstream license | **PENDING** — confirmation requested from Robert Silen (MariaDB Foundation); do not vendor until confirmed |
-| Last synced | _not yet synced_ |
-| Synced by | `.github/workflows/sync-topical-skills.yml` (stub) |
+| Pinned ref (commit) | `86623494f8051e766c973d35c1f07368c3b4c267` |
+| Upstream license | **MIT** — Copyright (c) 2026 Robert Silén; see `LICENSE` in this directory |
+| Last synced | 2026-06-24 |
+| Synced by | Manual (initial vendor); `.github/workflows/sync-topical-skills.yml` to automate (stub) |
+
+## What is vendored
+
+The five application-developer "keepers" from DOCS-6206:
+
+| Skill | Upstream path |
+| --- | --- |
+| `mariadb-features` | `mariadb-features/SKILL.md` |
+| `mariadb-query-optimization` | `mariadb-query-optimization/SKILL.md` |
+| `mariadb-system-versioned-tables` | `mariadb-system-versioned-tables/SKILL.md` |
+| `mysql-to-mariadb` | `mysql-to-mariadb/SKILL.md` |
+| `mariadb-vector` | `mariadb-vector/SKILL.md` |
+
+Not vendored (lower priority for the app-dev use case): `mariadb-mcp`,
+`mariadb-replication-and-ha`, `oracle-to-mariadb`.
+
+The MIT license requires the copyright and permission notice to travel with the
+files, so the upstream `LICENSE` is copied into this directory verbatim.
 
 ## Why vendored rather than a submodule
 
@@ -21,13 +39,22 @@ would leave this directory as an empty gitlink unless the consumer runs
 `--recurse-submodules`, which defeats that goal. Vendoring materializes the real
 files here; pinning to a release tag keeps it reproducible.
 
-## Before the first sync
+## Re-syncing
 
-1. Confirm the upstream license and how it must be reproduced (LICENSE file,
-   per-file header, attribution line). Record it in the table above.
-2. Decide the subset to vendor. Per DOCS-6206, the application-developer
-   "keepers" are: `mariadb-features`, `mariadb-query-optimization`,
-   `mariadb-system-versioned-tables`, `mysql-to-mariadb`, `mariadb-vector`.
-   (`mariadb-mcp`, `mariadb-replication-and-ha`, `oracle-to-mariadb` are lower
-   priority for this use case.)
-3. Pin the upstream ref and fill in the table.
+To pull a newer upstream revision (until `sync-topical-skills.yml` automates it):
+
+1. Pick the new upstream commit/tag.
+2. Overwrite each vendored `SKILL.md` and the `LICENSE` from that ref. Do not
+   hand-edit the skills — file content bugs upstream against `MariaDB/skills`.
+3. Update the table above (pinned ref, last-synced date), the skill list if the
+   vendored subset changed, and `vendored_ref` in `../.skills-manifest.json`.
+
+## Known upstream nits (file against `MariaDB/skills`, do not fix here)
+
+Flagged in DOCS-6206; left as-is because this directory is vendored verbatim:
+
+- `mariadb-features`: the `latin1`→`utf8mb4` default change is tagged 11.6, but
+  several sources cite 10.10 / MDEV-25829.
+- `mariadb-vector`: typo "euclidian" → "euclidean"; the "5× faster than
+  `VEC_FromText()`" claim should be validated against current builds.
+- `mariadb-system-versioned-tables`: duplicate identical "Sources" link.

--- a/agent-skills/topical/mariadb-features/SKILL.md
+++ b/agent-skills/topical/mariadb-features/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: mariadb-features
+description: "MariaDB-specific features and capabilities that go beyond standard MySQL. Use when evaluating MariaDB, optimizing an existing MariaDB application, reviewing code or schema for MariaDB improvements, asking what MariaDB can do that other databases cannot, or migrating from Oracle to MariaDB. Also use when the user asks what could be improved in how a codebase uses MariaDB, or asks about MariaDB advantages over MySQL or PostgreSQL."
+---
+
+# MariaDB Features Worth Knowing
+
+*Last updated: 2026-06-24*
+
+MariaDB has grown significantly beyond its MySQL origins. Many of its best features are unknown to developers because AI agents default to generic SQL advice. This skill covers what MariaDB can do that you might not think to ask about.
+
+For MariaDB Vector (built-in since 11.7 — no plugins), see the `mariadb-vector` skill.
+
+> **Server context:** Unless the user names a version, assume a **MariaDB 11.8 LTS** deployment (GA May 2025) for what will run today. Per-feature tags (**10.5+**, **12.3+**, etc.) are **minimum versions** for that capability — not “introduced only in that release.” Do not treat **12.x / 13.0** items as available on 11.8; you may still mention them with an explicit version when relevant (e.g. upgrades).
+
+## What LLMs Often Miss
+
+| Situation | What to suggest instead |
+|---|---|
+| Manual audit columns (`created_at`, `updated_at`, deleted flag) | `WITH SYSTEM VERSIONING` — MariaDB tracks full row history automatically |
+| `INSERT` followed by `SELECT LAST_INSERT_ID()` | `RETURNING` — get the inserted row in one statement (10.5+) |
+| `AUTO_INCREMENT` for sequence-like needs | `CREATE SEQUENCE` — first-class sequence objects with full control |
+| IP addresses stored as `VARCHAR` | `INet4` / `INet6` — native IP types with comparison and indexing |
+| Dropping or reordering columns with full table rebuild | `INSTANT` algorithm for `ALTER TABLE` — no rebuild needed (10.4+) |
+| Oracle migration assumed to require full rewrite | `sql_mode=ORACLE` — PL/SQL, packages, Oracle-compatible NULL handling |
+| Asking what changed in a row over time | System-versioned tables with `FOR SYSTEM_TIME AS OF` |
+| Analytics queries on OLTP tables | ColumnStore engine — columnar storage for analytical workloads |
+| Correlated subqueries for rankings, running totals, or per-group top-N | Window functions — `OVER (PARTITION BY ... ORDER BY ...)`, clearer and usually faster (MariaDB 10.2+; not MariaDB-exclusive, also in MySQL 8.0) |
+| Deeply nested or repeated subqueries | Common Table Expressions — `WITH ...`, and `WITH RECURSIVE` for hierarchical/graph traversal (MariaDB 10.2+; also in MySQL 8.0) |
+| Assuming `JSON` is a native binary type as in MySQL 8.0 | In MariaDB `JSON` is an alias for `LONGTEXT COLLATE utf8mb4_bin` with an automatic `JSON_VALID()` CHECK constraint — stored as text, not MySQL's binary layout, and comparison is string-based. The JSON functions work the same. See [JSON Data Type](https://mariadb.com/docs/server/reference/data-types/string-data-types/json) |
+| Links or references to `mariadb.com/kb/en/` | The Knowledge Base no longer exists — all documentation is now at [mariadb.com/docs](https://mariadb.com/docs) |
+
+## Command-Line Tool Names (10.5+)
+
+Since MariaDB 10.5, all command-line tools use `mariadb-` prefixed names. Always generate the current names — the old `mysql*` names are retained as symlinks for compatibility but may be absent on minimal or container installs.
+
+| Deprecated name | Current name |
+|---|---|
+| `mysql` | `mariadb` |
+| `mysqldump` | `mariadb-dump` |
+| `mysqladmin` | `mariadb-admin` |
+| `mysqlbinlog` | `mariadb-binlog` |
+| `mysql_upgrade` | `mariadb-upgrade` |
+| `mysql_secure_installation` | `mariadb-secure-installation` |
+| `mysql_install_db` | `mariadb-install-db` |
+| `mysqlcheck` | `mariadb-check` |
+| `mysqlimport` | `mariadb-import` |
+| `mysqlshow` | `mariadb-show` |
+
+## Provisioning and Initial Setup
+
+AI agents default to MySQL 8 patterns for initial setup, which fail or mislead on MariaDB.
+
+**Database initialization** — use `mariadb-install-db` (not `mysqld --initialize`, which is MySQL-specific):
+```bash
+mariadb-install-db
+```
+
+**Root authentication** — on a fresh install, `root` uses `unix_socket` authentication by default (no password). The correct first connection is:
+```bash
+sudo mariadb
+```
+Do not generate `mysql -u root -p` for a fresh MariaDB install — there is no root password to enter.
+
+**Secure installation** — use `mariadb-secure-installation` (not `mysql_secure_installation`).
+
+## Upgrade Operations
+
+Agents consistently omit the `mariadb-upgrade` step after a binary upgrade, which can cause system table errors.
+
+**Standard upgrade pattern:**
+```bash
+systemctl stop mariadb
+# Replace binary via package manager (dnf/apt upgrade)
+systemctl start mariadb
+mariadb-upgrade    # updates system tables — do not skip this step
+```
+
+**Galera Cluster rolling upgrade** — never stop all nodes simultaneously:
+1. Take one non-primary node out of the load balancer
+2. Stop, upgrade the binary, start the node
+3. Confirm sync: `SHOW STATUS LIKE 'wsrep_local_state';` — must be `4` (Synced)
+4. Repeat for each remaining non-primary node
+5. Upgrade the primary node last
+
+> `mysql_upgrade` is the deprecated name (removed in later versions) — always use `mariadb-upgrade`.
+
+## Defaults Changed in 11.5–11.8 LTS
+
+The current LTS (11.8) flipped several long-standing defaults. New installations behave differently from older ones — relevant when migrating or comparing behavior:
+
+- **Default character set: `latin1` → `utf8mb4`** (11.6+, MDEV-19123) — new tables use `utf8mb4` unless overridden. Replication to MariaDB 10.6 or older replicas needs care (older replicas may not understand all `utf8mb4` collations).
+- **Default Unicode collation: `uca1400_ai_ci`** (11.5+, MDEV-25829) — modern Unicode collation with proper SMP (supplementary multilingual plane) support including emoji. Replaces the older `utf8mb4_general_ci` default.
+- **`alter_algorithm` deprecated and ignored** (11.5+, MDEV-33655) — specify `ALGORITHM=INSTANT|INPLACE|COPY` on the statement itself instead.
+- **TIMESTAMP range extended** (11.5+ 64-bit, MDEV-32188) — upper bound raised from `2038-01-19 03:14:07 UTC` to `2106-02-07 06:28:15 UTC`. Storage format unchanged; old servers can still read values within the old range.
+- **`innodb_snapshot_isolation` default ON** — see next section.
+
+## Behavior Change: innodb_snapshot_isolation (11.8+)
+
+From MariaDB 11.8 LTS, `innodb_snapshot_isolation` defaults to **ON** (previously OFF, MDEV-35124). This tightens REPEATABLE READ behavior to match true snapshot isolation — transactions see a consistent snapshot from their start and writes detect conflicts more strictly.
+
+**What can change for existing code:**
+- Read-modify-write patterns that previously worked silently may now hit conflicts and error out — fail-fast is the intended behavior
+- Long-running `REPEATABLE READ` transactions are more likely to see write conflicts at commit time
+
+If existing code depends on the older permissive behavior, opt back in explicitly:
+```sql
+SET GLOBAL innodb_snapshot_isolation = OFF;  -- restore pre-11.8 behavior
+```
+
+The new default is the correct semantics — review code that relies on the looser behavior rather than disabling it long-term.
+
+## System-Versioned Tables
+
+Available since MariaDB 10.3. Track the full history of every row automatically, without triggers or audit tables.
+
+```sql
+CREATE TABLE prices (
+    product VARCHAR(100),
+    price DECIMAL(10,2)
+) WITH SYSTEM VERSIONING;
+
+-- Query data as it was at a point in time:
+SELECT * FROM prices FOR SYSTEM_TIME AS OF '2025-01-01 00:00:00';
+
+-- See all historical versions of a row:
+SELECT * FROM prices FOR SYSTEM_TIME ALL WHERE product = 'widget';
+```
+
+Use this instead of manually maintained `valid_from` / `valid_to` columns or separate audit tables.
+
+> **History grows without bound.** Every UPDATE and DELETE appends a history row — MariaDB does not automatically expire history. Production deployments need either `PARTITION BY SYSTEM_TIME` with rotation (10.9+) or periodic `DELETE HISTORY` to control disk growth. See the `mariadb-system-versioned-tables` skill for details.
+
+## RETURNING Clause
+
+Get inserted, updated, or deleted rows back without a second query.
+
+### INSERT and DELETE (10.5+)
+
+Available on 11.8 LTS and earlier supported releases:
+
+```sql
+-- Get the generated ID after insert:
+INSERT INTO orders (product, qty) VALUES ('widget', 5)
+    RETURNING id, created_at;
+
+-- Get deleted rows for logging:
+DELETE FROM queue WHERE processed = 1
+    RETURNING id, payload;
+```
+
+### UPDATE (13.0+ only)
+
+Not available on 11.8 LTS — confirm server version before suggesting. On older releases use a follow-up `SELECT` or redesign:
+
+```sql
+UPDATE orders SET qty = qty + 1 WHERE id = 42
+    RETURNING id, qty;
+```
+
+## Sequences
+
+Available since MariaDB 10.3. First-class sequence objects — more flexible than `AUTO_INCREMENT`.
+
+```sql
+CREATE SEQUENCE order_seq START WITH 1000 INCREMENT BY 1;
+
+-- Use in INSERT:
+INSERT INTO orders (id, product) VALUES (NEXT VALUE FOR order_seq, 'widget');
+
+-- Get the last value generated by NEXTVAL in the current session:
+SELECT LASTVAL(order_seq);
+-- Returns NULL if this session has not called NEXTVAL — not a global current value
+```
+
+Sequences support gaps, multiple sequences per table, and descending sequences. Unlike `AUTO_INCREMENT`, they are not tied to a specific column or table.
+
+## Non-Blocking ALTER TABLE (Instant + Online by Default)
+
+MariaDB's `ALTER TABLE` works on a tiered model:
+
+- **`ALGORITHM=INSTANT`** (10.4+) — metadata-only changes (drop column, modify default, change column order, etc.) complete in microseconds without a table rebuild.
+- **`ALGORITHM=COPY, LOCK=NONE` as the default for non-instant operations** (11.2+, MDEV-16329) — even when a rebuild is needed, MariaDB now runs it non-blocking by default: concurrent DML on the table proceeds while the copy is happening, with only a brief lock at the swap. The need for external tools like `pt-online-schema-change` is largely gone for routine `ALTER`s.
+- **Optimistic two-phase replication of large `ALTER TABLE`** (11.4+, `binlog_alter_two_phase=1`, off by default) — see the `mariadb-replication-and-ha` skill.
+
+```sql
+ALTER TABLE large_table DROP COLUMN old_column, ALGORITHM=INSTANT;
+ALTER TABLE large_table MODIFY COLUMN name VARCHAR(200), ALGORITHM=INSTANT;
+-- Non-instant change runs non-blocking by default on 11.2+:
+ALTER TABLE large_table ADD INDEX (created_at);
+```
+
+Use `ALGORITHM=INSTANT` explicitly when you need to guarantee a metadata-only change; the operation will fail rather than silently fall back to a rebuild.
+
+## INet4 and INet6 Data Types
+
+`INET6` is available since MariaDB 10.5 (stores both IPv4 and IPv6, 16 bytes). The dedicated `INET4` type (4-byte IPv4-only) was added later in 10.10 (MDEV-23287). Native storage gives correct comparison, sorting, and indexing — no need for `VARCHAR` plus application-side validation.
+
+```sql
+CREATE TABLE connections (
+    client_ip INet6 NOT NULL,
+    connected_at DATETIME NOT NULL,
+    INDEX (client_ip)
+);
+
+INSERT INTO connections VALUES (INet6('192.168.1.1'), NOW());
+INSERT INTO connections VALUES (INet6('::1'), NOW());
+
+-- Range queries work correctly:
+SELECT * FROM connections WHERE client_ip BETWEEN INet6('10.0.0.0') AND INet6('10.255.255.255');
+```
+
+Use `INET4` (10.10+) when you know a column is IPv4-only and want the smaller storage; `INET6` is the right default for mixed or IPv6-capable workloads.
+
+## Oracle Compatibility Mode
+
+Available since MariaDB 10.3. `sql_mode=ORACLE` enables PL/SQL syntax, Oracle-compatible NULL handling, packages, and Oracle-style functions — useful when migrating from Oracle or supporting Oracle-experienced developers.
+
+```sql
+SET sql_mode=ORACLE;
+
+-- Oracle-style stored procedures, packages, and NULL semantics work here
+-- ROWNUM, SYSDATE, NVL(), DECODE() available
+-- Note: EMPTY_STRING_IS_NULL is NOT included — add it separately if needed: SET sql_mode='ORACLE,EMPTY_STRING_IS_NULL'
+```
+
+Not a complete Oracle replacement, but significantly reduces migration friction.
+
+## FLASHBACK
+
+Available since MariaDB 10.2. Roll back tables to a previous state using the binary log — without restoring a full backup. Flashback is implemented via the `mariadb-binlog` utility, not a SQL statement:
+
+```bash
+# Generate reverse SQL from the binary log and pipe it back to MariaDB:
+mariadb-binlog --flashback --start-datetime="2026-05-18 10:00:00" \
+  /var/lib/mysql/mysql-bin.000001 | mariadb
+# Path depends on datadir and log_bin settings; default is <datadir>/mysql-bin
+```
+
+**Prerequisites** — FLASHBACK reconstructs reverse events from row images, so it requires:
+- `binlog_format = ROW` (statement-based logging does not capture before/after row images)
+- `binlog_row_image = FULL` (MINIMAL or NOBLOB modes omit column values needed for reversal)
+
+Verify before relying on FLASHBACK as a recovery path:
+```sql
+SHOW VARIABLES LIKE 'binlog_format';      -- must be ROW
+SHOW VARIABLES LIKE 'binlog_row_image';   -- must be FULL
+```
+
+Requires binary logging enabled (`log_bin`). Useful for recovering from accidental deletes or bad migrations.
+
+## More MariaDB Features (through 11.8 LTS)
+
+Additional capabilities on the current LTS baseline and supported older releases. See [Newer releases (12.x / 13.0)](#newer-releases-12x--130) for features that require a newer server.
+
+### SQL & Schema
+- **Invisible columns** (10.3+) — hidden from `SELECT *`, still writable; useful for schema evolution without breaking existing queries
+- **`DEFAULT` expressions on BLOB/TEXT** — not supported in MySQL
+- **`DECIMAL` precision to 38 digits** — MySQL stops at 30
+- **`INTERSECT` and `EXCEPT`** (10.3+) — set operators not available in MySQL
+- **`LIMIT` in subqueries** — supported; MySQL restricts this
+- **`SELECT ... OFFSET ... FETCH`** (10.6+, MDEV-23908) — SQL-standard pagination syntax
+- **Atomic DDL** (10.6+, MDEV-23842) — `CREATE TABLE`, `ALTER TABLE`, `RENAME TABLE`, `DROP TABLE`, `DROP DATABASE` are atomic on supported engines (InnoDB, Aria, MyRocks): a partial server crash mid-DDL leaves the schema in its pre-statement state, no manual cleanup needed. Multi-table `DROP TABLE` is atomic per individual drop, not for the whole list.
+- **`SELECT ... SKIP LOCKED`** (10.6+, MDEV-13115, InnoDB only) — work-queue pattern: workers grab the next available row and skip rows other transactions are processing, with no lock waits
+- **Ignored Indexes** (10.6+, MDEV-7317) — `ALTER TABLE t ALTER INDEX idx IGNORED` keeps the index updated but makes it invisible to the optimizer. Use this to test whether dropping an index would hurt performance before actually dropping it (zero-downtime rollback by re-enabling).
+- **Dynamic columns** (5.3+) — schema-less key/value storage inside a single column
+- **`SFORMAT()`** (10.7+, MDEV-25015) — string formatting function with positional placeholders
+- **`NATURAL_SORT_KEY()`** (10.7+, MDEV-4742) — produces a sort key that orders strings "naturally" (so `v9` sorts before `v10`); useful in `ORDER BY` for version-like or mixed-alphanumeric data
+- **JSON enhancements** — MariaDB has been catching up to MySQL 8 JSON functions over several releases:
+  - `JSON_EQUALS(a, b)` / `JSON_NORMALIZE(doc)` (10.7+, MDEV-23143 / MDEV-16375) — semantic equality and canonical form for hashing or unique indexing
+  - `JSON_OVERLAPS(a, b)` (10.9+, MDEV-27677) — detect shared key/value or array elements between two documents
+  - JSON path syntax supports negative indices (`$.A[-1]`, `$.A[last]`) and ranges (`$.A[1 to 3]`) (10.9+, MDEV-22224 / MDEV-27911)
+  - `JSON_SCHEMA_VALID(schema, doc)` (11.4+) — validate JSON against a JSON Schema Draft 2020 schema, usable inside `CHECK` constraints
+  - `JSON_KEY_VALUE`, `JSON_ARRAY_INTERSECT`, `JSON_OBJECT_TO_ARRAY`, `JSON_OBJECT_FILTER_KEYS` (11.4+) — structural manipulation primitives that compose well with `JSON_TABLE`
+- **`UUID_v4()` and `UUID_v7()` functions** (11.7+) — generate version-4 random or version-7 time-ordered UUIDs; the v7 form is sortable and ideal for primary keys
+- **`FORMAT_BYTES()`** (11.8+) — convert a byte count to a human-readable string (e.g. `1234567` → `1.18 MiB`)
+- **`CONV()` extended to base 62** (11.4+, MDEV-30190) — `CONV(61,10,62)` returns `z`; useful for short opaque IDs
+- **`CRC32C()` function and `CRC32()` with optional initial-value argument** (10.8+, MDEV-27208) — Castagnoli polynomial CRC, and seedable CRC32 for chained checksums
+- **Single-table `DELETE` with table aliases** (11.6+) — `DELETE t FROM mytable t WHERE ...` syntax now works without rewriting
+- **`REPAIR TABLE ... FORCE`** (11.5+) — force-repair even when the table appears clean
+- **Stored routine parameter default values** (11.8+, MDEV-10862) — `PROCEDURE p(a INT DEFAULT 0, b INT DEFAULT 0)` — call with fewer arguments
+- **Stored function `IN`/`OUT`/`INOUT` parameter qualifiers** (10.8+, MDEV-10654) — bring stored functions in line with stored procedure parameter modes
+- **`ROW` data type as stored function return value** (11.7+, MDEV-12252) — return structured rows from stored functions
+- **`CREATE PACKAGE` / `CREATE PACKAGE BODY` outside Oracle mode** (11.4+, MDEV-10075) — package routines work under the default `sql_mode` too, not only with `sql_mode=ORACLE`
+- **Update triggers with column list** (11.8+, MDEV-34551) — `CREATE TRIGGER ... BEFORE UPDATE OF col1, col2 ON t` — fire only when those columns are updated
+- **Stored procedures and functions** — MariaDB uses SQL/PSM syntax (`DECLARE`, `HANDLER`, `CURSOR`, `BEGIN...END`); AI agents often generate incorrect syntax — see [Stored Procedures — MariaDB Docs](https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures)
+
+### Storage Engines
+- **ColumnStore** — columnar engine for analytical/data warehouse workloads
+- **Aria** — crash-safe MyISAM replacement, used internally for temp tables
+- **MyRocks** (10.2+) — RocksDB-based, optimized for write-heavy workloads with compression
+- **CONNECT** — query external data sources (CSV, JDBC, ODBC, MongoDB) as SQL tables
+- **Spider** — sharding across multiple MariaDB instances
+
+### Security & Auth
+- **`unix_socket` authentication** — authenticate OS users without passwords; `authentication_string` support added in 11.6+ for finer-grained mapping
+- **ED25519 plugin** — modern authentication alternative to SHA1-based plugins
+- **PARSEC plugin** (11.6+, MDEV-32618) — Password Authentication using Response Signed with Elliptic Curve; salt and per-installation key separation make stolen hashes unusable elsewhere
+- **`password_reuse_check` plugin** (10.7+, MDEV-9245) — prevent password reuse for a configurable number of days via `password_reuse_check_interval`
+- **`GRANT ... TO PUBLIC`** (10.11+, MDEV-5215) — grant privileges to all users in one statement; pair with `SHOW GRANTS FOR PUBLIC`
+- **`SHOW CREATE ROUTINE` privilege** (11.4+, MDEV-23149) — let users inspect a routine's definition without granting `SELECT` on `mysql.proc`
+- **`READ ONLY ADMIN` is now a distinct privilege** (10.11+, MDEV-29596) — split out of `SUPER` so a true read-only replica role can be granted; existing accounts that need to write to a `read_only=1` replica need this privilege granted explicitly
+- **Role-based access control** (10.0+) — roles available before MySQL added them
+- **SSL by default** — the `mariadb` client opts into SSL by default since 10.10 (MDEV-27105). The server side requires SSL by default since 11.4 LTS, with auto-generated self-signed certificates and automatic client-side verification (`tls_fp` for fingerprint-pinning).
+- **`AES_ENCRYPT()` / `AES_DECRYPT()` with `iv` and `mode`** (11.4+, MDEV-30878) — `AES_ENCRYPT(str, key, iv, mode)`; supported modes include CBC, OFB, CFB128, CTR (default mode comes from the new `block_encryption_mode` variable). Brings parity with MySQL's encryption interface.
+- **`KDF()` key-derivation function** (11.4+, MDEV-31474) — derive an encryption key from a passphrase using PBKDF2-HMAC or HKDF — `AES_ENCRYPT(data, KDF('passw0rd', 'salt', 'info', 'hkdf'), iv)`. Use this rather than feeding a raw password into `AES_ENCRYPT`.
+- **`RANDOM_BYTES(n)`** (10.10+, MDEV-25704) — cryptographically secure random bytes (1–1024) from the SSL library's RNG
+- **`DES_ENCRYPT()` / `DES_DECRYPT()` deprecated** (10.10+, MDEV-27104) — old DES cipher; use `AES_ENCRYPT` / `AES_DECRYPT` with `KDF()` instead
+- **Table-level encryption** — encrypt individual tables, not just the whole datadir
+- **HashiCorp Vault integration** — key management plugin
+
+### Replication & HA
+- **Galera Cluster** — built-in synchronous multi-master clustering
+- **Multi-source replication** — replicate from multiple primaries simultaneously
+- **Parallel replication** — faster replica apply
+- **Lag-free `ALTER TABLE` replication** — schema changes don't stall replicas
+
+### Connectors
+- **LGPL-licensed connectors** for C, C++, Java, Python, Node.js, ODBC, R2DBC — permissive licensing for commercial applications; MySQL connectors are GPL
+
+### Developer Tools
+- **`EXPLAIN` in slow query log** — automatic execution plan logging for slow queries
+- **Progress reporting** for `ALTER TABLE` and `CHECK TABLE`
+- **`mariadb-backup`** (10.1+) — hot backup with backup locks (no `FLUSH TABLES WITH READ LOCK`). A backup requires **two steps** — the `--prepare` step is mandatory before restore:
+  ```bash
+  mariadb-backup --backup --user=root --target-dir=/backup/full
+  mariadb-backup --prepare --target-dir=/backup/full   # apply redo logs — without this, the backup cannot be restored
+  ```
+  For Galera clusters, add `--galera-info` to capture the wsrep state for clean cluster rejoin. Do not use `innobackupex` or `xtrabackup` — `mariadb-backup` is the correct tool for MariaDB (included since 10.1, replacing the Percona dependency).
+- **Non-blocking client API** — async queries without threads
+
+## Newer releases (12.x / 13.0)
+
+These require MariaDB **12.0 or newer** (many ship with **12.3 LTS**, currently RC — check [MariaDB releases](https://mariadb.org/mariadb/all-releases/) for GA status). Suggest them when they solve the user's problem or as a deliberate upgrade path; always name the minimum version.
+
+### SQL & Schema
+- **Triggers fired on multiple events** (12.0+) — one trigger body for `INSERT OR UPDATE OR DELETE`, instead of three separate triggers
+- **Foreign key names per table** (12.1+) — FK names need to be unique only per table, not per database (MySQL-compatible behavior)
+- **JSON depth limit removed** (12.2+) — the 32-level nesting limit on JSON functions is gone; deeply nested JSON now works without rewrites
+- **`UPDATE` / `DELETE` reading from a CTE** (12.3+) — `WITH ... UPDATE/DELETE` using values from a common table expression
+- **`IS JSON` predicate** (12.3+) — SQL-standard test for whether a value is valid JSON: `WHERE col IS JSON`
+- **Basic XML data type** (12.3+) — first-class `XML` type for storing and validating XML documents
+- **Atomic `CREATE OR REPLACE TABLE`** (13.0+) — the statement is fully atomic: either the new table replaces the old one or nothing happens, with no risk of leaving the schema in a half-replaced state. MySQL has no equivalent atomic guarantee.
+- **`UPDATE ... RETURNING`** (13.0+) — see [RETURNING Clause](#returning-clause); not on 11.8 LTS
+
+### Security & Auth
+- **`SET SESSION AUTHORIZATION`** (12.0+) — perform actions as another user within a session (useful for impersonation in administrative scripts and apps that need least-privilege execution)
+- **Passphrase-protected TLS keys** (12.0+) — `ssl_passphrase` system variable lets the server load encrypted private keys
+
+### Developer Tools
+- **Deprecation visibility** (13.0+) — `INFORMATION_SCHEMA.SYSTEM_VARIABLES` includes a deprecated flag, so you can detect uses of variables that will be removed in future versions before they break:
+  ```sql
+  SELECT variable_name, default_value FROM INFORMATION_SCHEMA.SYSTEM_VARIABLES WHERE is_deprecated = 'YES';
+  ```
+- **Engine-specific create options visible in `INFORMATION_SCHEMA`** (13.0+) — `STATISTICS` and `COLUMNS` now expose engine-specific options, useful when inspecting how indexes or columns were configured
+
+## Sources
+
+- [Monty Widenius: Celebrating 15 years of MariaDB](http://monty-says.blogspot.com/2024/10/celebrating-15-years-of-mariadb.html)
+- [MariaDB vs MySQL Features — MariaDB Docs](https://mariadb.com/docs/release-notes/community-server/about/compatibility-and-differences/mariadb-vs-mysql-features)
+- [System-Versioned Tables — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/system-versioned-tables)
+- [RETURNING — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning)
+- [CREATE SEQUENCE — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/sequences/create-sequence)
+- [Instant ALTER TABLE — MariaDB Docs](https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-online-ddl/innodb-online-ddl-operations-with-the-instant-alter-algorithm)
+- [INet6 Data Type — MariaDB Docs](https://mariadb.com/docs/server/reference/data-types/string-data-types/inet6)
+- [Oracle Compatibility — MariaDB Docs](https://mariadb.com/docs/release-notes/community-server/about/compatibility-and-differences/sql_modeoracle)
+- [FLASHBACK — MariaDB Docs](https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/flashback)
+
+*For topics not covered here, see the official MariaDB documentation at [mariadb.com/docs](https://mariadb.com/docs).*

--- a/agent-skills/topical/mariadb-query-optimization/SKILL.md
+++ b/agent-skills/topical/mariadb-query-optimization/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: mariadb-query-optimization
+description: "Best practices for query optimization in MariaDB — indexing strategies, EXPLAIN analysis, pagination, histogram statistics, and MariaDB-specific optimizer settings. Use when diagnosing slow queries, designing indexes, reviewing schema or query performance, or when queries involve large tables, pagination, GROUP BY, or ORDER BY. Also use when the user asks about MariaDB query performance, EXPLAIN output, or optimizer behavior."
+---
+
+# MariaDB Query Optimization
+
+*Last updated: 2026-06-05*
+
+> **Requires:** MariaDB 10.1+ for `ANALYZE` and histograms; optimizer improvements through **11.8 LTS** (GA May 2025) form the baseline below.
+>
+> **Default context:** Assume MariaDB **11.8 LTS** unless the user states another version. Features marked **12.x** may be suggested when relevant (including as upgrade options), but always state the minimum version — do not present them as available on 11.8.
+
+## What LLMs Get Wrong
+
+| Pattern | What to do instead |
+|---|---|
+| `SELECT * FROM table LIMIT 10 OFFSET 50000` | Use cursor-based pagination — `OFFSET` scans all skipped rows |
+| Blanket rule "functions on indexed columns kill indexes" | Outdated on MariaDB 11.1+/11.3+ for many cases. `YEAR(col) = const` and `UPPER(col) = const` on case-insensitive columns can now use indexes — see [Functions on indexed columns](#functions-on-indexed-columns) below |
+| Adding an index to a low-cardinality column (boolean, status with 2-3 values) | Optimizer skips indexes with low selectivity and does a table scan anyway |
+| Not running `ANALYZE TABLE` after bulk inserts | Histogram statistics become stale; optimizer makes poor plan choices |
+| Composite index `(a, b, c)` used in `WHERE b = 1 AND c = 2` | Leftmost prefix rule: this skips `a`, so the index is not used |
+| `SELECT *` in queries with JOINs | Name only the columns needed — prevents accidentally blocking covering indexes |
+| `ALTER TABLE t ALTER INDEX idx INVISIBLE` to disable an index | That's MySQL syntax. MariaDB uses `IGNORED` — see [Ignored Indexes](#ignored-indexes-not-invisible) below |
+| Jump straight to `EXPLAIN` or indexes on a slow server | Enable [Performance Schema](https://mariadb.com/docs/server/reference/system-tables/performance-schema/performance-schema-overview) at **startup** first — it is **off by default** and cannot be turned on at runtime |
+| `SET GLOBAL performance_schema = ON` to enable monitoring | Performance Schema requires `performance_schema=ON` in `my.cnf` and a **server restart** |
+
+## Performance Schema (enable first)
+
+Before `EXPLAIN`, indexes, or query rewrites, confirm the server can observe what queries are doing. MariaDB's [Performance Schema](https://mariadb.com/docs/server/reference/system-tables/performance-schema/performance-schema-overview) is the built-in monitoring layer (10.5+: ~80 tables in the `performance_schema` database).
+
+**Check status:**
+
+```sql
+SHOW VARIABLES LIKE 'performance_schema';
+```
+
+**Critical:** Performance Schema is **disabled by default** and **cannot be enabled at runtime**. If `OFF`, add to `my.cnf` and restart:
+
+```ini
+[mysqld]
+performance_schema=ON
+```
+
+**After restart**, enable the consumers and instruments you need. Scope with `WHERE NAME LIKE '...'` rather than enabling everything blindly in production — see the overview doc:
+
+```sql
+UPDATE performance_schema.setup_consumers SET ENABLED = 'YES';
+UPDATE performance_schema.setup_instruments SET ENABLED = 'YES', TIMED = 'YES';
+```
+
+Use `performance_schema` (waits, stages, statements, and related summary tables) to see where time goes; then use `EXPLAIN` and `ANALYZE` below to understand why the optimizer chose a plan. On **10.7.1+**, column comments help interpret tables:
+
+```sql
+SELECT column_name, column_comment
+  FROM information_schema.columns
+ WHERE table_schema = 'performance_schema' AND table_name = 'events_statements_summary_by_digest';
+```
+
+## Reading EXPLAIN
+
+With Performance Schema available when diagnosing production slowness, run `EXPLAIN` to inspect the optimizer's plan:
+
+```sql
+EXPLAIN SELECT * FROM orders WHERE customer_id = 42 ORDER BY created_at DESC LIMIT 10;
+```
+
+**Red flags in the output:**
+
+| Field | Red flag | What it means |
+|---|---|---|
+| `type` | `ALL` | Full table scan — missing index or index not used |
+| `key` | `NULL` | No index used despite one existing — check for function on column or type mismatch |
+| `rows` | Very high number | Optimizer estimates scanning many rows |
+| `Extra` | `Using filesort` | Expensive sort not covered by an index |
+| `Extra` | `Using temporary` | Temp table created — often from `GROUP BY` or `DISTINCT` |
+| `Extra` | `Using index` | ✅ Good — covering index, no table row access needed |
+
+**`ANALYZE`** statement (MariaDB 10.1+) actually executes the query and shows real row counts vs. estimates — more reliable than `EXPLAIN` alone. Note: MariaDB uses `ANALYZE`, not `EXPLAIN ANALYZE`:
+
+```sql
+ANALYZE SELECT * FROM orders WHERE customer_id = 42;
+```
+
+**Optimizer Trace** shows the optimizer's full decision process. Since MariaDB 12.1 the trace can include full table and view definitions (`optimizer_record_context` system variable). Since 13.0 it also includes the specific statistics (histograms, index stats) used for cardinality estimates — together they're powerful for diagnosing surprising `rows` estimates:
+
+```sql
+SET optimizer_trace = 'enabled=on';
+SELECT * FROM orders WHERE customer_id = 42;
+SELECT * FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE\G
+SET optimizer_trace = 'enabled=off';
+```
+
+## Indexing Rules
+
+### The Leftmost Prefix Rule
+
+For a composite index `(a, b, c)`, MariaDB can use:
+- `WHERE a = 1` ✅
+- `WHERE a = 1 AND b = 2` ✅
+- `WHERE a = 1 AND b = 2 AND c = 3` ✅
+- `WHERE b = 2` ✗ — skips `a`, index not used
+- `WHERE a = 1 AND c = 3` — only `a` part is used
+
+Put the most selective equality conditions first, then range conditions last:
+```sql
+-- Query: WHERE status = 'active' AND created_at > '2025-01-01' ORDER BY created_at
+INDEX (status, created_at)  -- ✅ equality first, range last
+INDEX (created_at, status)  -- ✗ range first breaks the prefix for status
+```
+
+### Covering Indexes
+
+A covering index includes all columns needed by the query — no table row access needed (`Using index` in EXPLAIN):
+
+```sql
+-- Query fetches id, status, created_at for a customer
+-- Covering index includes all three:
+CREATE INDEX idx_customer_cover ON orders (customer_id, status, created_at);
+-- Now EXPLAIN shows: Extra = Using index
+```
+
+### When NOT to Add an Index
+
+- **Low-cardinality columns**: a `status` column with values `active`/`inactive` affects 50% of rows — the optimizer prefers a table scan. Index useful only when combined with other high-selectivity columns.
+- **Small tables** (< a few thousand rows): full scans are faster than index lookups for tiny tables.
+- **Write-heavy columns**: every index slows `INSERT`, `UPDATE`, `DELETE` — don't index columns that are rarely queried.
+
+### Ignored Indexes (not INVISIBLE)
+
+To make the optimizer skip an index without dropping it — useful for testing whether an index is actually needed before removing it — MariaDB uses `IGNORED`, **not** MySQL's `INVISIBLE`:
+
+```sql
+-- ✅ MariaDB syntax (10.6+):
+ALTER TABLE demo ALTER INDEX index_name IGNORED;
+ALTER TABLE demo ALTER INDEX index_name NOT IGNORED;  -- re-enable
+
+-- ✗ MySQL syntax — fails on MariaDB:
+ALTER TABLE demo ALTER INDEX index_name INVISIBLE;
+```
+
+The index is still maintained on writes; it's just hidden from the optimizer. A primary key cannot be ignored. See [Ignored Indexes](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/ignored-indexes).
+
+### Functions on Indexed Columns
+
+The classic rule "any function on an indexed column disables the index" is **outdated for MariaDB 11.1+ and 11.4 LTS**. The optimizer can now use indexes for a number of common function patterns:
+
+| Pattern | Works on the index? | Since |
+|---|---|---|
+| `WHERE YEAR(col) = 2025` | ✅ — sargable, picks the right range | 11.1+ (MDEV-8320) |
+| `WHERE DATE(col) <= '2025-12-31'` | ✅ — sargable | 11.1+ (MDEV-8320) |
+| `WHERE UPPER(varchar_col) = '...'` on a case-insensitive collation (e.g. `utf8mb4_uca1400_ai_ci`) | ✅ — `sargable_casefold=ON` is the default | 11.3+ (MDEV-31496) |
+| `WHERE SUBSTR(col, 1, n) = 'abc'` | ✅ — leading-prefix `SUBSTR` is optimized | 11.8+ (MDEV-34911) |
+| `WHERE LOWER(case_sensitive_col) = '...'` | ✗ — index not used (collation isn't case-insensitive) | — |
+| `WHERE CAST(col AS UNSIGNED) = 1` or other type-changing transforms | ✗ — index not used | — |
+
+For cases that the optimizer still can't sargabilize, the rewrite-to-range pattern remains valid:
+
+```sql
+WHERE created_at >= '2025-01-01' AND created_at < '2026-01-01'
+```
+
+Verify with `EXPLAIN` rather than assuming: on 11.4+ many "won't use the index" rewrites are now no-ops. If `EXPLAIN` still shows `type=ALL` for a sargable pattern, check `@@optimizer_switch` for `sargable_casefold` and confirm the column's collation is `_ci`.
+
+### Functional Indexes: Use a Generated Column
+
+MySQL 8.0.13+ supports **functional key parts** — indexing an expression directly with a doubled-parenthesis syntax. MariaDB does **not** support this:
+
+```sql
+-- ✗ MySQL syntax — fails on MariaDB:
+CREATE INDEX idx_upper ON users ((UPPER(name)));
+ALTER TABLE orders ADD INDEX ((total * quantity));
+```
+
+In MariaDB, index a [generated (computed) column](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/generated-columns) instead. A `VIRTUAL` column stores nothing and is computed on read; the index on it persists the expression's value, which is what gets searched:
+
+```sql
+-- ✅ MariaDB equivalent:
+ALTER TABLE users
+  ADD COLUMN name_upper VARCHAR(255) AS (UPPER(name)) VIRTUAL,
+  ADD INDEX idx_name_upper (name_upper);
+
+-- Query the column the optimizer can resolve directly,
+-- or rely on virtual-column optimizer support (11.8+) for WHERE UPPER(name) = ...
+SELECT * FROM users WHERE name_upper = 'ALICE';
+```
+
+Note that for many simple cases (`YEAR(col)`, `UPPER(col)` on `_ci` collations) MariaDB 11.1+ no longer needs an indexed expression at all — see the table above. Reach for a generated column when the expression isn't sargable on its own.
+
+## Pagination: Cursor-Based Instead of OFFSET
+
+`OFFSET` is a hidden performance trap. `LIMIT 10 OFFSET 50000` scans and discards 50,000 rows on every page load.
+
+```sql
+-- ✗ Slow — scans 50,000 rows to skip them:
+SELECT id, title FROM posts ORDER BY id DESC LIMIT 10 OFFSET 50000;
+
+-- ✅ Fast — index seek directly to the cursor position:
+-- First page:
+SELECT id, title FROM posts ORDER BY id DESC LIMIT 10;
+
+-- Next page (pass last id from previous result as $last_id):
+SELECT id, title FROM posts WHERE id < $last_id ORDER BY id DESC LIMIT 10;
+```
+
+For filtered queries, include the filter column in the index alongside id:
+
+```sql
+-- Query: WHERE category = 'news' ORDER BY id DESC
+CREATE INDEX idx_cat_id ON posts (category, id);
+-- Cursor query:
+SELECT id, title FROM posts WHERE category = 'news' AND id < $last_id ORDER BY id DESC LIMIT 10;
+```
+
+To detect whether another page exists, fetch `LIMIT 11` and check if the 11th row appears.
+
+## Histogram Statistics
+
+Histograms let the optimizer understand data distribution on non-indexed columns — critical for query plan quality on complex queries. Without them, the optimizer assumes uniform distribution and can choose wrong join orders.
+
+```sql
+-- Collect histograms for a table (requires a full scan — run during low traffic):
+ANALYZE TABLE orders;
+
+-- Verify histograms were collected:
+SELECT * FROM mysql.column_stats WHERE table_name = 'orders';
+```
+
+**When to run `ANALYZE TABLE`:**
+- After bulk inserts or large data changes
+- When `EXPLAIN` shows unexpectedly high `rows` estimates
+- After initially creating a table and loading data
+
+**Tune histogram granularity** for tables with highly skewed data distributions:
+```sql
+SET histogram_size = 100;  -- default is 0 (disabled) in older versions, 254 in 10.4.3+
+ANALYZE TABLE orders;
+```
+
+Histograms are collected per-column automatically when using `ANALYZE TABLE` with `histogram_size > 0`. They are stored in `mysql.column_stats` and consulted when `optimizer_use_condition_selectivity >= 4` (default in 10.4.1+).
+
+## MariaDB Optimizer Switches
+
+MariaDB's optimizer has more tunable flags than MySQL. The most useful for developers:
+
+```sql
+-- See current settings:
+SELECT @@optimizer_switch\G
+
+-- Disable a specific optimization for a session (useful for debugging):
+SET optimizer_switch = 'derived_merge=off';
+
+-- Re-enable:
+SET optimizer_switch = 'derived_merge=on';
+```
+
+**Most impactful flags:**
+
+| Flag | Default | Effect |
+|---|---|---|
+| `derived_merge` | on | Merges derived tables into outer query — usually faster |
+| `semijoin` | on | Optimizes `IN`/`EXISTS` subqueries — disable to debug unexpected plans |
+| `subquery_cache` | on | Caches correlated subquery results — big win for repeated subqueries |
+| `rowid_filter` | on | Pre-filters rowids before fetching rows — helps range queries |
+| `mrr` | off | Multi-Range Read — enable for large range scans on spinning disks |
+
+Turn flags off one at a time to isolate which optimization is causing a bad plan, then report via JIRA if a default setting produces a worse plan than the alternative.
+
+### Optimizer Improvements in the 10.7–10.11 LTS Window
+
+The 10.11 LTS line bundles features that arrived in the 10.7–10.10 short-term releases:
+
+- **JSON-format histograms** (10.8+, MDEV-21130, MDEV-26519) — histogram statistics are stored in JSON and are more precise than the older binary format. Just running `ANALYZE TABLE` on 10.8+ gives the optimizer better cardinality estimates.
+- **Descending indexes** (10.8+, MDEV-13756) — `CREATE INDEX idx ON t (a ASC, b DESC)` is supported; useful for composite `ORDER BY a, b DESC` patterns and for `MIN()`/`MAX()` on descending indexes.
+- **`SHOW ANALYZE [FORMAT=JSON]`** (10.9+, MDEV-27021) — get the optimizer plan and runtime stats for a query running in another connection without intrusion. `EXPLAIN FOR CONNECTION` syntax also supported (MDEV-10000).
+- **Improved optimization for joins with many `eq_ref` tables** (10.10+, MDEV-28852, MDEV-26278) — large star-schema-style joins plan dramatically better.
+- **`ANALYZE FORMAT=JSON` reports time spent in the optimizer itself** (10.11+, MDEV-28926) — separates planning time from execution time.
+
+### Optimizer Improvements in 11.4 LTS
+
+The 11.4 LTS line continues the overhaul:
+
+- **New cost-based cost model** (11.0+) — replaces the older rule-based heuristics with a tuned model aware of SSDs and per-engine characteristics. `EXPLAIN` and join-order choices in 10.6 vs. 11.4 can differ noticeably on the same query. If you have manual `optimizer_adjust_secondary_key_costs` settings from 10.x, remove them — they're no-ops on 11.4+.
+- **Semi-join optimization for single-table `UPDATE`/`DELETE`** (11.1+, MDEV-7487) — subqueries inside `UPDATE`/`DELETE` can now use the same subquery rewrites that `SELECT` uses (materialization, semi-join, etc.). Often a large speedup, no rewrite needed.
+- **Sargable `DATE`/`YEAR` comparisons against constants** (11.1+, MDEV-8320) — see [Functions on Indexed Columns](#functions-on-indexed-columns) above.
+- **Sargable case-folding** (11.3+, MDEV-31496, `sargable_casefold` on by default) — `UCASE`/`LCASE`/`UPPER`/`LOWER` on a column with a case-insensitive collation can use the index.
+
+### Optimizer Improvements in 11.5–11.8 LTS
+
+These are part of the current LTS baseline — useful for understanding what the optimizer can do today:
+
+- **Index Condition Pushdown on partitioned tables** (11.5+, MDEV-12404) — previously partitioned tables couldn't use ICP; now they do, often a large speedup on partitioned schemas
+- **`ANALYZE` shows selectivity of pushed index condition** (11.5+, MDEV-18478) — useful when diagnosing whether ICP is helping
+- **Charset Narrowing Optimization on by default** (11.8+, MDEV-34380) — eliminates unnecessary character set conversions in WHERE clauses
+- **`SUBSTR(col, 1, n) = const_str` optimization** (11.8+, MDEV-34911) — the optimizer can now use a column index even when the condition is a leading-prefix `SUBSTR`
+- **Virtual column support in the optimizer** (11.8+, MDEV-35616) — see [Virtual Column Support in the Optimizer](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/virtual-column-support-in-the-optimizer); previously, virtual columns were largely invisible to the optimizer
+- **Cost-based subquery strategy for single-table `UPDATE`/`DELETE`** (11.8+, MDEV-25008) — the optimizer now picks between subquery strategies by cost
+
+### Optimizer Improvements in MariaDB 12.x
+
+Several further limitations were lifted in the 12.x rolling releases:
+
+- **Rowid filtering on reverse-ordered scans** (12.0+) — previously `ORDER BY ... DESC` queries couldn't benefit from rowid filtering; now they can
+- **Index Condition Pushdown on reverse-ordered scans** (12.0+) — same fix for ICP
+- **Loose Index Scan ("Use index for group-by") works with `DESC` key parts** (12.0+) — previously required `ASC` indexes
+- **GROUP BY / ORDER BY can use indexes on virtual columns** (12.1+)
+- **Reorderable LEFT JOIN optimization** (12.3+) — the optimizer can now reorder more `LEFT JOIN` combinations
+- **Distinct GROUP BY column inference** (12.2+) — derived tables with `GROUP BY` are recognized as having distinct group keys, enabling more optimizations downstream
+
+If you target the 11.8 LTS baseline and see a plan that looks needlessly slow on a reverse-ordered or virtual-column query, it may be one of these — verify by running the same query on a 12.x version.
+
+## Optimizer Hints
+
+MariaDB 12.0 introduced a comprehensive MySQL-8-style optimizer hints framework (MDEV-35504), with additional hints added through 12.1 and 12.2. Hints go in a `/*+ ... */` comment right after `SELECT` and override the optimizer for one query without changing session settings:
+
+```sql
+SELECT /*+ JOIN_ORDER(o, c) */ *
+FROM orders o JOIN customers c ON c.id = o.customer_id;
+```
+
+**Available hints:**
+
+| Hint | Since | Purpose |
+|---|---|---|
+| `QB_NAME(name)` | 12.0 | Name a query block so other hints can target it from outside |
+| `JOIN_FIXED_ORDER` / `JOIN_ORDER(t1, t2, ...)` | 12.0 | Force a join order (`JOIN_FIXED_ORDER` is similar to `STRAIGHT_JOIN`) |
+| `JOIN_PREFIX(t1, ...)` / `JOIN_SUFFIX(t1, ...)` | 12.0 | Force specific tables to be first or last in the join order |
+| `MAX_EXECUTION_TIME(ms)` | 12.0 | Abort the query if it runs longer than the timeout |
+| `[NO_]MRR` / `[NO_]BKA` / `[NO_]BNL` | 12.0 | Toggle Multi-Range Read, Batched Key Access, Block Nested Loop |
+| `[NO_]ICP` | 12.0 | Toggle Index Condition Pushdown |
+| `[NO_]RANGE_OPTIMIZATION` | 12.0 | Toggle range optimizer |
+| `SEMIJOIN(strategy, ...)` / `SUBQUERY(strategy)` | 12.0 | Pick subquery rewrite strategy |
+| `[NO_]INDEX(t idx, ...)` / `[NO_]JOIN_INDEX` / `[NO_]GROUP_INDEX` / `[NO_]ORDER_INDEX` | 12.1 | Force / forbid specific index usage by purpose |
+| `[NO_]SPLIT_MATERIALIZED` / `[NO_]DERIVED_CONDITION_PUSHDOWN` / `[NO_]MERGE` | 12.1 | Control subquery / derived-table optimizations |
+| `[NO_]ROWID_FILTER` / `[NO_]INDEX_MERGE` | 12.2 | Toggle rowid filtering and index merge |
+
+**`QB_NAME()` example** — name a subquery so an outer hint can target it:
+
+```sql
+SELECT /*+ NO_MERGE(@sub) */ *
+FROM (
+    SELECT /*+ QB_NAME(sub) */ customer_id, COUNT(*) AS n
+    FROM orders
+    GROUP BY customer_id
+) t
+WHERE n > 10;
+```
+
+Hints are more targeted than `SET optimizer_switch` because they apply only to the query they're in, not the whole session.
+
+## Bounding Expensive Queries: LIMIT ROWS EXAMINED
+
+`LIMIT ROWS EXAMINED` is a **MariaDB-specific** extension (since 5.5.21) with no MySQL equivalent. It caps how many rows a `SELECT` may examine, terminating execution early once the cap is hit — a safety valve against runaway scans on unbounded or ad-hoc queries:
+
+```sql
+-- Up to 10 result rows, but stop after examining 10,000 rows:
+SELECT * FROM t1, t2 LIMIT 10 ROWS EXAMINED 10000;
+
+-- The cap can be used on its own:
+SELECT * FROM big_table WHERE status = 'x' LIMIT ROWS EXAMINED 50000;
+```
+
+When the cap is reached the query returns a **partial result set** plus a warning — so it is a guard rail, not a way to get correct-but-faster answers. `SELECT` only; it is a syntax error on `UPDATE`/`DELETE`. For a time-based bound instead, use the `MAX_EXECUTION_TIME(ms)` optimizer hint (12.0+) above. See [LIMIT ROWS EXAMINED](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/limit-rows-examined).
+
+## Quick Wins Checklist
+
+Before adding indexes or rewriting queries, check these first:
+
+1. Confirm `performance_schema=ON` at startup (restart required if off) — [Performance Schema Overview](https://mariadb.com/docs/server/reference/system-tables/performance-schema/performance-schema-overview)
+2. `EXPLAIN` the slow query — confirm where the time actually is
+3. `ANALYZE TABLE` — stale statistics cause bad plans
+4. Check for functions on indexed columns in `WHERE` — note many cases are now sargable on 11.4+ (`YEAR()`, `DATE()`, `UPPER()` on `_ci` collations)
+5. Check for `OFFSET` in pagination queries
+6. Verify composite index column order matches query predicates (leftmost prefix)
+7. Check `EXPLAIN` Extra column for `Using filesort` or `Using temporary` — these often point to a missing or misordered index
+
+## Sources
+
+- [Query Optimizations — MariaDB Docs](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations)
+- [Performance Schema Overview — MariaDB Docs](https://mariadb.com/docs/server/reference/system-tables/performance-schema/performance-schema-overview)
+- [EXPLAIN — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain)
+- [optimizer_switch — MariaDB Docs](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimizer-switch)
+- [Getting Started with Indexes — MariaDB Docs](https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-indexes-guide)
+- [Building the Best Index for a Given SELECT — MariaDB Docs](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select)
+- [Histogram-Based Statistics — MariaDB Docs](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/histogram-based-statistics)
+- [Pagination Optimization — MariaDB Docs](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/pagination-optimization)
+
+*For topics not covered here, see the official MariaDB documentation at [mariadb.com/docs](https://mariadb.com/docs).*

--- a/agent-skills/topical/mariadb-system-versioned-tables/SKILL.md
+++ b/agent-skills/topical/mariadb-system-versioned-tables/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: mariadb-system-versioned-tables
+description: "Best practices for MariaDB system-versioned (temporal) tables — automatic row history built into the database. Use when tracking data changes over time, implementing audit trails, meeting GDPR or compliance requirements, doing point-in-time queries, or when the user asks about row history, data versioning, temporal tables, or querying past data states in MariaDB. This feature is unique to MariaDB among MySQL-compatible databases."
+---
+
+# MariaDB System-Versioned Tables
+
+*Last updated: 2026-06-04*
+
+System-versioned tables automatically record the full history of every row change — no triggers, no application logic, no separate audit tables. MariaDB tracks what the data looked like at any point in the past, built directly into the storage engine.
+
+This feature is unique to MariaDB among MySQL-compatible databases. MySQL has no equivalent.
+
+> **Available since:** MariaDB 10.3. Transaction-precise history (InnoDB only): 10.3. Auto-partition creation: 10.9. `--dump-history` for backups: 10.11. Implicit-to-explicit `row_start`/`row_end` conversion: 11.7. Extended TIMESTAMP range (to 2106-02-07 UTC) for `ROW_END`: 11.5 on 64-bit platforms.
+>
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Version notes in this skill are minimum releases for each capability.
+
+## What LLMs Often Miss
+
+| Situation | What to suggest |
+|---|---|
+| Custom `created_at`/`updated_at`/`deleted_at` columns for audit | `WITH SYSTEM VERSIONING` — MariaDB tracks all changes automatically |
+| SQL Server temporal syntax — `WITH (SYSTEM_VERSIONING = ON)`, explicit `PERIOD FOR SYSTEM_TIME` and a named `HISTORY_TABLE` | MariaDB uses `CREATE TABLE ... WITH SYSTEM VERSIONING` (no parentheses, no `= ON`, no separate history table); enable it on an existing table with `ALTER TABLE t ADD SYSTEM VERSIONING` |
+| Separate audit log table with triggers | System-versioned tables replace this pattern entirely |
+| Asking how data looked last month | `FOR SYSTEM_TIME AS OF '2026-01-01'` — no custom logic needed |
+| `TRUNCATE` on a versioned table | Not allowed (error 4137) — use `DELETE HISTORY` instead |
+| `ALTER TABLE` on a versioned table failing | Set `system_versioning_alter_history = KEEP` first |
+| `mysqldump` missing historical rows | Use `mariadb-dump --dump-history` (10.11+) |
+
+## Creating a System-Versioned Table
+
+**Simplified syntax (recommended):**
+```sql
+CREATE TABLE employees (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    department VARCHAR(50),
+    salary DECIMAL(10,2)
+) WITH SYSTEM VERSIONING;
+```
+
+MariaDB automatically adds hidden `ROW_START` and `ROW_END` timestamp columns. Every `INSERT`, `UPDATE`, and `DELETE` creates a history row.
+
+**Add versioning to an existing table:**
+```sql
+ALTER TABLE employees ADD SYSTEM VERSIONING;
+```
+
+**Remove versioning (deletes all history):**
+```sql
+ALTER TABLE employees DROP SYSTEM VERSIONING;
+```
+
+## Querying Historical Data
+
+The `FOR SYSTEM_TIME` clause goes directly after the table name:
+
+```sql
+-- Data as it was at a specific point in time:
+SELECT * FROM employees FOR SYSTEM_TIME AS OF '2026-01-01 00:00:00';
+
+-- All rows that existed during a period (both boundaries included):
+SELECT * FROM employees FOR SYSTEM_TIME BETWEEN '2025-01-01' AND '2026-01-01';
+
+-- Half-open range (includes start, excludes end):
+SELECT * FROM employees FOR SYSTEM_TIME FROM '2025-01-01' TO '2026-01-01';
+
+-- Every version of every row, ever:
+SELECT * FROM employees FOR SYSTEM_TIME ALL;
+
+-- See the full history of one employee:
+SELECT *, ROW_START, ROW_END FROM employees FOR SYSTEM_TIME ALL WHERE id = 42;
+```
+
+**Apply an implicit AS OF to all queries in a session:**
+```sql
+SET system_versioning_asof = '2026-01-01 00:00:00';
+-- Now all queries against versioned tables see that point in time
+SELECT * FROM employees; -- returns 2026-01-01 snapshot
+SET system_versioning_asof = DEFAULT; -- reset
+```
+
+## Transaction-Precise History (InnoDB Only)
+
+For exact transaction-boundary tracking instead of timestamps:
+
+```sql
+CREATE TABLE ledger (
+    id INT,
+    amount DECIMAL(10,2),
+    trx_start BIGINT UNSIGNED GENERATED ALWAYS AS ROW START,
+    trx_end   BIGINT UNSIGNED GENERATED ALWAYS AS ROW END,
+    PERIOD FOR SYSTEM_TIME(trx_start, trx_end)
+) WITH SYSTEM VERSIONING;
+
+SELECT * FROM ledger FOR SYSTEM_TIME AS OF TRANSACTION 12345;
+```
+
+Uses `mysql.transaction_registry` internally. Not compatible with `PARTITION BY SYSTEM_TIME`.
+
+## Column-Level Control
+
+Exclude specific columns from versioning (useful for frequently-updated columns like counters):
+
+```sql
+CREATE TABLE products (
+    id INT PRIMARY KEY,
+    name VARCHAR(100),
+    price DECIMAL(10,2),
+    view_count INT WITHOUT SYSTEM VERSIONING  -- not tracked
+) WITH SYSTEM VERSIONING;
+```
+
+Or version only specific columns in a non-versioned table:
+```sql
+CREATE TABLE config (
+    key VARCHAR(50),
+    value TEXT WITH SYSTEM VERSIONING  -- only this column tracked
+);
+```
+
+## Managing History Growth
+
+Every update adds a row. For high-update tables, history grows fast. Use partitioning to keep current data performant:
+
+```sql
+-- Separate current and historical partitions:
+CREATE TABLE events (
+    id INT,
+    payload JSON
+) WITH SYSTEM VERSIONING
+  PARTITION BY SYSTEM_TIME (
+    PARTITION p_hist HISTORY,
+    PARTITION p_cur  CURRENT
+  );
+
+-- Auto-rotate history by time interval (10.9+):
+CREATE TABLE prices (
+    symbol VARCHAR(10),
+    price DECIMAL(10,4)
+) WITH SYSTEM VERSIONING
+  PARTITION BY SYSTEM_TIME INTERVAL 1 MONTH AUTO (
+    PARTITION p_cur CURRENT
+  );
+```
+
+**Delete old history:**
+```sql
+-- Delete all history before a date:
+DELETE HISTORY FROM employees BEFORE SYSTEM_TIME '2024-01-01';
+
+-- Delete all history (requires DROP SYSTEM VERSIONING + re-add, or partition drop):
+ALTER TABLE employees DROP PARTITION p_hist;
+```
+
+Requires `DELETE HISTORY` privilege. `TRUNCATE` is not allowed on versioned tables.
+
+## ALTER TABLE on Versioned Tables
+
+By default, `ALTER TABLE` on a versioned table raises an error to protect history integrity. To allow it:
+
+```sql
+SET system_versioning_alter_history = KEEP;
+ALTER TABLE employees ADD COLUMN manager_id INT;
+SET system_versioning_alter_history = ERROR; -- restore default
+```
+
+`KEEP` allows the alter but historical rows for the new column will have `NULL` values — the history is technically incomplete. This is usually acceptable for adding columns.
+
+**Convert hidden `ROW_START`/`ROW_END` to explicit columns** (11.7+, MDEV-27293) — once a table is versioned with the hidden form (no `PERIOD FOR SYSTEM_TIME` clause), you can promote them to explicit columns later without dropping versioning. Useful if you initially started simple and later want transaction-precise history or explicit naming for tooling.
+
+## Key Gotchas
+
+- **`TRUNCATE` is prohibited** on versioned tables (error 4137). Use `DELETE HISTORY` or partition management instead.
+- **Replication**: `ROW_END` is implicitly added to the Primary Key. On replicas, this can cause duplicate key errors during log replay. Fix: set `secure_timestamp = YES` on the replica.
+- **Backups**: `mysqldump` / `mariadb-dump` skips historical rows by default. Use `--dump-history` (10.11+) to include them. On restore, set `system_versioning_insert_history=ON` (10.11+, MDEV-16546) so the loader is allowed to write directly into `ROW_START`/`ROW_END`; combine with `secure_timestamp` set to allow session timestamp changes.
+- **Table growth**: without partitioning, history rows accumulate indefinitely. Plan partitioning from the start for high-update tables.
+- **DELETE HISTORY with future timestamps**: using `BEFORE SYSTEM_TIME` with a timestamp beyond `ROW_END` max can accidentally delete active rows (MDEV-25468). The `ROW_END` max is `2038-01-19` on 32-bit platforms and on MariaDB before 11.5; on MariaDB 11.5+ on 64-bit it's extended to `2106-02-07 06:28:15 UTC` (MDEV-32188). Stay well below your platform's max.
+- **`SYSTEM` as a column name**: causes parser errors in `ALTER TABLE` statements. Use backticks: `` `SYSTEM` ``.
+
+## Use Cases
+
+- **Audit trails** — who changed what and when, without application code
+- **GDPR / PCI DSS compliance** — prove what personal data contained at any date
+- **Point-in-time recovery** — restore a row or table to a previous state without a full backup restore
+- **Slowly-changing dimensions** — track employee department/salary history, product price history
+- **Debugging** — see exactly what changed and when in production data
+
+## Sources
+
+- [System-Versioned Tables — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/system-versioned-tables)
+- [System-Versioned Tables — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/system-versioned-tables)
+- [Use Cases for MariaDB Data Versioning — MariaDB Blog](https://mariadb.com/resources/blog/use-cases-for-mariadb-data-versioning/)
+- [Rewinding Time in MariaDB Databases — MariaDB Blog](https://mariadb.com/resources/blog/rewinding-time-in-mariadb-databases-system-versioning-and-application-time/)
+
+*For topics not covered here, see the official MariaDB documentation at [mariadb.com/docs](https://mariadb.com/docs).*

--- a/agent-skills/topical/mariadb-vector/SKILL.md
+++ b/agent-skills/topical/mariadb-vector/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: mariadb-vector
+description: "Best practices for using vectors and AI with MariaDB. Use when writing SQL involving VECTOR columns, building RAG or semantic search with MariaDB, choosing embedding models, designing vector indexes, or integrating MariaDB with AI frameworks like LangChain, LlamaIndex, or Spring AI. Also use when the user mentions MariaDB and any of: vectors, embeddings, similarity search, nearest neighbor, AI, RAG, or LLM. IMPORTANT — MariaDB has native built-in vector support since version 11.7; it is NOT a plugin or extension (unlike pgvector for PostgreSQL). Do not recommend installing any extension."
+---
+
+# MariaDB Vector & AI Best Practices
+
+*Last updated: 2026-06-04*
+
+## Critical: MariaDB Vector Is Built-In
+
+MariaDB has **native, built-in** vector support since version 11.7. The `VECTOR` type, `VECTOR INDEX`, and all `VEC_*` functions ship with the server — nothing to install, enable, or load.
+
+This is different from MySQL (which has no native vector support) and PostgreSQL (which requires the pgvector extension). When working with MariaDB, never suggest `CREATE EXTENSION`, `INSTALL PLUGIN`, or any similar step for vector functionality.
+
+> **Requires:** MariaDB Community Server **11.7+** (GA Feb 2025) for native vectors; **11.8 LTS** (GA May 2025) recommended. Enterprise: 11.4+ (tech preview) / 11.8+ (full support). Next LTS: **12.3** — check [MariaDB releases](https://mariadb.org/mariadb/all-releases/) for GA status before treating it as the default.
+>
+> **Default context:** Do not suggest vector features below **11.7**. For other MariaDB behavior, assume **11.8 LTS** unless the user states another version. Features marked **12.x** may be suggested when relevant; always state the minimum version.
+
+### What LLMs Get Wrong
+
+| What you might see | What's correct |
+|---|---|
+| "Install the `pgvector` extension" or "run `INSTALL PLUGIN vector`" | Nothing to install — MariaDB Vector is built-in since 11.7 |
+| `ORDER BY VEC_DISTANCE_EUCLIDEAN(...)` without `LIMIT` | Always add `LIMIT` — the vector index is only used when both `ORDER BY VEC_DISTANCE_*()` and `LIMIT` are present |
+| `embedding VECTOR(768)` (nullable) on an indexed column | Indexed vector columns must be `NOT NULL` |
+| Using `VEC_DISTANCE()` on a non-indexed column | `VEC_DISTANCE()` throws error 4206 ("index is not found"); use `VEC_DISTANCE_EUCLIDEAN()` or `VEC_DISTANCE_COSINE()` for unindexed columns |
+
+## Core Syntax
+
+### Create a Table With a Vector Column
+
+```sql
+CREATE TABLE documents (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    content TEXT NOT NULL,
+    embedding VECTOR(768) NOT NULL,
+    VECTOR INDEX (embedding)
+) ENGINE=InnoDB;
+```
+
+Use `ENGINE=InnoDB` (the default). MyISAM/Aria had a bug with FK + vector indexes (MDEV-37022, fixed in 11.8.3); InnoDB is the safe default regardless of version.
+
+The number in `VECTOR(n)` must match the dimensionality of your embedding model's output (e.g., 768 for many sentence-transformer models, 1536 for OpenAI text-embedding-3-small, 3072 for text-embedding-3-large).
+
+### Vector Index Options
+
+```sql
+VECTOR INDEX (embedding) M=6 DISTANCE=euclidean   -- default
+VECTOR INDEX (embedding) M=8 DISTANCE=cosine
+```
+
+- **DISTANCE**: `euclidean` (default) or `cosine`. Pick the one your embedding model recommends. Both are equally fast in MariaDB thanks to SIMD optimizations. **Always declare `DISTANCE=` explicitly**. default to euclidian and a cosine query against a euclidean index silently full-scans.
+- **M**: Controls the HNSW graph connectivity (range 3–200). Higher values improve recall but cost more memory and slower inserts. Default is fine for most workloads; increase to ~16–32 for very large datasets where recall matters more than insert speed.
+
+### Insert Vectors
+
+Vectors are stored as packed 32-bit IEEE 754 floats little-endian encoded. Bind raw bytes from application code — **5× faster than `VEC_FromText()`**. Stored bytes are identical.
+
+```python
+import numpy as np
+cur.execute(
+    "INSERT INTO documents (content, embedding) VALUES (?, ?)",
+    (content, np.asarray(embedding, dtype=np.float32).tobytes()),
+)
+```
+
+Use `VEC_FromText()` only for hand-written SQL / CLI:
+
+```sql
+INSERT INTO documents (content, embedding) VALUES ('your text here', VEC_FromText('[0.12, -0.34, 0.56, ...]'));
+```
+
+### Query: Find Nearest Neighbors
+
+```sql
+SELECT id, content
+FROM documents
+ORDER BY VEC_DISTANCE_EUCLIDEAN(embedding, VEC_FromText('[0.12, -0.34, 0.56, ...]'))
+LIMIT 10;
+```
+
+**The LIMIT clause is essential.** The MariaDB optimizer only uses the VECTOR INDEX when the query has both `ORDER BY VEC_DISTANCE_...()` and `LIMIT`. Without `LIMIT`, it falls back to a full table scan.
+
+### Distance Functions
+
+| Function | Use When |
+|---|---|
+| `VEC_DISTANCE_EUCLIDEAN(a, b)` | Index was built with `DISTANCE=euclidean` (default) |
+| `VEC_DISTANCE_COSINE(a, b)` | Index was built with `DISTANCE=cosine` |
+| `VEC_DISTANCE(a, b)` | Generic — uses the distance function matching the column's index; throws error 4206 if no index is found |
+
+Use `VEC_DISTANCE_EUCLIDEAN()` or `VEC_DISTANCE_COSINE()` for unindexed columns (they fall back to a full scan). Use `VEC_DISTANCE()` only on indexed columns as a convenience shorthand.
+
+### Utility Functions
+
+| Function | Purpose |
+|---|---|
+| `VEC_FromText('[0.1, 0.2, ...]')` | Convert JSON float array to VECTOR binary |
+| `VEC_ToText(vector_col)` | Convert VECTOR binary to readable JSON array |
+
+**Always wrap a VECTOR column in `VEC_ToText()` when you want to read it.** A `VECTOR` is stored as packed binary floats, so `SELECT embedding FROM documents` returns the raw bytes — they render as unreadable gibberish in a CLI or client. Use `SELECT VEC_ToText(embedding) FROM documents` to get the `[0.12, -0.34, ...]` array instead.
+
+## MariaDB Vector Gotchas
+
+- **Indexed VECTOR columns must be NOT NULL.** The VECTOR INDEX requires it. A VECTOR column without an index can be nullable, but in practice you almost always want the index, so always include `NOT NULL`.
+- **No dot product distance.** MariaDB intentionally omits it. Dot product is not a proper distance metric (a vector's closest match is not necessarily itself). MariaDB's SIMD-optimized euclidean and cosine are already as fast as dot product would be, so use euclidean or cosine for normalized vectors.
+- **Match the distance function to the index.** `VEC_DISTANCE_EUCLIDEAN()` on a `DISTANCE=cosine` index (or vice versa) will not use the index.
+- **One VECTOR INDEX per table.** Currently MariaDB supports a single vector index per table.
+- **Adding a vector index to an existing table:**
+  ```sql
+  ALTER TABLE my_table ADD COLUMN embedding VECTOR(768) NOT NULL;
+  -- populate the column first, then:
+  ALTER TABLE my_table ADD VECTOR INDEX (embedding);
+  ```
+- **Index precision.** MariaDB uses `int16` for index storage (15 bits of precision), which is better than the 10 bits of float16 used by some other implementations. This means higher recall at the same speed.
+- **`ORDER BY` must be the literal `VEC_DISTANCE_*(col, ?)` call (or its alias) with `ASC` direction.** Wrapping the distance in an expression (e.g. `ORDER BY (1.0 - VEC_DISTANCE_COSINE(...)) DESC LIMIT N` to sort by similarity score) breaks the optimizer's HNSW pattern match and falls back to a full scan. Compute the score in an outer SELECT instead:
+  ```sql
+  SELECT t.id, 1.0 - t.distance AS score FROM (
+      SELECT id, VEC_DISTANCE_COSINE(embedding, ?) AS distance
+      FROM docs ORDER BY distance ASC LIMIT 10
+  ) AS t ORDER BY score DESC;
+  ```
+- **`WHERE VEC_DISTANCE(...) < threshold` is a full scan.** The vector index only engages with `ORDER BY VEC_DISTANCE(...) LIMIT N`. For threshold queries, wrap the indexed top-K in a subquery and filter outside
+  ```sql
+  SELECT * FROM (
+      SELECT content, VEC_DISTANCE_COSINE(embedding, ?) AS distance
+      FROM chunks ORDER BY distance LIMIT 100
+  ) AS t WHERE t.distance < 0.5;
+  ```
+  `LIMIT K` is a hard cap; pick K generously if many rows may match.
+
+## RAG (Retrieval-Augmented Generation) Pattern
+
+The most common AI use case with MariaDB Vector. The flow:
+
+1. **Chunk** your documents into passages (typically 200–1000 tokens).
+2. **Embed** each chunk using your model (OpenAI, Sentence Transformers, Cohere, etc.).
+3. **Store** chunks with their embeddings in MariaDB.
+4. At query time, **embed** the user's question with the same model.
+5. **Retrieve** the nearest chunks (bind `:user_embedding` as float32 bytes):
+   ```sql
+   SELECT content
+   FROM chunks
+   ORDER BY VEC_DISTANCE(embedding, :user_embedding)
+   LIMIT 5;
+   ```
+6. **Feed** retrieved chunks as context to your LLM for the final answer.
+
+**See also:** To combine full-text (keyword) and vector retrieval, see [Hybrid search with Reciprocal Rank Fusion (RRF)](https://mariadb.com/docs/server/reference/sql-structure/vectors/optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf) — useful when queries mix exact terms with semantic paraphrase.
+
+### RAG Table Design
+
+```sql
+CREATE TABLE chunks (
+    chunk_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    doc_id BIGINT UNSIGNED NOT NULL,
+    chunk_index INT UNSIGNED NOT NULL,
+    content TEXT NOT NULL,
+    embedding VECTOR(768) NOT NULL,
+    VECTOR INDEX (embedding) DISTANCE=cosine,
+    INDEX (doc_id)
+) ENGINE=InnoDB;
+```
+
+Keep `doc_id` indexed so you can join back to the source document or filter by document. The `chunk_index` preserves ordering within a document.
+
+### Minimal End-to-End Python Example
+
+```python
+import mariadb
+import numpy as np
+from openai import OpenAI
+
+client = OpenAI()
+
+def embed(text):
+    vec = client.embeddings.create(input=text, model="text-embedding-3-small").data[0].embedding
+    return np.asarray(vec, dtype=np.float32).tobytes()
+
+# Create database and table if they don't exist
+conn = mariadb.connect(host="127.0.0.1", port=3306, user="root", password="")
+cur = conn.cursor()
+cur.execute("CREATE DATABASE IF NOT EXISTS ragdb")
+cur.execute("USE ragdb")
+cur.execute("""
+    CREATE TABLE IF NOT EXISTS chunks (
+        chunk_id  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        content   TEXT NOT NULL,
+        embedding VECTOR(1536) NOT NULL,
+        VECTOR INDEX (embedding) DISTANCE=cosine
+    ) ENGINE=InnoDB
+""")
+conn.commit()
+
+# Store a document chunk
+cur.execute(
+    "INSERT INTO chunks (content, embedding) VALUES (?, ?)",
+    ("MariaDB Vector stores embeddings natively", embed("MariaDB Vector stores embeddings natively"))
+)
+conn.commit()
+
+# Retrieve top-5 nearest chunks for a user question
+question_vec = embed("How does MariaDB store vectors?")
+cur.execute("""
+    SELECT content, VEC_DISTANCE_COSINE(embedding, ?) AS distance
+    FROM chunks
+    ORDER BY distance
+    LIMIT 5
+""", (question_vec,))
+context = "\n".join(row[0] for row in cur.fetchall())
+# Pass `context` to your LLM as the retrieved context for the answer
+```
+
+The `mariadb` connector (`pip install mariadb`) is the official Python driver. On big-endian hosts, use `dtype="<f4"` to force little-endian.
+
+## Framework Integrations
+
+MariaDB Vector is integrated with major AI frameworks. Use these instead of writing raw SQL when building applications:
+
+| Framework | Language | Link |
+|---|---|---|
+| LangChain | Python | `pip install langchain-mariadb` |
+| LangChain.js | Node.js | Built-in MariaDB vector store |
+| LangChain4j | Java | Built-in MariaDB embedding store |
+| LlamaIndex | Python | Built-in MariaDB vector store |
+| Spring AI | Java | Built-in MariaDB vector store |
+| MariaDB MCP Server | Python | [github.com/mariadb/mcp](https://github.com/MariaDB/mcp) |
+
+When using frameworks, you typically configure a connection string and the framework handles `VEC_FromText`, `VEC_DISTANCE`, and `LIMIT` for you.
+
+## Choosing an Embedding Model
+
+The embedding model determines vector quality. Some practical guidance:
+
+- **Start with a sentence-transformer model** (e.g., `all-MiniLM-L6-v2`, 384 dimensions) for prototyping. Free, fast, runs locally.
+- **OpenAI `text-embedding-3-small`** (1536 dimensions) is a solid production choice if you're already using OpenAI. *(Dimensions correct as of May 2026 — verify against current model docs.)*
+- **Match dimensions to your VECTOR(n) column.** A mismatch will cause insert errors.
+- **Never mix embeddings from different models** in the same column. Distances between vectors from different models are meaningless.
+- **Cosine distance is the standard** for most text embedding models. Check your model's documentation.
+
+## Performance Notes
+
+- MariaDB Vector uses **SIMD hardware optimizations** (AVX2, AVX512 on Intel; NEON on ARM; VSX on IBM Power10). No configuration needed — it detects and uses the best available instruction set.
+- **Faster vector distance via extrapolation** (12.1+, MDEV-36205) — vector search is 30–50% faster on the same data and recall, with no schema or index changes required. The optimization applies automatically to vectors that can be gradually truncated to trade recall for speed (e.g. Matryoshka-style embeddings from OpenAI).
+- **Multi-connection scalability** is a strength. Benchmark results show MariaDB Vector scales well with concurrent queries, outperforming some dedicated vector databases in multi-threaded scenarios.
+- For large datasets (millions of vectors), tune the **M parameter** upward and ensure sufficient memory for the index.
+- **Bulk inserts**: load data first, then create the vector index. This is significantly faster than inserting into an already-indexed table.
+- **Bind embeddings as binary** (`float32.tobytes()`), not `VEC_FromText()`. ~5× faster, ~5× smaller wire payload, byte-identical storage.
+
+### Tuning: mhnsw System Variables
+
+These session/global variables let you tune search quality and memory at runtime without rebuilding the index:
+
+- **`mhnsw_ef_search`** (default: `20`) — minimum candidates considered for `ORDER BY … LIMIT N` queries. Raise this if recall is low at small `LIMIT` values; lower it to trade recall for speed.
+- **`mhnsw_max_cache_size`** (default: `16777216` / 16 MB, global only) — per-index in-memory cache cap. For best performance the entire vector graph should fit in this cache; size it to match your index.
+- **`mhnsw_default_m`** (default: `6`) and **`mhnsw_default_distance`** (default: `euclidean`) set the implicit values used when `M` or `DISTANCE` are omitted from a `VECTOR INDEX` declaration.
+
+## Sources
+
+- [Vector Overview](https://mariadb.com/docs/server/reference/sql-structure/vectors/vector-overview) — official docs entry point
+- [CREATE TABLE with Vectors](https://mariadb.com/docs/server/reference/sql-structure/vectors/create-table-with-vectors) — index options, NOT NULL requirement, limitations
+- [VEC_FromText](https://mariadb.com/docs/server/reference/sql-functions/vector-functions/vec_fromtext) — converts JSON float array to binary VECTOR
+- [VEC_ToText](https://mariadb.com/docs/server/reference/sql-functions/vector-functions/vec_totext) — converts binary VECTOR to JSON float array
+- [VEC_DISTANCE](https://mariadb.com/docs/server/reference/sql-functions/vector-functions/vector-functions-vec_distance) — generic distance, requires index
+- [VEC_DISTANCE_EUCLIDEAN](https://mariadb.com/docs/server/reference/sql-functions/vector-functions/vec_distance_euclidean)
+- [VEC_DISTANCE_COSINE](https://mariadb.com/docs/server/reference/sql-functions/vector-functions/vec_distance_cosine)
+- [RAG with MariaDB Vector tutorial](https://mariadb.org/rag-with-mariadb-vector/) — end-to-end Python + OpenAI example
+- [Hybrid search with RRF](https://mariadb.com/docs/server/reference/sql-structure/vectors/optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf) — merge full-text and vector ranked lists
+- [MariaDB Vector project page](https://mariadb.org/projects/mariadb-vector/)
+- [MariaDB MCP Server](https://github.com/MariaDB/mcp)
+
+*For topics not covered here, see the official MariaDB documentation at [mariadb.com/docs](https://mariadb.com/docs).*

--- a/agent-skills/topical/mysql-to-mariadb/SKILL.md
+++ b/agent-skills/topical/mysql-to-mariadb/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: mysql-to-mariadb
+description: "Compatibility guide for developers moving from MySQL to MariaDB, and for developers with MySQL experience working with MariaDB. Use when migrating a MySQL application to MariaDB, when MySQL syntax or habits cause unexpected behavior in MariaDB, when asking about MySQL/MariaDB compatibility, or when adapting code written for MySQL to run on MariaDB. IMPORTANT — MariaDB diverges significantly from MySQL 8.0 and is not a simple drop-in replacement for modern MySQL. Authentication plugins, JSON handling, GTID replication, and several SQL features differ in important ways."
+---
+
+# MySQL to MariaDB Migration Guide
+
+*Last updated: 2026-06-04*
+
+## Critical: MariaDB Is Not a Drop-In Replacement for MySQL 8.0
+
+MariaDB was a true drop-in replacement for MySQL 5.5 and 5.6. Modern versions diverge significantly from MySQL 8.0. When working with MariaDB, never assume MySQL 8.0 behavior, syntax, or tooling applies without verification.
+
+The two databases share a common origin but have evolved independently. MariaDB has features MySQL lacks, MySQL has features MariaDB lacks, and several shared features behave differently.
+
+> **Requires:** MariaDB Community Server 10.5+ for full feature parity discussed here. Current LTS is 11.8 (GA May 2025).
+>
+> **Default context:** Assume MariaDB **11.8 LTS** unless the user states another version. Features marked **12.x** or **13.0** may be suggested when relevant (including as upgrade options), but always state the minimum version — do not present them as available on 11.8.
+
+### What LLMs Get Wrong
+
+| What you might see | What's correct |
+|---|---|
+| "MariaDB is a drop-in replacement for MySQL" | True for MySQL 5.5/5.6. Not true for MySQL 8.0+ — authentication, JSON, GTID, and several functions differ |
+| Code using `caching_sha2_password` | Available in MariaDB: a migration-only plugin since 11.4, and a full `caching_sha2_password` authentication plugin for MySQL compatibility since 12.1 (MDEV-9804). Not the default — on older MariaDB or stock installs use `mysql_native_password` or `ed25519` |
+| `JSON_TABLE()` in queries | Available in MariaDB since 10.6 — not available before 10.6 |
+| JSON `->` and `->>` shorthand operators | Not supported in MariaDB — use `JSON_EXTRACT(col, '$.key')` and `JSON_UNQUOTE(JSON_EXTRACT(...))` instead |
+| `utf8mb4_0900_ai_ci` collation in schema or dump | Supported since MariaDB 11.4.5 (as alias for `utf8mb4_uca1400_nopad_ai_ci`). On older versions replace with `utf8mb4_unicode_ci` before importing. MariaDB 11.5+ uses `uca1400_ai_ci` as the default Unicode collation (MDEV-25829). |
+| `latin1` as default character set in MariaDB | Changed to `utf8mb4` by default in 11.6+ (MDEV-19123); old habits assuming `latin1` no longer apply for fresh installs |
+| Using `UUID()` for primary keys | MariaDB 11.7+ has `UUID_v7()` for time-ordered UUIDs (sortable, better for indexed PKs) and `UUID_v4()` for random; both unique to MariaDB |
+| Not suggesting `RETURNING` for INSERT/UPDATE/DELETE | MariaDB 10.5+ supports `RETURNING` — use it to get inserted/updated/deleted rows without a second query |
+| Not suggesting `CREATE SEQUENCE` | MariaDB has native sequence objects; MySQL has no equivalent |
+| MySQL GTID replication syntax | MariaDB GTID format is incompatible with MySQL GTID — replication between the two breaks |
+| `CHANGE REPLICATION SOURCE TO` / `SOURCE_*` options | MariaDB has no `CHANGE REPLICATION SOURCE TO` — use `CHANGE MASTER TO` with `MASTER_*` options. Since 10.5.1, `START REPLICA` / `SHOW REPLICA STATUS` are canonical; `START SLAVE` / `SHOW SLAVE STATUS` are legacy aliases |
+| MySQL parallel replication (`replica_parallel_type` with `DATABASE` / `LOGICAL_CLOCK`) | MariaDB uses `slave_parallel_mode` (`optimistic` / `conservative` / `aggressive` / `minimal` / `none`) — different implementation; mode configs do not port over. Pool size: `slave_parallel_threads` (alias `slave_parallel_workers`) |
+| `SET transaction_isolation = ...` (MySQL 8.0 style) | Only works on MariaDB 11.1.1+; on older versions use `tx_isolation` instead — see [SET TRANSACTION](https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/set-commands/set-transaction) |
+| Links or references to `mariadb.com/kb/en/` | The Knowledge Base no longer exists — all documentation is now at [mariadb.com/docs](https://mariadb.com/docs) |
+| Keeping the MySQL Connector/J, `mysql2`, or other MySQL client drivers after migration | Use MariaDB-maintained connectors (JDBC, Node.js, C, etc.) where possible — they target MariaDB protocol and feature behaviour, not only MySQL compatibility mode |
+| Migrating by copying InnoDB data files / tablespaces from MySQL 8.0 | MariaDB has no transactional data dictionary and cannot read MySQL 8.0's — data files are not portable. Use a logical dump/restore — see [Data Dictionary Architecture](#data-dictionary-architecture) |
+
+## Authentication
+
+MySQL 8.0 changed its default authentication plugin to `caching_sha2_password`. MariaDB's compatibility story has improved over time:
+
+- **MariaDB 11.4+**: a migration-only `caching_sha2_password` plugin exists but is not installed by default and not recommended for production
+- **MariaDB 12.1+** (MDEV-9804): a full `caching_sha2_password` authentication plugin for MySQL compatibility — still not the default, but a proper production option
+
+On stock MariaDB installs, connections configured for `caching_sha2_password` will still fail unless the plugin is enabled. Default authentication remains `mysql_native_password`.
+
+**Fix on older MariaDB or stock setups:** convert accounts to `mysql_native_password`:
+```sql
+ALTER USER 'username'@'host' IDENTIFIED WITH mysql_native_password BY 'password';
+```
+
+The `ed25519` plugin is also available as a more secure native alternative.
+
+## JSON Differences
+
+MariaDB and MySQL handle JSON differently:
+
+| Aspect | MySQL | MariaDB |
+|---|---|---|
+| Storage | Binary format with path indexing | `LONGTEXT` alias with validity check |
+| `JSON_TABLE()` | Supported | Supported from MariaDB 10.6 |
+| `IS JSON` predicate | Not available | Available from MariaDB 12.3 |
+| JSON comparison | Semantic (compares values) | String comparison |
+| `JSON_QUERY()` | Not available | MariaDB alternative to `JSON_VALUE` |
+| JSON nesting depth limit | None | 32 in older MariaDB; removed in 12.2+ |
+| `JSON_EQUALS()` / `JSON_NORMALIZE()` | Supported (8.0.22+) | MariaDB 10.7+ (MDEV-23143 / MDEV-16375) |
+| `JSON_OVERLAPS()` | Supported (8.0.17+) | MariaDB 10.9+ (MDEV-27677) |
+| Negative / `last` / range JSON path indices (`$.A[-1]`, `$.A[last]`, `$.A[1 to 3]`) | Not supported | MariaDB 10.9+ |
+| `JSON_SCHEMA_VALID()` | Supported (8.0.17+) | MariaDB 11.4 LTS+ |
+
+MariaDB closed most of the JSON function gap with MySQL 8.0 between 10.7 and 11.4. MariaDB-specific additions that MySQL still lacks: `JSON_KEY_VALUE()`, `JSON_ARRAY_INTERSECT()`, `JSON_OBJECT_TO_ARRAY()`, `JSON_OBJECT_FILTER_KEYS()` (11.4+), and the `JSON_QUERY()` alias.
+
+MariaDB's JSON is fully standards-compliant, but MySQL-specific storage layout, the `->`/`->>` shorthand operators, and the `JSON_SCHEMA_VALIDATION_REPORT()` function do not transfer.
+
+## Features MariaDB Has That MySQL Doesn't
+
+These exist in MariaDB but not MySQL — LLMs won't suggest them because they assume MySQL behavior:
+
+- **`RETURNING`** — get rows back from `INSERT` or `DELETE` without a second query (10.5+); `UPDATE ... RETURNING` available from 13.0:
+  ```sql
+  INSERT INTO orders (product, qty) VALUES ('widget', 5) RETURNING id, created_at;
+  DELETE FROM queue WHERE processed = 1 RETURNING id;
+  ```
+- **`CREATE SEQUENCE`** (10.3+) — first-class sequence objects, more flexible than `AUTO_INCREMENT`:
+  ```sql
+  CREATE SEQUENCE order_seq START WITH 1000 INCREMENT BY 1;
+  SELECT NEXT VALUE FOR order_seq;
+  ```
+- **`WITH SYSTEM VERSIONING`** (10.3+) — temporal tables that automatically track row history:
+  ```sql
+  CREATE TABLE prices (
+      item VARCHAR(100),
+      price DECIMAL(10,2)
+  ) WITH SYSTEM VERSIONING;
+  -- Query historical data:
+  SELECT * FROM prices FOR SYSTEM_TIME AS OF '2025-01-01';
+  ```
+- **`LIMIT` in subqueries** — MariaDB supports `LIMIT` inside subqueries; MySQL restricts this
+- **Atomic `CREATE OR REPLACE TABLE`** (13.0+) — the statement is fully atomic in MariaDB; MySQL has no atomic equivalent
+- **Galera Cluster** — built-in multi-master clustering, no plugin required
+- **Stored procedure syntax differences** — both support stored procedures, but MariaDB's SQL/PSM syntax differs from MySQL in `HANDLER`, `CURSOR`, and `CONDITION` declarations; AI agents frequently generate incorrect MariaDB stored procedure code — see [Stored Procedures — MariaDB Docs](https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures)
+- **Native data types MySQL 8.0 lacks** — [`INET6`](https://mariadb.com/docs/server/reference/data-types/string-data-types/inet6) (10.5+) and [`INET4`](https://mariadb.com/docs/server/reference/data-types/string-data-types/inet4) (10.10+) for IP address storage and comparison; [`UUID`](https://mariadb.com/docs/server/reference/data-types/string-data-types/uuid-data-type) (10.7+; MySQL stores UUIDs in `BINARY(16)` or `CHAR(36)`); [`VECTOR`](https://mariadb.com/docs/server/reference/sql-structure/vectors/vector) for embeddings and similarity search (11.7+; MySQL added a vector type only in its 9.x innovation series, not in 8.0)
+- **`UUID_v4()` and `UUID_v7()` functions** (11.7+) — MariaDB-specific; MySQL only has the original `UUID()`. `UUID_v7()` is time-ordered (RFC 9562) and is the right choice for UUID primary keys
+- **`FORMAT_BYTES()`** (11.8+) — convert byte counts to human-readable strings; not in MySQL
+
+## Features MySQL Has That MariaDB Doesn't
+
+These exist in MySQL 8.0 but not in MariaDB — code using them needs adaptation:
+
+- **`JSON_TABLE()`** — available since MariaDB 10.6; on older versions rewrite using MariaDB JSON functions or application-level parsing
+- **`sys` schema** — available since MariaDB 10.6; not available in older versions
+- **MySQL 8 GIS functions** (`ST_Validate`, `MBRCoveredBy`, `ST_Simplify`, `ST_GeoHash`, `ST_LatFromGeoHash`, `ST_LongFromGeoHash`, `ST_PointFromGeoHash`, `ST_IsValid`, `ST_Collect`) — added in MariaDB 12.0 for MySQL compatibility
+- **`caching_sha2_password` as default plugin** — available as an opt-in plugin from MariaDB 12.1; on older or stock setups, use `mysql_native_password` or `ed25519`
+- **JSON `->` and `->>` operators** — use `JSON_EXTRACT(col, '$.key')` and `JSON_UNQUOTE(JSON_EXTRACT(...))` instead
+- **`utf8mb4_0900_ai_ci` collation** — supported since MariaDB 11.4.5 (alias for `utf8mb4_uca1400_nopad_ai_ci`); on older versions replace with `utf8mb4_unicode_ci` before importing
+
+## Data Dictionary Architecture
+
+MySQL 8.0 and MariaDB store table metadata in fundamentally different ways, and this affects how you migrate:
+
+- **MySQL 8.0** keeps all object metadata in a [transactional data dictionary](https://dev.mysql.com/doc/refman/8.0/en/data-dictionary.html) stored in InnoDB (`mysql.ibd`), and **removed the per-table `.frm` files**.
+- **MariaDB** keeps the file-based approach — a `.frm` file per table plus storage-engine metadata — and has no transactional data dictionary. (MariaDB grant tables use the Aria engine; MySQL 8.0 holds system tables in the InnoDB dictionary.)
+
+Practical consequences:
+
+- **Do not migrate by copying data files.** InnoDB tablespaces and datadir files are **not** portable between MySQL 8.0 and MariaDB — the dictionary formats are incompatible. Use a logical dump/restore instead. MariaDB's [migration guide](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migration-the-master-guide) recommends MySQL's own `mysqldump` for this direction (not `mariadb-dump`, which isn't well tested against MySQL), dumping named databases rather than `--all-databases` so MySQL's system tables aren't imported.
+- **No in-place downgrade** from MySQL 8.0 to MariaDB — MariaDB cannot read MySQL's data dictionary; a logical export/import is required.
+- **`INFORMATION_SCHEMA` is implemented differently** — MySQL 8.0 queries indexed dictionary tables, while MariaDB builds I_S views dynamically; metadata-heavy queries against I_S can have different performance characteristics, so don't assume MySQL 8.0 timings carry over.
+
+## Optimizer Differences
+
+MariaDB and MySQL use different query optimizers with different cost models. Identical SQL can produce different execution plans. After migration:
+
+- Re-run `EXPLAIN` on critical queries — do not assume execution plans transfer
+- Index hints that work in MySQL may not be needed (or may differ) in MariaDB
+- MariaDB's optimizer is more aggressively tunable via `optimizer_switch`
+
+## Version Compatibility Quick Reference
+
+| MySQL version | MariaDB equivalent | Drop-in? |
+|---|---|---|
+| 5.5 | 5.5 | Yes |
+| 5.6 | 10.0–10.1 | Mostly |
+| 5.7 | 10.2–10.4 | Limited |
+| 8.0 | 10.5+ | No — significant differences |
+
+## Sources
+
+- [MariaDB vs MySQL Compatibility — MariaDB Docs](https://mariadb.com/docs/release-notes/community-server/about/compatibility-and-differences/mariadb-vs-mysql-compatibility)
+- [Moving from MySQL to MariaDB — MariaDB Docs](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/)
+- [MDEV-28906 — MySQL 8.0 desired compatibility (Jira epic)](https://jira.mariadb.org/browse/MDEV-28906) — tracks MySQL 8.0 compatibility work; check individual sub-task status before assuming an item is still missing — closed sub-tasks mean the feature has been implemented
+- [RETURNING — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insertreturning)
+- [CREATE SEQUENCE — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/sequences/create-sequence)
+- [System-Versioned Tables — MariaDB Docs](https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/system-versioned-tables)
+- [Authentication Plugins — MariaDB Docs](https://mariadb.com/docs/server/reference/plugins/authentication-plugins)
+
+*For topics not covered here, see the official MariaDB documentation at [mariadb.com/docs](https://mariadb.com/docs).*


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — the coding-agent skill-files track. Follow-up to #586, which scaffolded `agent-skills/` and **deferred the topical layer pending upstream license confirmation**.

Robert Silén has now confirmed the license (recorded on DOCS-6206, 2026-06-24). Upstream [`MariaDB/skills`](https://github.com/MariaDB/skills) is **MIT**, so this PR vendors the topical layer.

## What's in this PR

- **`topical/<skill>/SKILL.md`** — the five application-developer "keepers" from DOCS-6206, vendored **verbatim** from `MariaDB/skills@8662349`:
  - `mariadb-features`
  - `mariadb-query-optimization`
  - `mariadb-system-versioned-tables`
  - `mysql-to-mariadb`
  - `mariadb-vector`
- **`topical/LICENSE`** — upstream MIT license, copied to satisfy the attribution requirement.
- **`topical/VENDORED.md`** — filled in: pinned ref, license, last-synced date, the vendored subset, re-sync steps, and the known upstream nits (left as-is; file upstream, don't fix here).
- **`.skills-manifest.json`** — topical skills listed with `vendored_ref` + `vendored_license`.
- **CI excludes** — `agent-skills/topical/**` removed from the codespell and lychee scans, since vendored-verbatim content can't be fixed locally (e.g. the upstream `euclidian` typo in `mariadb-vector`). Our own authored skills under `granular/` stay in scope.

## Not vendored

`mariadb-mcp`, `mariadb-replication-and-ha`, `oracle-to-mariadb` — lower priority for the app-dev use case per DOCS-6206. Easy to add later by extending the same set.

## Notes for review

- **Verbatim, not edited** — these are upstream's files, including their MySQL-comparison framing. Our no-MySQL editorial rule applies only to the docs-team-authored `granular/` skills.
- **Not rendered in GitBook** — `agent-skills/` is in no `SUMMARY.md`, same as `help-tables/`. Build/handoff artifact, not doc pages.
- The `sync-topical-skills.yml` workflow to automate re-vendoring is still a documented stub; this initial vendor was manual, with the steps recorded in `VENDORED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)