### PR TITLE
DOCS-6206 Add data-import/seeding Tier 1 skills + granular/tools layer

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -17,7 +17,8 @@
         { "name": "mariadb-create-view", "path": "granular/statements/mariadb-create-view/SKILL.md", "status": "draft" },
         { "name": "mariadb-create-index", "path": "granular/statements/mariadb-create-index/SKILL.md", "status": "draft" },
         { "name": "mariadb-drop-table", "path": "granular/statements/mariadb-drop-table/SKILL.md", "status": "draft" },
-        { "name": "mariadb-create-database", "path": "granular/statements/mariadb-create-database/SKILL.md", "status": "draft" }
+        { "name": "mariadb-create-database", "path": "granular/statements/mariadb-create-database/SKILL.md", "status": "draft" },
+        { "name": "mariadb-load-data", "path": "granular/statements/mariadb-load-data/SKILL.md", "status": "draft" }
       ]
     },
     "granular-functions": {
@@ -26,6 +27,14 @@
       "author": "docs-team+extractor",
       "skills": [
         { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" }
+      ]
+    },
+    "granular-tools": {
+      "path": "granular/tools",
+      "author": "docs-team",
+      "skills": [
+        { "name": "mariadb-dump", "path": "granular/tools/mariadb-dump/SKILL.md", "status": "draft" },
+        { "name": "mariadb-import", "path": "granular/tools/mariadb-import/SKILL.md", "status": "draft" }
       ]
     },
     "topical": {

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -21,10 +21,11 @@ nothing here depends on a submodule fetch or a separate repository.
 | --- | --- | --- | --- |
 | `granular/statements/` | **Tier 1** — one skill per SQL statement family (`mariadb-create-table`, `mariadb-alter-table`, `mariadb-select`, …) | Docs team, hand-curated | Source of truth, here |
 | `granular/functions/` | **Tier 2** — one skill per function category (`mariadb-json-functions`, …); machine-extracted entries wrapped in a hand-written scaffold | Docs team + `extractor/` | Source of truth, here |
+| `granular/tools/` | **Tier 1 (tools)** — one skill per client utility (`mariadb-dump`, `mariadb-import`, …) | Docs team, hand-curated | Source of truth, here |
 | `topical/` | **Topical** — feature-area deep dives (`mariadb-features`, `mariadb-vector`, …) | Robert Silen / MariaDB Foundation | **Vendored** from [`MariaDB/skills`](https://github.com/MariaDB/skills) — see `topical/VENDORED.md`; do not hand-edit |
 
 Each skill is a directory containing a `SKILL.md` (Claude Code skill convention),
-so all three layers ingest uniformly.
+so every layer ingests uniformly.
 
 ## How to consume
 

--- a/agent-skills/granular/statements/mariadb-load-data/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-load-data/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: mariadb-load-data
+description: "MariaDB-specific syntax and behavior for LOAD DATA [LOCAL] INFILE (and LOAD XML) — the LOCAL vs server-side fork and its security/privilege requirements (local_infile, FILE privilege, secure_file_priv), tab/newline (not CSV) defaults, how LOCAL silently downgrades duplicate handling to IGNORE and disables strict-mode aborts, IGNORE n LINES, user-variable + SET transformation, the CHARACTER SET clause, and priority/concurrency. Use when writing, generating, or reviewing LOAD DATA / LOAD XML statements, or bulk-loading CSV/TSV/XML into MariaDB."
+---
+
+# LOAD DATA INFILE in MariaDB
+
+*Last updated: 2026-06-24*
+
+This skill covers the **delta between standard SQL bulk loading and MariaDB's** `LOAD DATA [LOCAL] INFILE` (and the `LOAD XML` companion). It assumes the agent knows the basic `LOAD DATA INFILE 'f' INTO TABLE t` form. The inverse — writing a file — is `SELECT … INTO OUTFILE` (see `mariadb-select`); the command-line wrapper is `mariadb-import` (see `mariadb-import`).
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `LOAD DATA LOCAL INFILE …` will just work once the client passes the file | `LOCAL` needs **both** ends enabled: the client/connector must allow local-infile (often **off by default** in drivers — the usual real blocker) *and* the server's `local_infile` system variable must be ON (it is, by default). Otherwise: *"the … server or client has disabled the local infile capability"* |
+| Without `LOCAL`, the path is relative to the client / current directory | Without `LOCAL` the **server** reads the file from *its own* filesystem. The connecting user needs the global **`FILE`** privilege, and if `secure_file_priv` is set the file must sit under that directory |
+| Adds `REPLACE` / `IGNORE` to a `LOCAL` load to control duplicate-key handling | With `LOCAL` the server can't error mid-stream, so a bare `LOAD DATA LOCAL` **silently treats duplicate-key rows as `IGNORE`** (keeps the old row, warns) — your intent to error is dropped. For reliable `REPLACE`/error semantics, load from a server-side file (no `LOCAL`) |
+| Expects strict mode to **error** on bad/truncated values during a `LOCAL` load | With `LOCAL`, strict-mode abort-on-warning is **disabled** — bad data is coerced and warned, never aborted. (A non-`LOCAL` load honors strict mode.) Always check `SHOW WARNINGS` after loading |
+| Assumes `LOAD DATA` errors out like an `INSERT` on bad rows | Even without `LOCAL`, `LOAD DATA` leans toward **warn-and-coerce** — too-few/too-many fields per row raise warnings, not errors. Inspect `SHOW WARNINGS` every time |
+| `LOAD DATA INFILE 'x.csv' INTO TABLE t` and expects CSV parsing | MariaDB's defaults are **tab-separated fields, newline-terminated lines, backslash escape — not CSV**. For real CSV: `FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'` |
+| Post-filters or pre-strips a header row | Use `IGNORE 1 LINES` (`LINES` and `ROWS` are interchangeable) to skip header rows |
+| Loads a value that needs transforming, then fixes it with a follow-up `UPDATE` | Read the raw field into a **user variable** and transform in `SET` in the same pass: `(id, @raw) SET created = STR_TO_DATE(@raw, '%m/%d/%Y')` |
+| Relies on `SET NAMES` / `character_set_client` for the file's encoding | `LOAD DATA` ignores those — use the `CHARACTER SET` clause. The default read charset is `character_set_database`; `CHARACTER SET binary` means no conversion |
+| Adds `LOW_PRIORITY` / `CONCURRENT` to speed up an InnoDB load | Both affect only table-lock engines (`CONCURRENT` is MyISAM-specific); no effect on InnoDB. They're also mutually exclusive |
+| Uses `LOAD DATA` machinery (FIELDS/LINES) for XML | `LOAD XML` has no FIELDS/LINES — it uses `ROWS IDENTIFIED BY '<tag>'` (angle brackets literal; default `<row>`) |
+
+## Syntax
+
+```sql
+LOAD DATA [LOW_PRIORITY | CONCURRENT] [LOCAL] INFILE 'file_name'
+    [REPLACE | IGNORE]
+    INTO TABLE tbl_name
+    [PARTITION (p, …)]
+    [CHARACTER SET charset_name]
+    [{FIELDS | COLUMNS}
+        [TERMINATED BY 'string']
+        [[OPTIONALLY] ENCLOSED BY 'char']
+        [ESCAPED BY 'char']]
+    [LINES
+        [STARTING BY 'string']
+        [TERMINATED BY 'string']]
+    [IGNORE number {LINES | ROWS}]
+    [(col_name_or_user_var, …)]
+    [SET col_name = expr, …];
+```
+
+Defaults when a clause is omitted: fields `\t`, lines `\n`, escape `\`.
+
+```sql
+-- Real CSV with a header row and an on-the-fly transform:
+LOAD DATA LOCAL INFILE '/tmp/data.csv'
+  INTO TABLE t
+  FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+  LINES TERMINATED BY '\n'
+  IGNORE 1 LINES
+  (a, @raw_b) SET b = UPPER(@raw_b);
+
+-- Server-side load (needs FILE privilege; path under secure_file_priv):
+LOAD DATA INFILE '/var/lib/mysql-files/import.tsv' REPLACE INTO TABLE t;
+```
+
+## `LOAD XML`
+
+```sql
+LOAD XML [LOW_PRIORITY | CONCURRENT] [LOCAL] INFILE 'file_name'
+    [REPLACE | IGNORE]
+    INTO TABLE [db_name.]tbl_name
+    [CHARACTER SET charset_name]
+    [ROWS IDENTIFIED BY '<tagname>']
+    [IGNORE number {LINES | ROWS}]
+    [(column_or_user_var, …)]
+    [SET col_name = expr, …];
+```
+
+`LOCAL`, `REPLACE`/`IGNORE`, `CHARACTER SET`, the column list, and `SET` behave exactly as for `LOAD DATA` — including the `LOCAL` duplicate/strict-mode caveats above. `ROWS IDENTIFIED BY` names the row element (default `<row>`); MariaDB auto-detects the common attribute/element layouts.
+
+## Security checklist
+
+- **No `LOCAL`** → server reads its own filesystem; requires `FILE` privilege; path constrained by `secure_file_priv` (and `secure_file_priv = NULL` disables file I/O entirely).
+- **`LOCAL`** → client streams the file; needs the connector's local-infile option on and server `local_infile = ON`; relaxes duplicate and strict-mode handling (see traps above).
+
+## See Also
+
+- **`mariadb-select`** — `SELECT … INTO OUTFILE` / `INTO DUMPFILE`, the inverse of `LOAD DATA`, with the same `FIELDS`/`LINES` grammar and `FILE`/`secure_file_priv` constraints (match `CHARACTER SET` on both sides for round-tripping)
+- **`mariadb-import`** — the command-line wrapper that issues `LOAD DATA INFILE` per file
+- **`mariadb-insert`** / **`mariadb-replace`** — duplicate-key handling: `IGNORE` semantics and `REPLACE` (delete-then-insert) caveats that `LOAD DATA … REPLACE` inherits
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-xml>

--- a/agent-skills/granular/tools/mariadb-dump/SKILL.md
+++ b/agent-skills/granular/tools/mariadb-dump/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: mariadb-dump
+description: "MariaDB-specific behavior of the mariadb-dump client for dev workflows (seeding, fixtures, schema snapshots, consistent backups) — why --single-transaction is the live-InnoDB flag and its limits, that --routines/--events are off by default while --triggers is on, --extended-insert vs diffable dumps, schema-only/data-only, --replace/--insert-ignore for idempotent seeding, that plain dbname omits CREATE DATABASE, restoring by piping into the mariadb client, and that the replication-coordinate flags are --master-data/--dump-slave (not --source-data/--dump-replica). Use when invoking or reviewing mariadb-dump commands."
+---
+
+# mariadb-dump in MariaDB
+
+*Last updated: 2026-06-24*
+
+`mariadb-dump` produces a SQL script that recreates schema and/or data — the workhorse for seeding dev databases, capturing fixtures, and logical backups. This skill covers its MariaDB-specific defaults and the traps that bite generated commands. The binary is `mariadb-dump` (`mysqldump` is a compatibility symlink, deprecated since 11.0 and absent on some minimal installs). Its round-trip partners are `mariadb-import` and `LOAD DATA` (see `mariadb-import`, `mariadb-load-data`).
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent runs / assumes… | …prefer the MariaDB form |
+|---|---|
+| Dumps a live InnoDB database with default locking | Add `--single-transaction` — a consistent snapshot (`START TRANSACTION WITH CONSISTENT SNAPSHOT`) that doesn't block writers. It auto-disables `--lock-tables` (the two are mutually exclusive) |
+| Assumes `--single-transaction` makes the whole dump consistent | Only **InnoDB** tables are consistent under it; non-transactional tables (MyISAM/Aria/MEMORY) can still change mid-dump. And **DDL on a dumped table during the dump breaks it** — no `ALTER`/`CREATE`/`DROP`/`TRUNCATE` on those tables while it runs |
+| Expects stored procedures/functions/events in the dump | `--routines` (`-R`) and `--events` (`-E`) are **off by default** — add them. `--triggers` *is* on by default. The classic "my dump is missing my stored procedures" |
+| Expects a readable / diffable dump (one INSERT per row) | `--extended-insert` is **on by default** (multi-row INSERTs). For version-control-friendly fixtures use `--skip-extended-insert`, usually with `--complete-insert` (column names) and `--compact` (drop boilerplate) |
+| Restores by "running" the dump with `mariadb-dump` or double-clicking it | The dump is a plain SQL script — restore by piping it into the **`mariadb` client**: `mariadb dbname < dump.sql`. (`mariadb-dump` only produces dumps, it never loads them) |
+| Reaches for `--source-data` / `--dump-replica` (to capture replication coordinates) | Those names **don't exist** in MariaDB. Use `--master-data[=1|2]` or `--dump-slave[=1|2]`, optionally with `--gtid` for GTID coordinates |
+| `mariadb-dump dbname` and expects `CREATE DATABASE` / `USE` in the output | A plain database name emits neither. Use `--databases dbname` (`-B`) or `--all-databases` (`-A`) to include `CREATE DATABASE`/`USE` |
+| Builds schema-only or data-only dumps with shell hacks | `--no-data` (`-d`) = structure only; `--no-create-info` (`-t`) = data only; `--ignore-table-data=db.tbl` = structure only for one table |
+| Generates a seed dump that fails on re-import because rows already exist | `--replace` emits `REPLACE INTO`; `--insert-ignore` emits `INSERT IGNORE` — either makes re-seeding idempotent. Both off by default |
+| Dumps binary/BLOB columns and gets corruption through pipes or editors | Add `--hex-blob` to emit `BINARY`/`BLOB`/`BIT` values as `0x…` hex literals |
+| Dumps from a current server expecting an older client to restore it | The dump opens with a sandbox-mode line that older clients reject, and `--opt`/`--extended-insert` assume a modern target. For an old target use `--skip-opt` and import with a current `mariadb` client. `--compatible=` only adjusts SQL mode — it does **not** convert data types |
+
+## Flags worth knowing (dev workflow)
+
+| Flag | Short | Default | Effect |
+|---|---|---|---|
+| `--single-transaction` | | off | Consistent InnoDB snapshot, no writer blocking |
+| `--no-data` / `--no-create-info` | `-d` / `-t` | off | Schema only / data only |
+| `--routines` / `--events` | `-R` / `-E` | **off** | Include stored routines / events |
+| `--triggers` | | **on** | Include triggers (`--skip-triggers` to omit) |
+| `--extended-insert` | `-e` | **on** | Multi-row INSERTs (`--skip-extended-insert` for diffable) |
+| `--complete-insert` | `-c` | off | Column names in every INSERT |
+| `--replace` / `--insert-ignore` | | off | `REPLACE INTO` / `INSERT IGNORE` for re-seeding |
+| `--where=` | `-w` | | Row filter, e.g. `-w "id > 1000"` |
+| `--databases` / `--all-databases` | `-B` / `-A` | off | Emit `CREATE DATABASE`/`USE` / dump everything |
+| `--hex-blob` | | off | Binary columns as `0x…` |
+| `--no-tablespaces` | `-y` | off | Skip tablespace clauses (portable restores) |
+| `--compact` | | off | Strip boilerplate (good with diffable dumps) |
+| `--opt` | | **on** | Bundle (`--add-drop-table --extended-insert --lock-tables --quick …`); `--skip-opt` for old targets |
+
+```bash
+# Schema only:
+mariadb-dump --no-data appdb > schema.sql
+
+# Consistent live-DB dump including routines and events:
+mariadb-dump --single-transaction --routines --events appdb > dump.sql
+
+# Diffable fixture (one INSERT per row, column names, no boilerplate):
+mariadb-dump --skip-extended-insert --complete-insert --compact appdb > fixture.sql
+
+# Filtered, binary-safe seed of one table:
+mariadb-dump --single-transaction --hex-blob -w "created_at > '2025-01-01'" appdb orders > seed.sql
+
+# Restore (pipe into the mariadb client):
+mariadb appdb < dump.sql
+```
+
+Newer-than-baseline extras, mention only if the target version supports them: `--as-of=` for system-versioned point-in-time *(since 10.7)*, `--order-by-size` *(since 10.9)*, and `--parallel`/`--dir` for parallel tab-format dumps *(since 11.4/11.5)*.
+
+## See Also
+
+- **`mariadb-import`** — the round-trip partner: `mariadb-dump --tab`/`--dir` produces the files `mariadb-import` loads back
+- **`mariadb-load-data`** — the `LOAD DATA INFILE` statement underlying tab-format restores
+- **`mariadb-select`** — `SELECT … INTO OUTFILE`, the per-query text-export analog of `--tab`
+- **`mariadb-replace`** — what `--replace` emits (delete-then-insert semantics and their caveats)
+- Canonical reference on `mariadb.com/docs`, consult only for edge cases not covered here: <https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump>

--- a/agent-skills/granular/tools/mariadb-import/SKILL.md
+++ b/agent-skills/granular/tools/mariadb-import/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: mariadb-import
+description: "MariaDB-specific behavior of the mariadb-import client — a command-line wrapper around LOAD DATA INFILE for bulk-loading text files. Covers the table-name-from-filename rule, TAB (not CSV) defaults, the --local vs server-side fork, --replace/--ignore, --columns vs --ignore-lines, --parallel and its --lock-tables interaction, and the locale-autodetected charset. Use when invoking or reviewing mariadb-import commands, or scripting bulk CSV/TSV imports into MariaDB."
+---
+
+# mariadb-import in MariaDB
+
+*Last updated: 2026-06-24*
+
+`mariadb-import` is the command-line front end for `LOAD DATA INFILE`: it bulk-loads text files into tables. It does **not** change `LOAD DATA`'s rules — for the loading *semantics* (the `LOCAL` security model, duplicate/strict-mode behavior, escaping), see `mariadb-load-data`. This skill covers the tool's own quirks. The binary is `mariadb-import` (`mysqlimport` is a compatibility symlink).
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Passes the target table as an argument (`mariadb-import db mytable file.csv`) | There is **no table argument**. The table name is the data file's **base name**, minus directory and extension: `users.csv` → table `users`; `/data/orders.tsv` → table `orders`. To load into table `t`, name the file `t.<ext>`. The first non-option argument is the **database** |
+| Expects a `.csv` file to be parsed as comma-separated | `mariadb-import` uses the `LOAD DATA` defaults — **TAB-separated fields, newline-terminated lines** — regardless of extension. For real CSV: `--fields-terminated-by=, --fields-optionally-enclosed-by='"'` |
+| Assumes the client reads the file | Without `--local`, the **server** reads the file (server-side path; needs `FILE` privilege and `secure_file_priv` compliance). Use `--local`/`-L` to have the **client** read it (`LOAD DATA LOCAL INFILE`) — subject to the same `local_infile` enablement caveats. See `mariadb-load-data` |
+| Combines `--replace` and `--ignore` to "handle dupes safely" | They are **mutually exclusive** — the tool errors and exits. Pick `-r`/`--replace` (replace the row) or `-i`/`--ignore` (keep the existing row) |
+| Uses `--columns` to skip a header row, or `--ignore-lines` to map columns | They're different jobs: `--ignore-lines=N` skips N header lines; `--columns=c1,c2,…` names the target columns. A CSV with a header usually needs **both** |
+| Adds `--parallel`/`--use-threads` together with `--lock-tables` | `--lock-tables`/`-l` **disables** parallelism — the threaded path runs only when locking is off. Don't expect concurrent loads while holding write locks |
+| Wonders why a `UNIQUE` constraint didn't fire mid-import | For speed, `mariadb-import` wraps each load in `DISABLE KEYS`/`ENABLE KEYS` and sets session `unique_checks=0` / `check_constraint_checks=0`. Constraints are validated as keys are re-enabled, not row-by-row |
+| Assumes the connection charset defaults to `latin1` | The default character set is **auto-detected from the client locale**, not a fixed `latin1`. Pass `--default-character-set=utf8mb4` to be explicit |
+
+## Flags worth knowing
+
+Invocation: `mariadb-import [options] database file1 [file2 …]` — one `LOAD DATA INFILE` per file.
+
+| Flag | Effect |
+|---|---|
+| `-L`, `--local` | Client reads the file (`LOAD DATA LOCAL INFILE`) |
+| `-r`, `--replace` / `-i`, `--ignore` | Duplicate handling (mutually exclusive) |
+| `-c`, `--columns=list` | Target column list |
+| `--ignore-lines=N` | Skip the first N lines (header) |
+| `-d`, `--delete` | `DELETE FROM table` first (empty before load) |
+| `--fields-terminated-by` / `--fields-optionally-enclosed-by` / `--fields-escaped-by` / `--lines-terminated-by` | Map 1:1 to the `LOAD DATA` clauses |
+| `-l`, `--lock-tables` | Write-lock the tables (disables `--parallel`) |
+| `--low-priority`, `-k`/`--ignore-foreign-keys`, `-f`/`--force` | Priority / `foreign_key_checks=0` / continue past errors |
+| `-j`, `--parallel=N` *(since 11.4; synonym `--use-threads`)* | Up to N concurrent file loads |
+| `--innodb-optimize-keys` *(since 11.8, on by default)* | Build InnoDB secondary indexes after load |
+| `--dir` + `--database`/`--table`/`--ignore-database`/`--ignore-table` *(since 11.6)* | Restore a `mariadb-dump --dir` directory tree |
+
+```bash
+# Local CSV with a header row, comma-delimited, quoted fields → table `users` in db `mydb`:
+mariadb-import --local \
+  --fields-terminated-by=, --fields-optionally-enclosed-by='"' \
+  --ignore-lines=1 \
+  --user=admin --password mydb ./users.csv
+
+# Replace-on-duplicate, parallel load of several files:
+mariadb-import --local --replace --parallel=4 --user=admin --password mydb t1.tsv t2.tsv
+```
+
+## See Also
+
+- **`mariadb-load-data`** — the underlying `LOAD DATA [LOCAL] INFILE` statement: the `LOCAL`/`local_infile`/`secure_file_priv` security model, duplicate and strict-mode behavior, escaping — all of which `mariadb-import` inherits
+- **`mariadb-dump`** — the round-trip companion: `mariadb-dump --tab` / `--dir` produces the files that `mariadb-import` (and `mariadb-import --dir`) load back
+- Canonical reference on `mariadb.com/docs`, consult only for edge cases not covered here: <https://mariadb.com/docs/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-import>


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track. **Third Tier 1 batch**: data import and seeding (the ticket flags this as its own gap). Adds the `LOAD DATA` statement skill and introduces a new **`granular/tools/`** category for client-utility skills.

## What's in this PR

- `granular/statements/mariadb-load-data` — `LOAD DATA [LOCAL] INFILE` (+ `LOAD XML`)
- `granular/tools/mariadb-dump` — the dump client, dev-workflow focused
- `granular/tools/mariadb-import` — the bulk-load client
- **New `granular-tools` layer** in `.skills-manifest.json` + a README layer-table row. Client utilities aren't SQL statements or function categories, so they get their own granular kind (agreed approach).

Each follows the pilot structure: triage `description`, **11.8 LTS** default-context note, **"What LLMs Often Miss"** table, feature sections, cross-linked **See Also** with public `mariadb.com/docs` URLs. No MySQL product naming (the `mysqldump`/`mysqlimport` binary aliases are noted factually). 5.6–7 KB each.

## How these were produced

Three parallel research agents **source-verified** claims against `mariadb-server` (`sql/sql_load.cc` + the LOAD grammar; the `client/mysqldump.cc` and `client/mysqlimport.cc` option tables) and the canonical docs pages. Verified traps of note:

- **LOAD DATA:** `local_infile` server default is **ON** (so the usual `LOCAL` blocker is the client/connector); `LOCAL` **silently downgrades duplicate handling to `IGNORE`** and **disables strict-mode aborts**; field/line defaults are **tab/newline, not CSV**.
- **mariadb-dump:** `--single-transaction` for live InnoDB (InnoDB-only consistency; DDL during the dump breaks it); `--routines`/`--events` **off by default**; restore by piping into the `mariadb` client; **`--source-data`/`--dump-replica` don't exist** (use `--master-data`/`--dump-slave`).
- **mariadb-import:** the **table name comes from the file's basename**; tab (not CSV) defaults; the default charset is **locale-autodetected**, not `latin1`.

(Research also surfaced a minor docs bug — `load-data-infile.md` cites error 1064 for a duplicate key; it's 1062. The skill states correct behavior; can file a docs-fix ticket if you want.)

## Status: `draft` — needs human verification

Marked `"status": "draft"` in the manifest, pending the human verification gate per `dev-docs/agent-skills-maintenance.md` before promotion to `pilot`.

## Notes

- Not rendered in GitBook (no `SUMMARY.md` entry), like the rest of `agent-skills/`.
- Independent of the other open DOCS-6206 PRs; the manifest additions are on distinct lines (clean 3-way merge).
- codespell + link-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)