### PR TITLE
DOCS-6206 Add common DDL Tier 1 agent skills (VIEW/INDEX/DROP TABLE/DATABASE)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -13,7 +13,11 @@
         { "name": "mariadb-insert", "path": "granular/statements/mariadb-insert/SKILL.md", "status": "pilot" },
         { "name": "mariadb-update", "path": "granular/statements/mariadb-update/SKILL.md", "status": "pilot" },
         { "name": "mariadb-delete", "path": "granular/statements/mariadb-delete/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "pilot" }
+        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-create-view", "path": "granular/statements/mariadb-create-view/SKILL.md", "status": "draft" },
+        { "name": "mariadb-create-index", "path": "granular/statements/mariadb-create-index/SKILL.md", "status": "draft" },
+        { "name": "mariadb-drop-table", "path": "granular/statements/mariadb-drop-table/SKILL.md", "status": "draft" },
+        { "name": "mariadb-create-database", "path": "granular/statements/mariadb-create-database/SKILL.md", "status": "draft" }
       ]
     },
     "granular-functions": {

--- a/agent-skills/granular/statements/mariadb-create-database/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-database/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: mariadb-create-database
+description: "MariaDB-specific syntax and behavior for databases — CREATE DATABASE / CREATE SCHEMA (exact synonyms), the OR REPLACE data-loss footgun vs IF NOT EXISTS, CHARACTER SET / COLLATE / COMMENT specifications and the utf8mb4 default-charset change, ALTER DATABASE (charset/collate/comment + UPGRADE DATA DIRECTORY NAME), DROP DATABASE, and the absence of a RENAME DATABASE statement. Use when writing, generating, or reviewing CREATE DATABASE / ALTER DATABASE / DROP DATABASE statements that target MariaDB."
+---
+
+# CREATE DATABASE in MariaDB
+
+*Last updated: 2026-06-24*
+
+This skill covers the **delta between standard SQL and MariaDB** for creating and managing databases (schemas). It assumes the agent knows the basic `CREATE DATABASE db;` form.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `DROP DATABASE x; CREATE DATABASE x …` to reset a database | `CREATE OR REPLACE DATABASE x …` does exactly that in one statement |
+| Treats `CREATE OR REPLACE DATABASE` as a safe "create if missing" | **It drops the existing database first** — every table in it is gone, irreversibly. Use `CREATE DATABASE IF NOT EXISTS x` when you only want create-if-absent. `OR REPLACE` and `IF NOT EXISTS` express opposite intents — never both |
+| Thinks `CREATE SCHEMA` differs from `CREATE DATABASE` | They are exact synonyms (same for `ALTER`/`DROP`, and `SCHEMAS`/`DATABASES`) |
+| Reaches for a `RENAME DATABASE` / `RENAME SCHEMA` statement | There is none (it was removed as unsafe). Rename per-table with `RENAME TABLE old_db.t TO new_db.t`, or dump and reload |
+| `CHARACTER SET utf8` (the 3-byte legacy alias) | Use `utf8mb4` for full Unicode. On fresh 11.6+ installs `utf8mb4` is already the **default** charset (was `latin1`), with default collation `uca1400_ai_ci` *(since 11.5/11.6)* — see `mariadb-features` |
+| Expects `ALTER DATABASE` to rename or relocate a database | It can only change `CHARACTER SET`, `COLLATE`, or `COMMENT` (or run `UPGRADE DATA DIRECTORY NAME` for a legacy directory). No rename, no move |
+| Assumes changing a database's charset re-encodes existing data or updates existing routines | It changes only the database **default** for newly created objects. Existing tables keep their charset; existing stored routines must be dropped and recreated to pick up the new default |
+| Wraps `CREATE`/`DROP DATABASE` in a transaction to roll back | DDL does an **implicit commit** — it can't be rolled back. (`DROP DATABASE` is crash-safe per-table, but that's not the same as transactional) |
+| `DROP DATABASE x` without realizing the blast radius | It drops the database and **all** its tables. Privileges granted on the database are **not** automatically removed |
+| Bare `CREATE DATABASE x` in a script that may re-run | Errors (`1007 … database exists`) the second time. Use `IF NOT EXISTS` to downgrade to a note |
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] {DATABASE | SCHEMA} [IF NOT EXISTS] db_name
+    [ [DEFAULT] CHARACTER SET [=] charset
+    | [DEFAULT] COLLATE [=] collation
+    | COMMENT [=] 'string' ] …;
+```
+
+```sql
+CREATE DATABASE app
+  CHARACTER SET = 'utf8mb4'
+  COLLATE = 'uca1400_ai_ci'
+  COMMENT = 'application schema';
+```
+
+- `CREATE OR REPLACE DATABASE` reports 2 rows affected (the drop, then the create).
+- `COMMENT` is stored in `INFORMATION_SCHEMA.SCHEMATA`; max 1024 bytes.
+
+## `ALTER DATABASE`
+
+```sql
+ALTER {DATABASE | SCHEMA} [db_name]
+    {CHARACTER SET = charset | COLLATE = collation | COMMENT = 'string'};
+
+ALTER {DATABASE | SCHEMA} db_name UPGRADE DATA DIRECTORY NAME;
+```
+
+`db_name` may be omitted to target the current database. `UPGRADE DATA DIRECTORY NAME` re-encodes a legacy `#mysql50#`-prefixed directory name and is normally driven by `mariadb-upgrade`, not hand-written.
+
+## `DROP DATABASE`
+
+```sql
+DROP {DATABASE | SCHEMA} [IF EXISTS] db_name;
+```
+
+Without `IF EXISTS`, a missing database errors (`1008`); with it, a note. Drops every table in the database — there is no `RESTRICT`/`CASCADE` and no confirmation.
+
+## See Also
+
+- **`mariadb-features`** (topical) — the `latin1` → `utf8mb4` default-charset change (since 11.6) and the `uca1400_ai_ci` default-collation change (since 11.5); the canonical home for that story
+- **`mariadb-create-table`** — the table-level analogs of `CREATE OR REPLACE` and `IF NOT EXISTS`, the `utf8`/`utf8mb4` trap, and per-object charset/collation
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-database>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-database>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/drop/drop-database>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/renaming-databases>

