### PR TITLE
DOCS-6206 Add Tier 2 function-category skills (string/date-time/numeric/aggregate)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -26,7 +26,11 @@
       "path": "granular/functions",
       "author": "docs-team+extractor",
       "skills": [
-        { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" }
+        { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-string-functions", "path": "granular/functions/mariadb-string-functions/SKILL.md", "status": "draft" },
+        { "name": "mariadb-date-time-functions", "path": "granular/functions/mariadb-date-time-functions/SKILL.md", "status": "draft" },
+        { "name": "mariadb-numeric-functions", "path": "granular/functions/mariadb-numeric-functions/SKILL.md", "status": "draft" },
+        { "name": "mariadb-aggregate-functions", "path": "granular/functions/mariadb-aggregate-functions/SKILL.md", "status": "draft" }
       ]
     },
     "granular-tools": {

--- a/agent-skills/extractor/extract_function_category.py
+++ b/agent-skills/extractor/extract_function_category.py
@@ -54,10 +54,14 @@ DESC_RE = re.compile(
 # (e.g. `JSON\_EXTRACT`).
 TITLE_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
 
-# First fenced SQL code block under the Syntax heading.
-# Tolerates `## Syntax` and `### Syntax` (some pages are inconsistent).
+# First fenced code block under the Syntax heading.
+# Tolerates `## Syntax` and `### Syntax` (some pages are inconsistent); any (or
+# no) fence language tag — categories vary: `sql` (json-functions), `bnf`
+# (string/date/numeric/aggregate), or a bare ``` fence; and optional GitBook
+# `{% tabs %}`/`{% tab %}` markup between the heading and the fence (version-
+# tabbed syntax, e.g. CRC32) — the first fence is the "Current" form.
 SYNTAX_BLOCK_RE = re.compile(
-    r"^#{2,3}\s+Syntax\s*\n+```sql\s*\n(.*?)\n```",
+    r"^#{2,3}\s+Syntax\s*\n+(?:\{%[^\n]*%\}\s*\n+)*```[A-Za-z0-9]*\s*\n(.*?)\n```",
     re.DOTALL | re.MULTILINE,
 )
 
@@ -69,9 +73,12 @@ DESCRIPTION_BODY_RE = re.compile(
 )
 
 # Alias-only stub: pages like JSON_PRETTY whose body is just
-# "FOO is an alias for [BAR](bar.md)." with no Syntax section.
+# "FOO is an alias for [BAR](bar.md)." with no Syntax section. Also matches
+# "is a synonym for" (e.g. SUBSTR -> SUBSTRING). The captured target is
+# validated as a function name (uppercase) by the caller, so prose like
+# "synonym for the Oracle mode version of ..." is correctly rejected.
 ALIAS_RE = re.compile(
-    r"`?\w+`?\s+is\s+an\s+alias\s+for\s+\[?`?(\w+)`?\]?",
+    r"is\s+(?:an\s+alias|a\s+synonym)\s+for\s+\[?`?(\w+)`?\]?",
     re.IGNORECASE,
 )
 
@@ -144,6 +151,13 @@ def extract_function(path: Path) -> dict:
         raise ExtractionError(f"no `# Title` heading in {path.name}")
     name = unescape_title(title_match.group(1))
 
+    # Some function pages disambiguate the title with a " Function" suffix
+    # because the name collides with a type/statement/keyword (e.g.
+    # "CHAR Function", "INSERT Function", "REPLACE Function", "DATE FUNCTION").
+    # Strip it so the real function name is recovered. Operator/editorial
+    # suffixes ("Operator", "Units", …) are left alone and still rejected below.
+    name = re.sub(r"\s+Function$", "", name, flags=re.IGNORECASE).strip()
+
     # Editorial pages (e.g. "Differences between X and Y") don't look like
     # function names. Function names are uppercase with underscores/digits.
     if not re.match(r"^[A-Z][A-Z0-9_]*$", name):
@@ -162,7 +176,10 @@ def extract_function(path: Path) -> dict:
     syntax_match = SYNTAX_BLOCK_RE.search(text)
     if not syntax_match:
         alias = ALIAS_RE.search(body)
-        if alias:
+        # Only treat as an alias if the target reads like a function name
+        # (uppercase). Rejects prose like "synonym for the Oracle mode ...".
+        if alias and re.match(r"^[A-Z][A-Z0-9_]*$", alias.group(1).upper()) \
+                and alias.group(1).isupper():
             return {
                 "path": path,
                 "name": name,

--- a/agent-skills/granular/functions/mariadb-aggregate-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-aggregate-functions/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: mariadb-aggregate-functions
+description: "MariaDB aggregate functions — calculations across a set of rows (typically with GROUP BY or as window functions via OVER()). Covers counting (COUNT, COUNT(DISTINCT)), totals/averages (SUM, AVG), extrema (MIN, MAX), string aggregation (GROUP_CONCAT with DISTINCT/ORDER BY/SEPARATOR/LIMIT), bitwise aggregation (BIT_AND, BIT_OR, BIT_XOR), and the statistical family (STD/STDDEV/STDDEV_POP, STDDEV_SAMP, VARIANCE/VAR_POP, VAR_SAMP). Use when summarizing or rolling up rows in MariaDB. Note aggregates skip NULLs, GROUP_CONCAT silently truncates at group_concat_max_len, and ONLY_FULL_GROUP_BY is not in the default sql_mode."
+---
+
+# MariaDB Aggregate Functions
+
+*Last updated: 2026-06-24*
+
+Catalog of every built-in aggregate function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at <https://mariadb.com/docs/server/reference/sql-functions/aggregate-functions>. For `GROUP BY`, `HAVING`, `WITH ROLLUP`, and window-function `OVER()` mechanics, see `mariadb-select`.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `COUNT(col)` counts every row, the same as `COUNT(*)` | `COUNT(*)` counts **all rows** (including `NULL`s); `COUNT(expr)` counts only **non-NULL** `expr`; `COUNT(DISTINCT expr)` counts distinct non-NULL values. All three can differ on the same column |
+| `SUM`/`AVG`/`MIN`/`MAX` factor `NULL` rows into the result | Every aggregate except `COUNT(*)` **skips `NULL`** rows. `AVG(col)` is sum-of-non-null ÷ count-of-non-null — `NULL`s change the denominator, not just the numerator |
+| `SUM`/`AVG` over an empty set returns `0` | On no matching rows, `SUM`, `AVG`, `MIN`, `MAX`, `GROUP_CONCAT`, and the `STDDEV`/`VAR` family return **`NULL`**; only `COUNT` returns `0` |
+| `GROUP_CONCAT(...)` returns the full concatenation | Output is silently capped at **`group_concat_max_len` (default 1 MB)** and truncated. A truncation **warning** is raised (not an error) — check `SHOW WARNINGS`, or raise the variable |
+| `GROUP_CONCAT` is plain concatenation with no ordering or dedup | It takes `[DISTINCT]`, `ORDER BY`, `SEPARATOR str` (default comma; `SEPARATOR ''` for none), and `LIMIT`, all inside the call: `GROUP_CONCAT(DISTINCT x ORDER BY y SEPARATOR '; ' LIMIT 10)` |
+| Selecting non-grouped columns will be rejected (ONLY_FULL_GROUP_BY) | MariaDB's **default `sql_mode` does not include `ONLY_FULL_GROUP_BY`**, so the query runs and returns an **arbitrary** row's value per group — a silent-bug source. Add the column to `GROUP BY`, or enable `ONLY_FULL_GROUP_BY` to make it an error |
+| `STDDEV(x)` / `STD(x)` is the sample standard deviation | `STD`, `STDDEV`, and `STDDEV_POP` all return the **population** standard deviation (÷N). For the sample value (÷N−1) use `STDDEV_SAMP`. Likewise `VARIANCE`/`VAR_POP` are population; `VAR_SAMP` is sample |
+| Any aggregate works as a window function with `OVER()` | Most do (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `BIT_*`, the stats family). But `SUM`/`AVG` **with `DISTINCT`** cannot be window functions, and `JSON_ARRAYAGG`/`JSON_OBJECTAGG` cannot either |
+| `MIN(enum_col)` / `MAX(enum_col)` orders by the declared `ENUM` order | `MIN`/`MAX` compare `ENUM`/`SET` by **string value**, not declared position — the result can differ from `ORDER BY enum_col LIMIT 1` |
+| `BIT_AND`/`BIT_OR`/`BIT_XOR` work at the column's native width | They always compute at **64-bit** precision and ignore `NULL`s. On an all-`NULL`/empty set they return the identity (`BIT_AND` → all bits set, `BIT_OR`/`BIT_XOR` → 0) |
+| Aggregating JSON needs a custom function | Use `JSON_ARRAYAGG` / `JSON_OBJECTAGG` — but they're catalogued under **`mariadb-json-functions`** (they live in the JSON tree), and their output is also bounded by `group_concat_max_len` |
+
+For `COUNT(DISTINCT expr [, expr...])` specifically, note it counts distinct **non-NULL** combinations across the listed expressions.
+
+## Functions
+
+Auto-generated from the canonical `server/reference/sql-functions/aggregate-functions/` pages by `agent-skills/extractor/extract_function_category.py`; regenerate when the doc tree changes. Do not hand-edit between the markers. (The JSON aggregates `JSON_ARRAYAGG`/`JSON_OBJECTAGG` live in the JSON tree — see `mariadb-json-functions`.)
+
+<!-- BEGIN GENERATED -->
+<!-- Extracted from server/reference/sql-functions/aggregate-functions -->
+<!-- 16 functions, 1 pages skipped on extraction failure -->
+
+### AVG
+`AVG([DISTINCT] expr)`  
+Returns the average value of expr.
+
+### BIT_AND
+`BIT_AND(expr) [over_clause]`  
+Returns the bitwise AND of all bits in _expr_.
+
+### BIT_OR
+`BIT_OR(expr) [over_clause]`  
+Returns the bitwise OR of all bits in `expr`.
+
+### BIT_XOR
+`BIT_XOR(expr) [over_clause]`  
+Returns the bitwise XOR of all bits in `expr`.
+
+### COUNT
+`COUNT(expr)`  
+Returns a count of the number of non-NULL values of expr in the rows retrieved by a SELECT statement.
+
+### GROUP_CONCAT
+`GROUP_CONCAT(expr)`  
+This function returns a string result with the concatenated non-NULL values from a group.
+
+### MAX
+`MAX([DISTINCT] expr)`  
+Returns the largest, or maximum, value of _`expr`_.
+
+### MIN
+`MIN([DISTINCT] expr)`  
+Returns the minimum value of _`expr`_.
+
+### STD
+`STD(expr)`  
+Returns the population standard deviation of _`expr`_.
+
+### STDDEV
+`STDDEV(expr)`  
+Returns the population standard deviation of _`expr`_.
+
+### STDDEV_POP
+`STDDEV_POP(expr)`  
+Returns the population standard deviation of _`expr`_ (the square root of VAR_POP()).
+
+### STDDEV_SAMP
+`STDDEV_SAMP(expr)`  
+Returns the sample standard deviation of `expr` (the square root of VAR_SAMP()).
+
+### SUM
+`SUM([DISTINCT] expr)`  
+Returns the sum of _`expr`_.
+
+### VARIANCE
+`VARIANCE(expr)`  
+Returns the population standard variance of `expr`.
+
+### VAR_POP
+`VAR_POP(expr)`  
+Returns the population standard variance of `expr`.
+
+### VAR_SAMP
+`VAR_SAMP(expr)`  
+Returns the sample variance of _`expr`_.
+<!-- END GENERATED -->
+
+## See Also
+
+- **`mariadb-select`** — `GROUP BY`, `HAVING`, `WITH ROLLUP`, and window-function `OVER()` mechanics; the `ONLY_FULL_GROUP_BY` interaction
+- **`mariadb-json-functions`** — `JSON_ARRAYAGG` / `JSON_OBJECTAGG`
+- **`mariadb-string-functions`** — non-aggregate string building (`CONCAT`, `CONCAT_WS`)
+- Canonical reference on `mariadb.com/docs`: <https://mariadb.com/docs/server/reference/sql-functions/aggregate-functions>

--- a/agent-skills/granular/functions/mariadb-date-time-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-date-time-functions/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: mariadb-date-time-functions
+description: "MariaDB date and time functions — current time (NOW, CURRENT_TIMESTAMP, SYSDATE, CURDATE, CURTIME, UTC_TIMESTAMP/UTC_DATE/UTC_TIME), arithmetic (DATE_ADD, DATE_SUB, ADDDATE, SUBDATE, INTERVAL units), differences (TIMESTAMPDIFF, TIMESTAMPADD, DATEDIFF, TIMEDIFF), extraction (EXTRACT, YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/MICROSECOND, QUARTER, WEEK, DAYOFWEEK, WEEKDAY, LAST_DAY), parsing/formatting (STR_TO_DATE, DATE_FORMAT, GET_FORMAT), Unix time (UNIX_TIMESTAMP, FROM_UNIXTIME), time-zone conversion (CONVERT_TZ), construction (MAKEDATE, MAKETIME, SEC_TO_TIME), and Oracle-compat helpers (ADD_MONTHS, MONTHS_BETWEEN, TO_DATE). Use when computing, parsing, formatting, or converting dates, times, and timestamps in MariaDB."
+---
+
+# MariaDB Date and Time Functions
+
+*Last updated: 2026-06-24*
+
+Catalog of every built-in date/time function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at <https://mariadb.com/docs/server/reference/sql-functions/date-time-functions>.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `NOW()` and `SYSDATE()` are interchangeable | `NOW()` / `CURRENT_TIMESTAMP` are **constant for the whole statement** (statement-start time); `SYSDATE()` returns the **actual time when it executes** (two calls in one statement can differ), is non-deterministic, unsafe for statement-based replication, and prevents index use. Prefer `NOW()` |
+| `NOW()` returns sub-second precision by default | Default fractional precision is **0** — sub-seconds are truncated. Use `NOW(6)` with a `DATETIME(6)`/`TIME(6)` column. Narrowing precision **truncates, not rounds** |
+| `NOW()` / `CURDATE()` return UTC | They return the **session time zone** value (the `time_zone` variable, default `SYSTEM`). For UTC use `UTC_TIMESTAMP()` / `UTC_DATE()` / `UTC_TIME()` |
+| `CONVERT_TZ(dt, 'UTC', 'Europe/Berlin')` works out of the box | Named zones require the time-zone tables to be **loaded** (`mariadb-tzinfo-to-sql`); with an unknown/unloaded zone `CONVERT_TZ` returns **`NULL`**. Numeric offsets like `'+00:00'` always work |
+| `UNIX_TIMESTAMP()` / `FROM_UNIXTIME()` cap at 2038 | On 64-bit builds the max is `4294967295` = **`2106-02-07`** *(since 11.5)*; beyond it they return `NULL`. For dates past that, store a `DATETIME`, not a `TIMESTAMP`. `FROM_UNIXTIME()` applies the **session** time zone |
+| `DAYOFWEEK()` and `WEEKDAY()` index the same way | They don't: `DAYOFWEEK()` is **1 = Sunday … 7 = Saturday**; `WEEKDAY()` is **0 = Monday … 6 = Sunday**. Mixing them shifts every weekday calculation |
+| `WEEK(d)` gives an unambiguous week number | `WEEK()` depends on a **mode** argument (and `default_week_format` when omitted) for whether weeks start Sunday/Monday and whether week 1 must be full. Pass the mode explicitly |
+| `DATE_ADD(d, 7)` adds 7 days | `DATE_ADD`/`DATE_SUB` need the `INTERVAL` form: `DATE_ADD(d, INTERVAL 7 DAY)` (or `d + INTERVAL 7 DAY`). Only `ADDDATE(d, 7)`/`SUBDATE(d, 7)` accept a bare-integer days argument |
+| `TIMESTAMPDIFF(start, end, MONTH)` or guessing the order | Signature is `TIMESTAMPDIFF(unit, start, end)` returning **end − start** — the **unit comes first**. `TIMESTAMPADD(unit, n, datetime)` likewise takes the unit first and a plain number (no `INTERVAL`) |
+| `STR_TO_DATE()` errors on input it can't parse | It returns **`NULL`** (with a warning) on a parse failure — guard for `NULL`. Its format specifiers (`%Y %m %d %H %i %s %f`) are shared with `DATE_FORMAT`; `%f` is microseconds |
+| `ADD_MONTHS()` / `MONTHS_BETWEEN()` / `TRUNC()` only exist in Oracle mode | They're **always available**, in any `sql_mode`. Only **`TO_DATE()`** is Oracle-mode-specific (and new *(since 12.3)*). `ADD_MONTHS` clamps to the last day of a shorter target month |
+| `DATE_FORMAT(d, '%Z')` / `'%z'` for a zone name/offset | The `%Z` (abbreviation) and `%z` (numeric offset) specifiers exist only *(since 11.3)* |
+
+## Related concept pages
+
+These aren't functions, so they aren't in the catalog below, but they underpin it:
+
+- **Date and time units** — the `INTERVAL quantity unit` reference: the unit keywords (`MICROSECOND`…`YEAR`) and composite units (`DAY_SECOND`, `YEAR_MONTH`, …) used by `DATE_ADD`/`DATE_SUB`/`EXTRACT`/`TIMESTAMPADD`/`+ INTERVAL`.
+- **Microseconds** — the fractional-seconds model: default precision 0, `DATETIME(N)`/`TIME(N)` for N up to 6, the `%f` specifier, and truncate-not-round.
+
+## Functions
+
+Auto-generated from the canonical `server/reference/sql-functions/date-time-functions/` pages by `agent-skills/extractor/extract_function_category.py`; regenerate when the doc tree changes. Do not hand-edit between the markers.
+
+<!-- BEGIN GENERATED -->
+<!-- Extracted from server/reference/sql-functions/date-time-functions -->
+<!-- 64 functions, 3 pages skipped on extraction failure -->
+
+### ADDDATE
+`ADDDATE(date,INTERVAL expr unit), ADDDATE(expr,days)`  
+When invoked with the `INTERVAL` form of the second argument, `ADDDATE()` is a synonym for DATE_ADD().
+
+### ADDTIME
+`ADDTIME(expr1,expr2)`  
+`ADDTIME()` adds _expr2_ to _expr1_ and returns the result.
+
+### ADD_MONTHS
+`ADD_MONTHS(date, months)`  
+`ADD_MONTHS` adds an integer _months_ to a given _date_ (DATE, DATETIME or TIMESTAMP), returning the resulting date. *(since 10.6.1)*
+
+### CONVERT_TZ
+`CONVERT_TZ(dt,from_tz,to_tz)`  
+`CONVERT_TZ()` converts a datetime value _dt_ from the time zone given by _from_tz_ to the time zone given by _to_tz_ and returns the resulting value.
+
+### CURDATE
+`CURDATE()`  
+`CURDATE` returns the current date as a value in `YYYY-MM-DD` or `YYYYMMDD` format, depending on whether the function is used in a string or numeric context.
+
+### CURRENT_DATE
+`CURRENT_DATE, CURRENT_DATE()`  
+`CURRENT_DATE` and `CURRENT_DATE()` are synonyms for CURDATE().
+
+### CURRENT_TIME
+`CURRENT_TIME`  
+`CURRENT_TIME` and `CURRENT_TIME()` are synonyms for CURTIME().
+
+### CURRENT_TIMESTAMP
+`CURRENT_TIMESTAMP`  
+`CURRENT_TIMESTAMP` and `CURRENT_TIMESTAMP()` are synonyms for NOW().
+
+### CURTIME
+`CURTIME([precision])`  
+Returns the current time as a value in `HH:MM:SS` or `HHMMSS.uuuuuu` format, depending on whether the function is used in a string or numeric context.
+
+### DATE
+`DATE(expr)`  
+Extracts the date part of the date or datetime expression _expr_.
+
+### DATEDIFF
+`DATEDIFF(expr1,expr2)`  
+`DATEDIFF()` returns (_expr1_ – _expr2_) expressed as a value in days from one date to the other.
+
+### DATE_ADD
+`DATE_ADD(date,INTERVAL expr unit)`  
+Performs date arithmetic.
+
+### DATE_FORMAT
+`DATE_FORMAT(date, format[, locale])`  
+Formats the date value according to the format string.
+
+### DATE_SUB
+`DATE_SUB(date,INTERVAL expr unit)`  
+Performs date arithmetic.
+
+### DAY
+`DAY(date)`  
+`DAY()` is a synonym for DAYOFMONTH().
+
+### DAYNAME
+`DAYNAME(date)`  
+Returns the name of the weekday for date.
+
+### DAYOFMONTH
+`DAYOFMONTH(date)`  
+Returns the day of the month for date, in the range `1` to `31`, or `0` for dates such as `'0000-00-00'` or `'2008-00-00'` which have a zero day part.
+
+### DAYOFWEEK
+`DAYOFWEEK(date)`  
+Returns the day of the week index for the date (1 = Sunday, 2 = Monday, ..., 7 = Saturday).
+
+### DAYOFYEAR
+`DAYOFYEAR(date)`  
+Returns the day of the year for date, in the range 1 to 366.
+
+### EXTRACT
+`EXTRACT(unit FROM date)`  
+The EXTRACT() function extracts the required unit from the date.
+
+### FORMAT_PICO_TIME
+`FORMAT_PICO_TIME(time_val)`  
+Given a time in picoseconds, returns a human-readable time value and unit indicator.
+
+### FROM_DAYS
+`FROM_DAYS(N)`  
+Given a day number N, returns a DATE value.
+
+### FROM_UNIXTIME
+`FROM_UNIXTIME(unix_timestamp)`  
+Converts the number of seconds from the epoch (1970-01-01 00:00:00 UTC) to a`TIMESTAMP` value, the opposite of what UNIX_TIMESTAMP() is doing.
+
+### GET_FORMAT
+`GET_FORMAT({DATE|DATETIME|TIME}, {'EUR'|'USA'|'JIS'|'ISO'|'INTERNAL'})`  
+Returns a format string.
+
+### HOUR
+`HOUR(time)`  
+Returns the hour for time.
+
+### LAST_DAY
+`LAST_DAY(date)`  
+Takes a date or datetime value and returns the corresponding value for the last day of the month.
+
+### LOCALTIME
+`LOCALTIME`  
+`LOCALTIME` and `LOCALTIME()` are synonyms for NOW().
+
+### LOCALTIMESTAMP
+`LOCALTIMESTAMP`  
+`LOCALTIMESTAMP` and `LOCALTIMESTAMP()` are synonyms for NOW().
+
+### MAKEDATE
+`MAKEDATE(year,dayofyear)`  
+Returns a date, given `year` and `day-of-year values`.
+
+### MAKETIME
+`MAKETIME(hour,minute,second)`  
+Returns a time value calculated from the `hour`, `minute`, and `second` arguments.
+
+### MICROSECOND
+`MICROSECOND(expr)`  
+Returns the microseconds from the time or datetime expression _expr_ as a number in the range from 0 to 999999.
+
+### MINUTE
+`MINUTE(time)`  
+Returns the minute for _time_, in the range 0 to 59.
+
+### MONTH
+`MONTH(date)`  
+Returns the month for `date` in the range 1 to 12 for January to December, or 0 for dates such as `0000-00-00` or `2008-00-00` that have a zero month part.
+
+### MONTHNAME
+`MONTHNAME(date)`  
+Returns the full name of the month for date.
+
+### NOW
+`NOW([precision])`  
+Returns the current date and time as a value in `YYYY-MM-DD HH:MM:SS` or `YYYYMMDDHHMMSS.uuuuuu` format, depending on whether the function is used in a string or numeric context.
+
+### PERIOD_ADD
+`PERIOD_ADD(P,N)`  
+Adds `N` months to period `P`.
+
+### PERIOD_DIFF
+`PERIOD_DIFF(P1,P2)`  
+Returns the number of months between periods P1 and P2.
+
+### QUARTER
+`QUARTER(date)`  
+Returns the quarter of the year for `date`, in the range 1 to 4.
+
+### SECOND
+`SECOND(time)`  
+Returns the second for a given `time` (which can include microseconds), in the range 0 to 59, or `NULL` if not given a valid time value.
+
+### SEC_TO_TIME
+`SEC_TO_TIME(seconds)`  
+Returns the seconds argument, converted to hours, minutes, and seconds, as a TIME value.
+
+### STR_TO_DATE
+`STR_TO_DATE(str,format)`  
+This is the inverse of the DATE_FORMAT() function.
+
+### SUBDATE
+`SUBDATE(date,INTERVAL expr unit), SUBDATE(expr,days)`  
+When invoked with the `INTERVAL` form of the second argument, `SUBDATE()` is a synonym for DATE_SUB().
+
+### SUBTIME
+`SUBTIME(expr1,expr2)`  
+`SUBTIME()` returns `expr1` - `expr2` expressed as a value in the same format as `expr1`.
+
+### SYSDATE
+`SYSDATE([precision])`  
+Returns the current date and time as a value in `YYYY-MM-DD HH:MM:SS` or `YYYYMMDDHHMMSS.uuuuuu` format, depending on whether the function is used in a string or numeric context.
+
+### TIME
+`TIME(expr)`  
+Extracts the time part of the time or datetime expression `expr` and returns it as a string.
+
+### TIMEDIFF
+`TIMEDIFF(expr1,expr2)`  
+TIMEDIFF() returns `expr1` - `expr2` expressed as a time value.
+
+### TIMESTAMP
+`TIMESTAMP(expr), TIMESTAMP(expr1,expr2)`  
+With a single argument, this function returns the date or datetime expression `expr` as a datetime value.
+
+### TIMESTAMPADD
+`TIMESTAMPADD(unit,interval,datetime_expr)`  
+Adds the integer expression interval to the date or datetime expression datetime_expr.
+
+### TIMESTAMPDIFF
+`TIMESTAMPDIFF(unit,datetime_expr1,datetime_expr2)`  
+Returns `datetime_expr2` - `datetime_expr1`, where `datetime_expr1` and`datetime_expr2` are date or datetime expressions.
+
+### TIME_FORMAT
+`TIME_FORMAT(time,format)`  
+This is used like the DATE_FORMAT() function, but the format string may contain format specifiers only for hours, minutes, and seconds.
+
+### TIME_TO_SEC
+`TIME_TO_SEC(time)`  
+Returns the time argument, converted to seconds.
+
+### TO_DATE
+`TO_DATE(string_expression [DEFAULT string_expression ON CONVERSION ERROR],`  
+`TO_DATE` was added for Oracle support. *(since 12.3)*
+
+### TO_DAYS
+`TO_DAYS(date)`  
+Given a date `date`, returns the number of days since the start of the current calendar (`0000-00-00`).
+
+### TO_SECONDS
+`TO_SECONDS(expr)`  
+Returns the number of seconds from year 0 till `expr`, or NULL if `expr` is not a valid date or datetime.
+
+### TRUNC
+`TRUNC(date[,fmt])`  
+Returns a DATETIME truncated according to `fmt`.
+
+### UNIX_TIMESTAMP
+`UNIX_TIMESTAMP()`  
+If called with no argument, returns a Unix timestamp (seconds since `1970-01-01 00:00:00` UTC) as an unsigned integer.
+
+### UTC_DATE
+`UTC_DATE, UTC_DATE()`  
+Returns the current UTC date as a value in `YYYY-MM-DD` or `YYYYMMDD` format, depending on whether the function is used in a string or numeric context.
+
+### UTC_TIME
+`UTC_TIME`  
+Returns the current UTC time as a value in `HH:MM:SS` or `HHMMSS.uuuuuu` format, depending on whether the function is used in a string or numeric context.
+
+### UTC_TIMESTAMP
+`UTC_TIMESTAMP`  
+Returns the current UTC date and time as a value in `YYYY-MM-DD HH:MM:SS` or `YYYYMMDDHHMMSS.uuuuuu` format, depending on whether the function is used in a string or numeric context.
+
+### WEEK
+`WEEK(date[,mode])`  
+This function returns the week number for `date`.
+
+### WEEKDAY
+`WEEKDAY(date)`  
+Returns the weekday index for `date` (`0` = Monday, `1` = Tuesday, ...
+
+### WEEKOFYEAR
+`WEEKOFYEAR(date)`  
+Returns the calendar week of the date as a number in the range from 1 sqto 53.
+
+### YEAR
+`YEAR(date)`  
+Returns the year for the given date, in the range 1000 to 9999, or 0 for the "zero" date.
+
+### YEARWEEK
+`YEARWEEK(date), YEARWEEK(date,mode)`  
+Returns year and week for a date.
+<!-- END GENERATED -->
+
+## See Also
+
+- **`mariadb-create-table`** — `DEFAULT CURRENT_TIMESTAMP` / `ON UPDATE CURRENT_TIMESTAMP` auto-timestamp columns, and choosing `DATETIME(6)` vs `TIMESTAMP` (the 2106 range cutoff)
+- **`mariadb-features`** (topical) — `sql_mode=ORACLE` (for `TO_DATE`) and temporal/system-versioning context
+- Canonical reference on `mariadb.com/docs`: <https://mariadb.com/docs/server/reference/sql-functions/date-time-functions>

--- a/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-json-functions/SKILL.md
@@ -28,7 +28,7 @@ Catalog of every built-in JSON function in MariaDB, with signature and a one-lin
 
 ## Functions
 
-The list below is **auto-generated** from `server/reference/sql-functions/special-functions/json-functions/` by `_extractors/extract_function_category.py`. Regenerate when the doc tree changes.
+The list below is **auto-generated** from `server/reference/sql-functions/special-functions/json-functions/` by `agent-skills/extractor/extract_function_category.py`. Regenerate when the doc tree changes.
 
 
 ### JSON_ARRAY

--- a/agent-skills/granular/functions/mariadb-numeric-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-numeric-functions/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: mariadb-numeric-functions
+description: "MariaDB numeric and math functions — rounding/truncation (ROUND, the TRUNCATE function vs the TRUNCATE TABLE statement, FLOOR, CEILING, SIGN, ABS), integer-vs-decimal division (the DIV operator vs /, MOD / %), powers and logs (POW/POWER, SQRT, EXP, LN, LOG, LOG2, LOG10), trigonometry (SIN, COS, TAN, ASIN, ACOS, ATAN, ATAN2, COT, PI, DEGREES, RADIANS), randomness (RAND, seeded RAND(N)), base conversion (CONV, OCT, BIN, HEX), checksums (CRC32, CRC32C), and number formatting (FORMAT). Use when writing SQL that does arithmetic, rounding, base conversion, or random sampling in MariaDB — especially where exact-vs-approximate types or division-by-zero behavior matter."
+---
+
+# MariaDB Numeric Functions
+
+*Last updated: 2026-06-24*
+
+Catalog of every built-in numeric/math function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at <https://mariadb.com/docs/server/reference/sql-functions/numeric-functions>.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `a / b` between two integers returns an integer (e.g. `7/2 = 3`) | `/` **always returns a decimal** — `7/2` is `3.5000` (four fractional digits by default, via `div_precision_increment`). Use `a DIV b` for integer (toward-zero) division |
+| `7 DIV 2` returns a float or rounds | `DIV` returns an **integer**, discarding the remainder (`3`); it's `BIGINT`-based. Get the remainder with `MOD` / `%` |
+| `x / 0` raises a division-by-zero error | By default it returns **`NULL`**. You get an error only when `ERROR_ON_DIVISION_BY_ZERO` is in `sql_mode` (it's part of the default strict mode). Same for `MOD` by zero |
+| `ROUND(2.5)` uses banker's rounding (round-half-to-even) | For **`DECIMAL`/exact** values MariaDB rounds **half away from zero**: `ROUND(2.5)=3`, `ROUND(-2.5)=-3`. For **`FLOAT`/`DOUBLE`** the platform C library decides, so results can differ between operating systems — round a `DECIMAL` if you need determinism |
+| Storing money in `FLOAT`/`DOUBLE` and rounding for display | `FLOAT`/`DOUBLE` are **approximate** (`0.1 + 0.2 != 0.3`). Use `DECIMAL(p,s)` for currency and anything needing exactness (up to 38 digits) |
+| `TRUNCATE(x, d)` and `TRUNCATE TABLE` are related | They're unrelated despite the name. `TRUNCATE(X, D)` is the **function** that chops to `D` decimal places toward zero; `TRUNCATE TABLE` is the **DDL statement** that empties a table (see `mariadb-drop-table`) |
+| `FLOOR(x)` / `CEILING(x)` always return a `BIGINT` | The return type **follows the argument**: integer/string/double args yield `BIGINT`, but a `DECIMAL` argument yields a **`DECIMAL`**. Don't assume the result fits an integer column |
+| `RAND()` is fine for security tokens or unbiased sampling | `RAND()` is **not cryptographically secure**; `RAND(N)` with a constant seed is **repeatable** (good for tests, not secrets), and `RAND()` is unsafe for statement-based replication. `ORDER BY RAND()` scans the whole table — avoid on large ones |
+| `MOD(n, 0)` errors, or `MOD` of a negative behaves like Python's `%` | `MOD` returns **`NULL`** for a zero divisor (unless `ERROR_ON_DIVISION_BY_ZERO`), and the result **takes the sign of the dividend** (`-7 MOD 3 = -1`), not the divisor. `N % M`, `N MOD M`, `MOD(N,M)` are equivalent |
+| `FORMAT(n, 2)` returns a number you can compute with | `FORMAT` returns a **string** with locale-aware thousands separators (`'1,234,567.89'`). Feeding it back into arithmetic re-parses and truncates at the first separator |
+| `CONV(n, 10, 62)` works on every version | Bases up to **62** are supported *(since 11.4)*; earlier versions cap at base 36. `CONV` returns a string at 64-bit precision |
+| `CRC32('abc')` is unary and `CRC32C` always exists | `CRC32` gained an optional rolling-checksum argument — `CRC32([par,] expr)` — and `CRC32C` (Castagnoli, as used by InnoDB/MyRocks) was added, both *(since 10.8)* |
+
+## Related operators
+
+Arithmetic lives partly as **operators**, not functions, so they aren't in the catalog below:
+
+- **`/`** — division; always returns a decimal. `div_precision_increment` (default 4) sets the fractional digits.
+- **`DIV`** — integer division (toward zero).
+- **`%` / `MOD`** — modulo; result takes the dividend's sign; `NULL` on zero divisor unless strict mode errors.
+
+`FORMAT()` (locale-aware number-to-string) and `HEX`/`BIN` are catalogued under **`mariadb-string-functions`**, not here.
+
+## Functions
+
+Auto-generated from the canonical `server/reference/sql-functions/numeric-functions/` pages by `agent-skills/extractor/extract_function_category.py`; regenerate when the doc tree changes. Do not hand-edit between the markers.
+
+<!-- BEGIN GENERATED -->
+<!-- Extracted from server/reference/sql-functions/numeric-functions -->
+<!-- 34 functions, 0 pages skipped on extraction failure -->
+
+### ABS
+`ABS(X)`  
+Returns the absolute (non-negative) value of `X`.
+
+### ACOS
+`ACOS(X)`  
+Returns the arc cosine of `X`, that is, the value whose cosine is `X`.
+
+### ASIN
+`ASIN(X)`  
+Returns the arc sine of X, that is, the value whose sine is X.
+
+### ATAN
+`ATAN(X)`  
+Returns the arc tangent of X, that is, the value whose tangent is X.
+
+### ATAN2
+`ATAN(Y,X), ATAN2(Y,X)`  
+Returns the arc tangent of the two variables X and Y.
+
+### CEIL
+`CEIL(X)`  
+`CEIL()` is a synonym for CEILING().
+
+### CEILING
+`CEILING(X)`  
+Returns the smallest integer value not less than X.
+
+### CONV
+`CONV(N,from_base,to_base)`  
+Converts numbers between different number bases.
+
+### COS
+`COS(X)`  
+Returns the cosine of X, where X is given in radians.
+
+### COT
+`COT(X)`  
+Returns the cotangent of X.
+
+### CRC32
+`CRC32([par,]expr)`  
+Computes a cyclic redundancy check (CRC) value and returns a 32-bit unsigned value.
+
+### CRC32C
+`CRC32C([par,]expr)`  
+MariaDB has always included a native unary function CRC32() that computes the CRC-32 of a string using the ISO 3309 polynomial that used by zlib and many others.
+
+### DEGREES
+`DEGREES(X)`  
+Returns the argument _`X`_, converted from radians to degrees.
+
+### DIV
+`DIV`  
+Integer division.
+
+### EXP
+`EXP(X)`  
+Returns the value of e (the base of natural logarithms) raised to the power of X.
+
+### FLOOR
+`FLOOR(X)`  
+Returns the largest integer value not greater than X.
+
+### LN
+`LN(X)`  
+Returns the natural logarithm of X; that is, the base-e logarithm of X.
+
+### LOG
+`LOG(X), LOG(B,X)`  
+If called with one parameter, this function returns the natural logarithm of X.
+
+### LOG10
+`LOG10(X)`  
+Returns the base-10 logarithm of X.
+
+### LOG2
+`LOG2(X)`  
+Returns the base-2 logarithm of X.
+
+### MOD
+`MOD(N,M), N % M, N MOD M`  
+Modulo operation.
+
+### OCT
+`OCT(N)`  
+Returns a string representation of the octal value of N, where N is a longlong (BIGINT) number.
+
+### PI
+`PI()`  
+Returns the value of π (pi).
+
+### POW
+`POW(X,Y)`  
+Returns the value of X raised to the power of Y.
+
+### POWER
+`POWER(X,Y)`  
+This is a synonym for POW(), which returns the value of X raised to the power of Y.
+
+### RADIANS
+`RADIANS(X)`  
+Returns the argument _`X`_, converted from degrees to radians.
+
+### RAND
+`RAND(), RAND(N)`  
+Returns a random DOUBLE precision floating point value v in the range 0 <= v < 1.0.
+
+### ROUND
+`ROUND(X), ROUND(X,D)`  
+Rounds the argument `X` to `D` decimal places.
+
+### SIGN
+`SIGN(X)`  
+Returns the sign of the argument as -1, 0, or 1, depending on whether X is negative, zero, or positive.
+
+### SIN
+`SIN(X)`  
+Returns the sine of X, where X is given in radians.
+
+### SQRT
+`SQRT(X)`  
+Returns the square root of X.
+
+### TAN
+`TAN(X)`  
+Returns the tangent of X, where X is given in radians.
+
+### TO_NUMBER
+`TO_NUMBER(number_or_string_subject)`  
+The function returns the `DOUBLE` data type for all signatures and input data types.
+
+### TRUNCATE
+`TRUNCATE(X,D)`  
+Returns the number X, truncated to D decimal places.
+<!-- END GENERATED -->
+
+## See Also
+
+- **`mariadb-create-table`** — choosing `DECIMAL` vs `FLOAT`/`DOUBLE` for the columns these functions operate on
+- **`mariadb-drop-table`** — the `TRUNCATE TABLE` statement (not the `TRUNCATE()` function above)
+- **`mysql-to-mariadb`** (topical) — division-by-zero `sql_mode` behavior and money-in-`DECIMAL` guidance
+- Canonical reference on `mariadb.com/docs`: <https://mariadb.com/docs/server/reference/sql-functions/numeric-functions>

--- a/agent-skills/granular/functions/mariadb-string-functions/SKILL.md
+++ b/agent-skills/granular/functions/mariadb-string-functions/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: mariadb-string-functions
+description: "MariaDB string functions — extraction (SUBSTRING/SUBSTR, LEFT, RIGHT, MID, SUBSTRING_INDEX); length in bytes (LENGTH/OCTET_LENGTH/LENGTHB) vs characters (CHAR_LENGTH/CHARACTER_LENGTH); search (LOCATE, INSTR, POSITION, FIND_IN_SET, FIELD); concatenation (CONCAT, CONCAT_WS); modification (REPLACE, INSERT, REVERSE, REPEAT, SPACE, LPAD/RPAD, TRIM/LTRIM/RTRIM); case (LOWER/UPPER); PCRE2 regular expressions (REGEXP/RLIKE, REGEXP_REPLACE, REGEXP_INSTR, REGEXP_SUBSTR); formatting (FORMAT, SFORMAT); encoding (HEX/UNHEX, TO_BASE64/FROM_BASE64, ASCII, CHAR, ORD); plus the LIKE, REGEXP, SOUNDS LIKE, and BINARY operators. Use when writing SQL that searches, slices, pads, concatenates, case-folds, or pattern-matches string data in MariaDB."
+---
+
+# MariaDB String Functions
+
+*Last updated: 2026-06-24*
+
+Catalog of every built-in string function in MariaDB, with signature and a one-line semantic summary per entry. For a function not listed here, fall back to the canonical reference at <https://mariadb.com/docs/server/reference/sql-functions/string-functions> (PCRE2 regex syntax: <https://mariadb.com/docs/server/reference/sql-functions/string-functions/regular-expressions-functions>).
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Functions with a `*(since X.Y)*` annotation are only available from that version onward; everything else is in every current LTS branch (10.6, 10.11, 11.4, 11.8).
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `LENGTH(str)` to count characters | `LENGTH()` returns **bytes**, not characters. Under the default `utf8mb4`, a 5-emoji string returns 20, not 5. Use `CHAR_LENGTH()` / `CHARACTER_LENGTH()` for a character count; `OCTET_LENGTH()` / `LENGTHB()` are the explicit byte forms |
+| `CONCAT(a, b, c)` and expecting `NULL` arguments to be skipped | `CONCAT()` returns `NULL` if **any** argument is `NULL` — one `NULL` wipes the whole result. Use `CONCAT_WS(sep, …)` (skips `NULL`s), or wrap args in `IFNULL(x, '')` |
+| `SUBSTRING(str, 0, n)` to take from the start | String positions are **1-indexed**; `pos = 0` returns an **empty string**. Use `SUBSTRING(str, 1, n)`. A negative `pos` counts from the end (`SUBSTRING(str, -4)` → last 4 chars) |
+| `LOCATE(str, substr)` / `INSTR(substr, str)` — guessing the argument order | The two take **reversed** orders: `LOCATE(substr, str)` (needle first) but `INSTR(str, substr)` (haystack first). `POSITION(substr IN str)` is a synonym for `LOCATE`. All are 1-based, `0` if not found |
+| `str REGEXP '…'` expecting POSIX ERE semantics | MariaDB's `REGEXP`/`RLIKE` and the `REGEXP_*` functions use **PCRE2** — inline flags `(?i)`/`(?m)`, lazy quantifiers `.+?`, backreferences. Treat the dialect as PCRE, not classic POSIX ERE |
+| Case-sensitivity of `LIKE`, `REGEXP`, `=` is fixed | It depends on the operand **collation**. With the default `utf8mb4_uca1400_ai_ci` they are **case-insensitive**. Force case-sensitive matching with a `_bin`/`_cs` collation (`COLLATE utf8mb4_bin`), the `BINARY` operator, or a PCRE `(?-i)` flag. (`REPLACE()` is always case-sensitive regardless of collation) |
+| `REGEXP_REPLACE(…)` with `$1`-style replacement backreferences | Replacement backreferences use `\N` (`\\1`…`\\9` in a SQL string literal), not `$1`. Inline flags like `(?i)` go inside the **pattern** |
+| `TRIM(str)` to strip an arbitrary character | Bare `TRIM` removes **spaces** from both ends. Use `TRIM(LEADING | TRAILING | BOTH remstr FROM str)` for other characters or one side (`remstr` is a full string, not a char set). `LTRIM`/`RTRIM` are space-only |
+| `a || b` for string concatenation | By default `||` is **logical OR**, not concatenation — use `CONCAT()`. `||` concatenates only when `sql_mode` includes `PIPES_AS_CONCAT` (or `ORACLE`) |
+| `LPAD(str, len)` / `RPAD(str, len)` only lengthens | If `str` is **longer** than `len`, the result is **truncated** to `len`. `len` counts characters; the pad string defaults to a single space |
+| `'a' = 'a '` is false (trailing spaces significant) | `CHAR`/`VARCHAR` comparison **ignores trailing spaces** by default, so `'a' = 'a '` is true. Use the `BINARY` operator (or a `NO PAD` collation) to make trailing spaces and case significant |
+| `printf`-style `%s` formatting in SQL | Use `SFORMAT(fmt, …)` for Python/fmtlib-style `{}` placeholders *(since 10.7)*. Note it has no native temporal/decimal handling (`TIME`→string, `DECIMAL`→real) |
+
+## Related operators
+
+Pattern-matching and comparison are **operators**, not functions, so they aren't in the catalog below:
+
+- **`LIKE` / `NOT LIKE`** — wildcard match (`%`, `_`) with an optional `ESCAPE` clause; collation-dependent case-sensitivity; index-usable when the pattern doesn't start with `%`/`_`.
+- **`REGEXP` / `RLIKE` / `NOT REGEXP`** — PCRE2 pattern match returning 1/0/`NULL`; session `default_regex_flags` sets default modifiers.
+- **`BINARY`** — forces a byte-wise (case- and trailing-space-sensitive) comparison; the canonical way to make a comparison case-sensitive.
+- **`SOUNDS LIKE`** — shorthand for `SOUNDEX(a) = SOUNDEX(b)`.
+
+To join multiple rows into one string, see `GROUP_CONCAT` in **`mariadb-aggregate-functions`**.
+
+## Functions
+
+Auto-generated from the canonical `server/reference/sql-functions/string-functions/` pages by `agent-skills/extractor/extract_function_category.py`; regenerate when the doc tree changes. Do not hand-edit between the markers.
+
+<!-- BEGIN GENERATED -->
+<!-- Extracted from server/reference/sql-functions/string-functions -->
+<!-- 58 functions, 8 pages skipped on extraction failure -->
+
+### ASCII
+`ASCII(str)`  
+Returns the numeric ASCII value of the leftmost character of the string argument.
+
+### BIN
+`BIN(N)`  
+Returns a string representation of the binary value of the given longlong (that is, BIGINT) number.
+
+### BIT_LENGTH
+`BIT_LENGTH(str)`  
+Returns the length of the given string argument in bits.
+
+### CAST
+`CAST(expr AS type)`  
+The `CAST()` function takes a value of one data type and produces a value of another data type, similar to the CONVERT() function.
+
+### CHAR
+`CHAR(N,... [USING charset_name])`  
+`CHAR()` interprets each argument as an INT and returns a string consisting of the characters given by the code values of those integers.
+
+### CHARACTER_LENGTH
+`CHARACTER_LENGTH(str)`  
+`CHARACTER_LENGTH()` is a synonym for CHAR_LENGTH().
+
+### CHAR_LENGTH
+`CHAR_LENGTH(str)`  
+Returns the length of the given string argument, measured in characters.
+
+### CHR
+`CHR(N)`  
+`CHR()` interprets each argument N as an integer and returns a VARCHAR(1) string consisting of the character given by the code values of the integer.
+
+### CONCAT
+`CONCAT(str1,str2,...)`  
+Returns the string that results from concatenating the arguments.
+
+### CONCAT_WS
+`CONCAT_WS(separator,str1,str2,...)`  
+`CONCAT_WS()` stands for Concatenate With Separator and is a special form of CONCAT().
+
+### CONVERT
+`CONVERT(expr,type), CONVERT(expr USING transcoding_name)`  
+The `CONVERT()` and CAST() functions take a value of one type and produce a value of another type.
+
+### ELT
+`ELT(N, str1[, str2, str3,...])`  
+Takes a numeric argument and a series of string arguments.
+
+### EXPORT_SET
+`EXPORT_SET(bits, on, off[, separator[, number_of_bits]])`  
+Takes a minimum of three arguments.
+
+### EXTRACTVALUE
+`EXTRACTVALUE(xml_frag, xpath_expr)`  
+The `EXTRACTVALUE()` function takes two string arguments: a fragment of XML markup and an XPath expression, (also known as a locator).
+
+### FIELD
+`FIELD(pattern, str1[,str2,...])`  
+Returns the index position of the string or number matching the given pattern.
+
+### FIND_IN_SET
+`FIND_IN_SET(pattern, strlist)`  
+Returns the index position where the given pattern occurs in a string list.
+
+### FORMAT
+`FORMAT(num, decimal_position[, locale])`  
+Formats the given number for display as a string, adding separators to appropriate position and rounding the results to the given decimal position.
+
+### FROM_BASE64
+`FROM_BASE64(str)`  
+Decodes the given base-64 encode string, returning the result as a binary string.
+
+### HEX
+`HEX(N_or_S)`  
+If `N_or_S` is a number, returns a string representation of the hexadecimal value of `N`, where `N` is a `longlong` (BIGINT) number.
+
+### INSERT
+`INSERT(str,pos,len,newstr)`  
+Returns the string `str`, with the substring beginning at position `pos` and `len` characters long replaced by the string `newstr`.
+
+### INSTR
+`INSTR(str,substr)`  
+Returns the position of the first occurrence of substring _substr_ in string _str_.
+
+### LCASE
+`LCASE(str)`  
+`LCASE()` is a synonym for LOWER().
+
+### LEFT
+`LEFT(str,len)`  
+Returns the leftmost `len` characters from the string `str`, or `NULL` if any argument is `NULL`.
+
+### LENGTH
+`LENGTH(str)`  
+Returns the length of the string `str`.
+
+### LENGTHB
+`LENGTHB(str)`  
+`LENGTHB()` returns the length of the given string, in bytes.
+
+### LIKE
+`expr LIKE pat [ESCAPE 'escape_char']`  
+Tests whether _expr_ matches the pattern _pat_.
+
+### LOAD_FILE
+`LOAD_FILE(file_name)`  
+Reads the file and returns the file contents as a string.
+
+### LOCATE
+`LOCATE(substr,str), LOCATE(substr,str,pos)`  
+The first syntax returns the position of the first occurrence of substring `substr` in string `str`.
+
+### LOWER
+`LOWER(str)`  
+Returns the string `str` with all characters changed to lowercase according to the current character set mapping.
+
+### LPAD
+`LPAD(str, len [,padstr])`  
+Returns the string `str`, left-padded with the string `padstr` to a length of `len` characters.
+
+### LTRIM
+`LTRIM(str)`  
+Returns the string `str` with leading space characters removed.
+
+### MAKE_SET
+`MAKE_SET(bits,str1,str2,...)`  
+Returns a set value (a string containing substrings separated by "," characters) consisting of the strings that have the corresponding bit in bits set.
+
+### MID
+`MID(str,pos,len)`  
+MID(str,pos,len) is a synonym for SUBSTRING(str,pos,len)!
+
+### NATURAL_SORT_KEY
+`NATURAL_SORT_KEY(str)`  
+The `NATURAL_SORT_KEY` function is used for sorting that is closer to natural sorting. *(since 10.7)*
+
+### OCTET_LENGTH
+`OCTET_LENGTH(str)`  
+`OCTET_LENGTH()` returns the length of the given string, in octets (bytes).
+
+### ORD
+`ORD(str)`  
+If the leftmost character of the string `str` is a multi-byte character, returns the code for that character, calculated from the numeric values of its constituent bytes using this formula:
+
+### POSITION
+`POSITION(substr IN str)`  
+`POSITION(substr IN str)` is a synonym for LOCATE(substr,str).
+
+### QUOTE
+`QUOTE(str)`  
+Quotes a string to produce a result that can be used as a properly escaped data value in an SQL statement.
+
+### REPEAT
+`REPEAT(str,count)`  
+Returns a string consisting of the string `str` repeated `count` times.
+
+### REPLACE
+`REPLACE(str,from_str,to_str)`  
+Returns the string `str` with all occurrences of the string `from_str` replaced by the string `to_str`.
+
+### REVERSE
+`REVERSE(str)`  
+Returns the string `str` with the order of the characters reversed.
+
+### RIGHT
+`RIGHT(str,len)`  
+Returns the rightmost _`len`_ characters from the string _`str`_, or `NULL` if any argument is `NULL`.
+
+### RPAD
+`RPAD(str, len [, padstr])`  
+Returns the string `str`, right-padded with the string `padstr` to a length of `len` characters.
+
+### RTRIM
+`RTRIM(str)`  
+Returns the string `str` with trailing space characters removed.
+
+### SOUNDEX
+`SOUNDEX(str)`  
+Returns a soundex string from _`str`_.
+
+### SPACE
+`SPACE(N)`  
+Returns a string consisting of _`N`_ space characters.
+
+### STRCMP
+`STRCMP(expr1,expr2)`  
+`STRCMP()` returns `0` if the strings are the same, `-1` if the first argument is smaller than the second according to the current sort order, and `1` if the strings are otherwise not the same.
+
+### SUBSTR
+Alias for `SUBSTRING`.
+
+### SUBSTRING
+`SUBSTRING(str,pos),`  
+The forms without a _`len`_ argument return a substring from string _`str`_ starting at position _`pos`_.
+
+### SUBSTRING_INDEX
+`SUBSTRING_INDEX(str,delim,count)`  
+Returns the substring from string _`str`_ before count occurrences of the delimiter _`delim`_.
+
+### TO_BASE64
+`TO_BASE64(str)`  
+Converts the string argument `str` to its base-64 encoded form, returning the result as a character string in the connection character set and collation.
+
+### TO_CHAR
+`TO_CHAR(expr[, fmt])`  
+{% tabs %} {% tab title="Current" %} The `TO_CHAR` function converts an _expr_ of type date, datetime, time or timestamp to a string.
+
+### TRIM
+`TRIM_ORACLE([{BOTH | LEADING | TRAILING} [remstr] FROM] str), TRIM([remstr FROM] str)`  
+Returns the string `str` with all `remstr` prefixes or suffixes removed.
+
+### UCASE
+`UCASE(str)`  
+`UCASE()` is a synonym for UPPER().
+
+### UNHEX
+`UNHEX(str)`  
+Performs the inverse operation of HEX(str).
+
+### UPDATEXML
+`UpdateXML(xml_target, xpath_expr, new_xml)`  
+This function replaces a single portion of a given fragment of XML markup`xml_target` with a new XML fragment `new_xml`, and then returns the changed XML.
+
+### UPPER
+`UPPER(str)`  
+Returns the string `str` with all characters changed to uppercase according to the current character set mapping.
+
+### WEIGHT_STRING
+`WEIGHT_STRING(str [AS {CHAR|BINARY}(N)] [LEVEL levels] [flags])`  
+Returns a binary string representing the string's sorting and comparison value.
+<!-- END GENERATED -->
+
+## See Also
+
+- **`mariadb-features`** (topical) — the `latin1` → `utf8mb4` default-charset (since 11.6) and `uca1400_ai_ci` default-collation (since 11.5) changes that drive every case-sensitivity row
+- **`mysql-to-mariadb`** (topical) — the `||`-as-OR default and collation-alias behavior
+- **`mariadb-aggregate-functions`** — `GROUP_CONCAT` for joining rows into a string
+- Canonical reference on `mariadb.com/docs`: <https://mariadb.com/docs/server/reference/sql-functions/string-functions>


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track. **Second Tier 2 batch** (after the `json-functions` pilot): the four highest-use SQL function categories.

Each `SKILL.md` is a hand-written scaffold (frontmatter, intro, **"What LLMs Often Miss"** table, version notes, cross-linked See Also) wrapping the **extractor-generated per-function catalog** between `BEGIN/END GENERATED` markers — the intended Tier 2 split.

- `granular/functions/mariadb-string-functions` — 58 functions
- `granular/functions/mariadb-date-time-functions` — 64 functions
- `granular/functions/mariadb-numeric-functions` — 34 functions
- `granular/functions/mariadb-aggregate-functions` — 16 functions

## Extractor generalization (ships with this batch)

The extractor had only ever been validated against `json-functions` and matched **zero** functions in these categories. Three fixes:

- **Syntax fence:** accept any/no language tag — these pages use ` ```bnf ` (or a bare fence); json used ` ```sql `.
- **Version tabs:** tolerate `{% tabs %}`/`{% tab %}` between the Syntax heading and the fence (picks the "Current" form, e.g. `CRC32`).
- **Title/alias recovery:** rescue disambiguated " Function"-suffixed titles (`CHAR`/`INSERT`/`REPEAT`/`REPLACE`/`DATE`) and "synonym for" aliases (`SUBSTR`), with the alias target validated as an uppercase function name so editorial prose is correctly rejected.

`json-functions` regression: still 40 functions, aliases intact. Also fixes the json pilot's stale `_extractors/` path reference.

## How the editorial parts were produced

The per-function entries are mechanical (extractor). The **traps tables** were researched by four parallel agents and **source-verified** against `mariadb-server/sql/` and the canonical docs. Highlights: `LENGTH` (bytes) vs `CHAR_LENGTH` (chars) under utf8mb4; `CONCAT` nulls if any arg is `NULL`; PCRE2 regex; integer `/` returns a decimal (use `DIV`); `ROUND` half-away-from-zero for `DECIMAL` but OS-dependent for `FLOAT`; `NOW()` constant per statement vs `SYSDATE()`; `UNIX_TIMESTAMP` max now 2106 (since 11.5); aggregates skip `NULL`s; `GROUP_CONCAT` truncates at `group_concat_max_len` (1 MB); `ONLY_FULL_GROUP_BY` not in the default `sql_mode`.

## Status: `draft` — needs human verification

Marked `"status": "draft"` in the manifest, pending the human verification gate per `dev-docs/agent-skills-maintenance.md`.

## Notes

- Not rendered in GitBook (no `SUMMARY.md` entry), like the rest of `agent-skills/`.
- codespell + link-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)