### PR TITLE
DOCS-6206 Use public mariadb.com/docs URLs in pilot skill references

### DIFF
--- a/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
@@ -7,7 +7,7 @@ description: "MariaDB JSON functions — complete catalog of JSON_*, JSON_ARRAY/
 
 *Last updated: 2026-06-02*
 
-Catalog of every built-in JSON function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at `server/reference/sql-functions/special-functions/json-functions/`. For JSONPath syntax (used by `JSON_EXTRACT`, `JSON_QUERY`, `JSON_VALUE`, `JSON_TABLE`, etc.), see the JSONPath reference page in the same directory.
+Catalog of every built-in JSON function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at <https://mariadb.com/docs/server/reference/sql-functions/special-functions/json-functions>. For JSONPath syntax (used by `JSON_EXTRACT`, `JSON_QUERY`, `JSON_VALUE`, `JSON_TABLE`, etc.), see <https://mariadb.com/docs/server/reference/sql-functions/special-functions/json-functions/jsonpath-expressions>.
 
 > **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
 
@@ -201,4 +201,4 @@ Given a JSON document, returns the scalar specified by the path.
 
 - **`mariadb-create-table`** — declaring `JSON`-typed columns (alias for `LONGTEXT` with auto `CHECK`)
 - **`mariadb-select`** — `JSON_TABLE` in the `FROM` clause for relational projection of JSON documents
-- Canonical reference: `server/reference/sql-functions/special-functions/json-functions/` (41 pages); JSONPath syntax at `…/jsonpath-expressions.md`
+- Canonical reference on `mariadb.com/docs`: <https://mariadb.com/docs/server/reference/sql-functions/special-functions/json-functions> (the JSON Functions section); JSONPath syntax at <https://mariadb.com/docs/server/reference/sql-functions/special-functions/json-functions/jsonpath-expressions>

--- a/agent-skills/granular/statements/mariadb-alter-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-alter-table/SKILL.md
@@ -153,4 +153,4 @@ InnoDB-only. Aria, MyISAM, etc. don't need this — they pick up data files plac
 
 - **`mariadb-create-table`** — column definitions, index definitions, and table options (shared syntax surface)
 - **`mariadb-system-versioned-tables`** — versioning model, `system_versioning_alter_history`, history-row semantics
-- Canonical reference: `server/reference/sql-statements/data-definition/alter/alter-table/README.md` (~870 lines) plus `…/alter-table/online-schema-change.md` — consult only for edge cases not covered here
+- Canonical references on `mariadb.com/docs`, consult only for edge cases not covered here: <https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table> and <https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table/online-schema-change>

--- a/agent-skills/granular/statements/mariadb-create-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-table/SKILL.md
@@ -123,4 +123,4 @@ Keywords `INDEX` and `KEY` are interchangeable in MariaDB.
 
 - **`mariadb-system-versioned-tables`** — full system-versioning, application-time, bitemporal, querying history, partitioning, removing history
 - **`mariadb-vector`** — `VECTOR(N)` columns and vector indexes
-- Canonical reference: `server/reference/sql-statements/data-definition/create/create-table.md` (~980 lines) — consult only for edge cases not covered here
+- Canonical reference on `mariadb.com/docs`, consult only for edge cases not covered here: <https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-table>

--- a/agent-skills/granular/statements/mariadb-select/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-select/SKILL.md
@@ -194,11 +194,9 @@ Constraints and traps:
 
 - **`mariadb-system-versioned-tables`** — full `FOR SYSTEM_TIME` semantics, transaction-precise history, versioning-aware partitioning
 - **`mariadb-create-table`** / **`mariadb-alter-table`** — shared column, index, and table-option surface
-- Canonical references:
-  - `server/reference/sql-statements/data-manipulation/selecting-data/select.md` (~220 lines)
-  - `…/select-into-outfile.md` (~80 lines)
-  - `…/select-into-dumpfile.md` (~60 lines)
-  - `…/select-offset-fetch.md` (~120 lines)
-  - `…/select-with-rollup.md` (~155 lines)
-
-  Consult only for edge cases not covered here.
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select-into-outfile>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select-into-dumpfile>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select-offset-fetch>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select-with-rollup>


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track. Small follow-up to PR #623.

The four **merged** pilot skills cited their "Canonical reference" as **repo-relative paths** (e.g. `server/reference/sql-statements/data-definition/create/create-table.md`). That assumes a consumer has a full `mariadb-docs` clone — but the documented consumption model pulls **only `agent-skills/`** (sparse checkout / tarball / push), so those paths don't resolve for a consuming agent, and they aren't fetchable URLs.

This switches the consumer-facing references to public **`https://mariadb.com/docs/…`** URLs (each verified to resolve) and drops the `(~N lines)` annotations, which mean nothing to a consumer. It aligns the pilots with the same fix made to the new DML skills in #623, and with the design's stated fallback ("fall through to `mariadb.com/docs`").

## Files

- `granular/statements/mariadb-create-table/SKILL.md`
- `granular/statements/mariadb-alter-table/SKILL.md`
- `granular/statements/mariadb-select/SKILL.md`
- `granular/functions/mariadb-json-functions/SKILL.md` (See Also + the intro "fall back to" reference)

## Note

The json-functions **extractor-provenance** path (the doc tree it extracts from + the extractor script) is intentionally left as a repo path — that's maintainer/build-facing, not a consumer reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)