--- a/agent-skills/granular/statements/mariadb-create-index/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-index/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mariadb-create-index
+description: "MariaDB-specific syntax and behavior for CREATE INDEX / DROP INDEX — that it maps to ALTER TABLE (batch multiple adds), can't create a PRIMARY KEY, needs a prefix length on TEXT/BLOB columns, has no expression/functional indexes (index a generated column instead), real descending indexes (since 10.8), IGNORED indexes for safe optimizer testing, UNIQUE/FULLTEXT/SPATIAL/VECTOR kinds, USING BTREE/HASH/RTREE, CREATE OR REPLACE / IF NOT EXISTS, KEY_BLOCK_SIZE being ignored here, and dropping a PRIMARY KEY via DROP INDEX `PRIMARY`. Use when writing, generating, or reviewing CREATE INDEX / DROP INDEX statements that target MariaDB."
+---
+
+# CREATE INDEX in MariaDB
+
+*Last updated: 2026-06-24*
+
+This skill covers the **delta between standard SQL `CREATE INDEX` and MariaDB's**. It assumes the agent knows the basic `CREATE INDEX i ON t (col);` form. For defining indexes inline with the table, see `mariadb-create-table`; for *choosing* indexes and query-shape pitfalls, see the `mariadb-query-optimization` topical skill.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `CREATE INDEX` … to add a `PRIMARY KEY` | Not possible — `CREATE INDEX` cannot create a primary key. Use `ALTER TABLE t ADD PRIMARY KEY (…)` or define it in `CREATE TABLE` (preferable for InnoDB, which clusters on the PK and would otherwise rebuild) |
+| `CREATE INDEX i ON t ((col1 + col2))` or any expression index | MariaDB has **no expression/functional index** in `CREATE INDEX` — index columns are plain column names only. Add a generated column and index that: `ALTER TABLE t ADD c INT AS (col1 + col2) PERSISTENT, ADD INDEX (c);` |
+| Indexes a `TEXT`/`BLOB` column without a prefix length | A prefix length is **mandatory** for `TEXT`/`BLOB` (otherwise `ER_BLOB_KEY_WITHOUT_LENGTH`): `CREATE INDEX i ON t (body(255));` |
+| Issues several `CREATE INDEX` statements on one table | Each `CREATE INDEX` maps to an `ALTER TABLE … ADD INDEX`, so N statements can mean N table operations. Add them in **one** `ALTER TABLE t ADD INDEX …, ADD INDEX …` to do the work once |
+| Filters with a function on the indexed column (`WHERE DATE(ts) = …`, `WHERE LOWER(email) = …`) and expects the index to be used | Wrapping an indexed column in a function defeats the index. Rewrite as a range (`ts >= … AND ts < …`), or index a generated column holding the expression. See `mariadb-query-optimization` |
+| Assumes a `DESC` index key is decorative / ignored | Descending index parts are **physically real** *(since 10.8)* — `CREATE INDEX i ON t (a ASC, b DESC)` stores `b` in reverse order, which can serve mixed-direction `ORDER BY` without a filesort |
+| Drops an index just to measure whether a query still needs it | Mark it `IGNORED` instead — the optimizer ignores it while it stays fully maintained, so you can test impact and flip it back instantly: `ALTER TABLE t ALTER INDEX i IGNORED;` (or `IGNORED` in the `CREATE INDEX` options) |
+| `DROP INDEX i; CREATE INDEX i …` to change an index | `CREATE OR REPLACE INDEX i ON t (…)` drops and recreates it in one statement. `CREATE INDEX IF NOT EXISTS i …` warns (note) instead of erroring if it already exists |
+| Tries `DROP INDEX` to remove a primary key by table name | Drop it by the reserved name, quoted: ``DROP INDEX `PRIMARY` ON t;`` |
+| Sets `KEY_BLOCK_SIZE` on a `CREATE INDEX` expecting it to take effect | `KEY_BLOCK_SIZE` is **ignored** by `CREATE INDEX` (it still shows in `SHOW CREATE TABLE`). Set it at the table level if you need it |
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] [UNIQUE | FULLTEXT | SPATIAL | VECTOR] INDEX
+    [IF NOT EXISTS] index_name
+    [USING {BTREE | HASH | RTREE}]
+    ON tbl_name (col_name [(length)] [ASC | DESC], …)
+    [WAIT n | NOWAIT]
+    [index_option …]
+    [algorithm_option | lock_option] …;
+```
+
+Key points:
+
+- **Maps to `ALTER TABLE`.** `CREATE INDEX` and `DROP INDEX` are shortcuts for `ALTER TABLE … ADD/DROP INDEX`; the online-DDL `ALGORITHM` and `LOCK` clauses apply (see `mariadb-alter-table`).
+- **Index kinds:** `UNIQUE`, `FULLTEXT`, `SPATIAL`, and `VECTOR` *(since 11.7)*. `VECTOR` indexes take `DISTANCE = {EUCLIDEAN | COSINE}` and `M = n` options — see the `mariadb-vector` topical skill.
+- **`USING BTREE | HASH | RTREE`** selects the index algorithm where the engine supports a choice.
+- **`IGNORED` / `NOT IGNORED`** toggles whether the optimizer considers the index, without dropping it.
+- **`WITHOUT OVERLAPS`** (in a `UNIQUE` index) constrains application-time periods so they can't overlap — see temporal-tables material.
+- **`WAIT n` / `NOWAIT`** bounds the metadata-lock wait.
+
+```sql
+CREATE UNIQUE INDEX uq_email ON users (email);
+CREATE INDEX i_body ON articles (body(255));          -- prefix required for TEXT/BLOB
+CREATE OR REPLACE INDEX i_created ON orders (created_at DESC);
+```
+
+## `DROP INDEX`
+
+```sql
+DROP INDEX [IF EXISTS] index_name ON tbl_name [WAIT n | NOWAIT];
+```
+
+Maps to `ALTER TABLE … DROP INDEX`. Use ``DROP INDEX `PRIMARY` ON t`` to drop a primary key (the quotes are required — `PRIMARY` is a keyword). `IF EXISTS` downgrades a missing index to a warning.
+
+## See Also
+
+- **`mariadb-create-table`** — defining indexes inline at table creation (preferable for InnoDB primary keys) and the full index-definition surface
+- **`mariadb-alter-table`** — what `CREATE INDEX`/`DROP INDEX` actually map to; batching several index changes into one statement; `ALGORITHM`/`LOCK` online-DDL options
+- **`mariadb-query-optimization`** (topical) — choosing indexes, and why functions on indexed columns prevent index use
+- **`mariadb-vector`** (topical) — `VECTOR` indexes, `DISTANCE`, and `M`
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-index>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/drop/drop-index>

--- a/agent-skills/granular/statements/mariadb-create-view/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-view/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: mariadb-create-view
+description: "MariaDB-specific syntax and behavior for views — CREATE OR REPLACE VIEW vs CREATE VIEW IF NOT EXISTS (mutually exclusive), ALGORITHM = UNDEFINED/MERGE/TEMPTABLE and its effect on updatability and performance, the SQL SECURITY DEFINER default, WITH CASCADED/LOCAL CHECK OPTION, what makes a view updatable/insertable, frozen-at-creation definitions, and ALTER VIEW / DROP VIEW. Use when writing, generating, or reviewing CREATE VIEW / ALTER VIEW / DROP VIEW statements that target MariaDB."
+---
+
+# CREATE VIEW in MariaDB
+
+*Last updated: 2026-06-24*
+
+This skill covers the **delta between standard SQL views and MariaDB's** — the view-definition options, updatability rules, and security semantics that trip up generated SQL. It assumes the agent already knows the basic `CREATE VIEW v AS SELECT …` form. The view body is a `SELECT`; for its clauses see `mariadb-select`.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `DROP VIEW x; CREATE VIEW x …` to redefine a view | `CREATE OR REPLACE VIEW x AS …` — atomic, no window where the view is missing. (`ALTER VIEW x AS …` also works when it already exists) |
+| `CREATE OR REPLACE VIEW IF NOT EXISTS …`, assuming the two combine | Hard error (`ER_WRONG_USAGE`). `OR REPLACE` and `IF NOT EXISTS` are mutually exclusive — pick one |
+| Omits `SQL SECURITY`, expecting the caller's privileges to apply | The default is **`SQL SECURITY DEFINER`** — the view executes with the *definer's* privileges, not the invoker's. For caller-privilege semantics you must write `SQL SECURITY INVOKER` explicitly |
+| Treats any view as updatable / `INSERT`-able | A view is **not** updatable if its `SELECT` uses an aggregate, `DISTINCT`, `GROUP BY`, `HAVING`, `UNION`, a subquery in the select list, an outer join, references no base table, or refers to one base-table column more than once. `ALGORITHM = TEMPTABLE` is never updatable |
+| Sets `ALGORITHM = TEMPTABLE` on a view it then writes through | `TEMPTABLE` views are never updatable; only `MERGE` (or an `UNDEFINED` view the optimizer can merge) can be written through |
+| `INSERT`s through a view whose columns are expressions (`col + 1`, `LOWER(col)`, literals) | Insertable views need every column to be a plain base-table column, must include all `NOT NULL`/no-default base columns, and may not repeat a base column. Otherwise `ERROR 1348: Column is not updatable` |
+| Bare `WITH CHECK OPTION` on a view built on another view, expecting only the local predicate to be checked | Bare `WITH CHECK OPTION` means **`CASCADED`** (checks this view *and* all underlying views). Use `WITH LOCAL CHECK OPTION` to check only this view's predicate |
+| Puts `ORDER BY` inside the view to guarantee output order | The view's `ORDER BY` is **ignored** whenever the outer query has its own `ORDER BY`. Don't rely on in-view ordering — sort in the query that reads the view |
+| Expects `SELECT *` in a view to pick up columns added to the base table later | The definition is **frozen at creation**: `SELECT *` is expanded to the columns that existed then. New base-table columns don't appear until you recreate the view |
+| Tries to index a view, or `CREATE TEMPORARY VIEW`, or put a subquery in the view's `FROM` | None are allowed. Index the underlying base table; there is no temporary view; a view's `SELECT` can't have a derived table in `FROM` |
+| Leaves expression columns unnamed | Every view column needs a unique name — give expressions an alias, or supply an explicit `(column_list)` whose length matches the select list |
+
+## Syntax
+
+```sql
+CREATE
+    [OR REPLACE]
+    [ALGORITHM = {UNDEFINED | MERGE | TEMPTABLE}]
+    [DEFINER = { user | CURRENT_USER | role | CURRENT_ROLE }]
+    [SQL SECURITY { DEFINER | INVOKER }]
+    VIEW [IF NOT EXISTS] view_name [(column_list)]
+    AS select_statement
+    [WITH [CASCADED | LOCAL] CHECK OPTION];
+```
+
+Clause order is fixed (`OR REPLACE` → `ALGORITHM` → `DEFINER` → `SQL SECURITY` → `VIEW`). `DEFINER` accepts a role or `CURRENT_ROLE`, not just a user. `CREATE VIEW` is atomic DDL.
+
+## `ALGORITHM`
+
+| Algorithm | Behavior |
+|---|---|
+| `MERGE` | The view text is merged into the referencing query. More efficient, and **required for an updatable view**. Not possible if the view uses `GROUP BY`, `HAVING`, `LIMIT`, `DISTINCT`, `UNION`, an aggregate, or a select-list subquery |
+| `TEMPTABLE` | The view result is materialized into a temporary table. Never updatable; can release underlying locks earlier |
+| `UNDEFINED` (default) | The server chooses, preferring `MERGE` and falling back to a temp table when the shape forbids merging |
+
+## Updatable views and `WITH CHECK OPTION`
+
+When a view is updatable, `WITH CHECK OPTION` rejects writes that would produce rows the view can't see:
+
+```sql
+CREATE VIEW active AS SELECT * FROM users WHERE status = 'active' WITH CHECK OPTION;
+-- INSERT/UPDATE that sets status <> 'active' → ERROR 1369: CHECK OPTION failed
+```
+
+For views layered on views, `LOCAL` checks only this view's predicate; `CASCADED` (the default) also checks every underlying view's predicate.
+
+## `ALTER VIEW` and `DROP VIEW`
+
+```sql
+ALTER VIEW view_name [(column_list)] AS select_statement …;   -- same options as CREATE, minus OR REPLACE / IF NOT EXISTS
+DROP VIEW [IF EXISTS] view_name [, view_name] … [RESTRICT | CASCADE];
+```
+
+- `ALTER VIEW` is equivalent to `CREATE OR REPLACE VIEW` on an existing view.
+- In `DROP VIEW`, `RESTRICT` and `CASCADE` are **parsed but ignored** (accepted only for syntax compatibility).
+- `DROP VIEW IF EXISTS` downgrades a missing view to a note; in a multi-view drop, existing views are still dropped.
+
+## See Also
+
+- **`mariadb-select`** — the view body is a `SELECT`; the clauses that make a view non-updatable or non-mergeable are all `SELECT` features
+- **`mariadb-create-table`** — shares the `CREATE OR REPLACE` / `IF NOT EXISTS` atomic-DDL model and the same mutual-exclusion rule
+- **`mariadb-query-optimization`** (topical) — when the `MERGE` vs `TEMPTABLE` choice matters for performance
+- **`mariadb-system-versioned-tables`** (topical) — a view adds no row history; put `WITH SYSTEM VERSIONING` on the base table and query it with `FOR SYSTEM_TIME`
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/server-usage/views/create-view>
+  - <https://mariadb.com/docs/server/server-usage/views/view-algorithms>
+  - <https://mariadb.com/docs/server/server-usage/views/inserting-and-updating-with-views>
+  - <https://mariadb.com/docs/server/server-usage/views/alter-view>
+  - <https://mariadb.com/docs/server/server-usage/views/drop-view>

--- a/agent-skills/granular/statements/mariadb-drop-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-drop-table/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: mariadb-drop-table
+description: "MariaDB-specific syntax and behavior for DROP TABLE — RESTRICT/CASCADE being no-ops, the DROP TEMPORARY TABLE guard against dropping a same-named base table, partial drops in a multi-table statement, IF EXISTS warning behavior, failure when a table is referenced by a foreign key, DROP TABLE on a view, automatic trigger removal, implicit-commit (and the DROP TEMPORARY exception), WAIT/NOWAIT, and CREATE OR REPLACE TABLE as the atomic replace. Use when writing, generating, or reviewing DROP TABLE statements that target MariaDB."
+---
+
+# DROP TABLE in MariaDB
+
+*Last updated: 2026-06-24*
+
+This skill covers the **delta between standard SQL `DROP TABLE` and MariaDB's**. It assumes the agent knows the basic `DROP TABLE t;` form. Everything below documents MariaDB-specific behavior and the traps that bite generated SQL.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Adds `CASCADE` expecting dependent objects (FK children, etc.) to be dropped too | `RESTRICT` and `CASCADE` are **parsed but do nothing** on `DROP TABLE` — accepted only for portability. Nothing cascades. To remove a referencing foreign key, drop or alter that table explicitly |
+| Bare `DROP TABLE x` to discard a temporary table | `DROP TEMPORARY TABLE x` — `TEMPORARY` restricts the drop to temporary tables, so a stray base table of the same name can never be dropped by accident. The safer form whenever you mean a temp table |
+| Assumes one missing table aborts `DROP TABLE a, b, c` and leaves the rest | **Partial drop**: the tables that exist are still dropped; the missing ones are collected and reported together at the end. Without `IF EXISTS` you get both the drops *and* an error |
+| Expects `DROP TABLE IF EXISTS missing` to still error | `IF EXISTS` turns the unknown-table error into a **note-level warning** (visible via `SHOW WARNINGS`) — not an error, not silent |
+| `DROP TABLE v` where `v` is a view | Errors (`ER_IT_IS_A_VIEW`) — use `DROP VIEW v`. (See `mariadb-create-view`) |
+| Drops a table that another table's foreign key references | Blocked (`ER_ROW_IS_REFERENCED`). Drop the referencing FK first, or `SET foreign_key_checks = 0` for the session to bypass the check |
+| Wraps `DROP TABLE` in a transaction expecting to roll it back | DDL does an **implicit commit** — it can't be rolled back. The one exception: `DROP TEMPORARY TABLE` does *not* implicitly commit the surrounding transaction |
+| Drops a table, then separately hunts down its triggers | `DROP TABLE` removes the table's triggers automatically — no separate `DROP TRIGGER` needed |
+| `DROP TABLE x; CREATE TABLE x …` to replace a table definition | `CREATE OR REPLACE TABLE x …` — atomic, with no window where the table is missing. See `mariadb-create-table` |
+| Uses `DROP TABLE` to clear rows or reset `AUTO_INCREMENT` | That destroys the table. To empty it, use `TRUNCATE TABLE` (resets `AUTO_INCREMENT`, implicit commit) or `DELETE FROM` (transactional). See `mariadb-delete` |
+
+## Syntax
+
+```sql
+DROP [TEMPORARY] TABLE [IF EXISTS]
+    tbl_name [, tbl_name] …
+    [WAIT n | NOWAIT]
+    [RESTRICT | CASCADE];
+```
+
+Clause order is load-bearing: `WAIT`/`NOWAIT` comes **after** the table list and **before** the (no-op) `RESTRICT`/`CASCADE`. `TABLE` and `TABLES` are interchangeable.
+
+```sql
+-- Missing tables tolerated as warnings:
+DROP TABLE IF EXISTS employees, customers;
+
+-- Guard against dropping a same-named base table:
+DROP TEMPORARY TABLE IF EXISTS scratch;
+
+-- Qualified names can span databases in one statement:
+DROP TABLE app.sessions, archive.sessions;
+
+-- Bound the metadata-lock wait instead of blocking:
+DROP TABLE big_table WAIT 5;     -- or NOWAIT to fail immediately
+```
+
+`WAIT n` / `NOWAIT` sets the lock-wait timeout for the statement — useful when a long-held metadata lock would otherwise make the `DROP` block. A single-table `DROP TABLE` is atomic (crash-safe) on InnoDB/Aria/MyISAM; in a multi-table drop each individual table drop is atomic, but the statement as a whole is **not** all-or-nothing.
+
+## See Also
+
+- **`mariadb-create-table`** — `CREATE OR REPLACE TABLE` (the atomic replace) and the shared implicit-commit / atomic-DDL behavior
+- **`mariadb-create-view`** — `DROP VIEW` for views (`DROP TABLE` won't drop them)
+- **`mariadb-delete`** — when you want to *empty* a table rather than drop it: `TRUNCATE TABLE` vs `DELETE FROM`
+- Canonical reference on `mariadb.com/docs`, consult only for edge cases not covered here: <https://mariadb.com/docs/server/reference/sql-statements/data-definition/drop/drop-table>


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track. **Second Tier 1 batch**, following the core-DML batch (#623): the common DDL object statements that complement `create-table`/`alter-table`.

Adds four hand-authored `SKILL.md` files under `agent-skills/granular/statements/`:

- `mariadb-create-view` (+ `ALTER`/`DROP VIEW`)
- `mariadb-create-index` (+ `DROP INDEX`)
- `mariadb-drop-table`
- `mariadb-create-database` (+ `ALTER`/`DROP DATABASE`)

Each follows the pilot structure: triage `description`, the **11.8 LTS** default-context note, a **"What LLMs Often Miss"** table, MariaDB-specific feature sections, and a cross-linked **See Also** using public `mariadb.com/docs` URLs (the convention from #624). No MySQL naming. 4.9–7 KB each.

## How these were produced

Claude-authored from four parallel research agents that **source-verified** claims against `mariadb-server/sql/` (grammar in `sql_yacc.yy`, plus `sql_db.cc` / `sql_table.cc` / `sql_view.cc` and error strings) and the canonical `server/reference` + `server-usage` pages. Verified traps of note:

- **Views:** `SQL SECURITY` defaults to `DEFINER` (not `INVOKER`); bare `WITH CHECK OPTION` means `CASCADED`; `ALGORITHM = TEMPTABLE` views are never updatable; `OR REPLACE` + `IF NOT EXISTS` is a hard error.
- **Database:** `CREATE OR REPLACE DATABASE` **drops the existing database first** (data-loss footgun); `SCHEMA` is an exact synonym; there is no `RENAME DATABASE`.
- **DROP TABLE:** `RESTRICT`/`CASCADE` are no-ops; `DROP TEMPORARY TABLE` guards against dropping a same-named base table; DDL implicit-commits — except `DROP TEMPORARY TABLE`, which doesn't.
- **CREATE INDEX:** can't create a `PRIMARY KEY` and has no expression/functional index (index a generated column); `TEXT`/`BLOB` need a prefix length; descending index parts are physically real (since 10.8); `IGNORED` indexes for safe optimizer testing.

## Status: `draft` — needs human verification

Marked `"status": "draft"` in `.skills-manifest.json`. Authoring + source-checking is done; the **human verification pass is the next gate** per `dev-docs/agent-skills-maintenance.md` before promotion to `pilot`. Reviewing this diff is that pass.

## Notes

- Not rendered in GitBook (no `SUMMARY.md` entry), like the rest of `agent-skills/`.
- Independent of the in-flight promotion PR (#625), which only flips the DML statuses — different manifest lines, clean merge.
- codespell + link-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)