### PR TITLE
DOCS-6206 Promote core DML skills to pilot

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -10,10 +10,10 @@
         { "name": "mariadb-create-table", "path": "granular/statements/mariadb-create-table/SKILL.md", "status": "pilot" },
         { "name": "mariadb-alter-table", "path": "granular/statements/mariadb-alter-table/SKILL.md", "status": "pilot" },
         { "name": "mariadb-select", "path": "granular/statements/mariadb-select/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-insert", "path": "granular/statements/mariadb-insert/SKILL.md", "status": "draft" },
-        { "name": "mariadb-update", "path": "granular/statements/mariadb-update/SKILL.md", "status": "draft" },
-        { "name": "mariadb-delete", "path": "granular/statements/mariadb-delete/SKILL.md", "status": "draft" },
-        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "draft" }
+        { "name": "mariadb-insert", "path": "granular/statements/mariadb-insert/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-update", "path": "granular/statements/mariadb-update/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-delete", "path": "granular/statements/mariadb-delete/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "pilot" }
       ]
     },
     "granular-functions": {


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track.

The four core DML skills (`mariadb-insert`, `mariadb-update`, `mariadb-delete`, `mariadb-replace`) merged as `draft` in #623 have now been **reviewed and verified** — the non-negotiable human verification gate described in `dev-docs/agent-skills-maintenance.md`. This flips their `.skills-manifest.json` status from `draft` to `pilot`, putting them on the same footing as the `create-table`/`alter-table`/`select` pilots.

Manifest-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)