### PR TITLE
DOCS-6206 Promote Tier 2 function-category skills to pilot

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -27,10 +27,10 @@
       "author": "docs-team+extractor",
       "skills": [
         { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-string-functions", "path": "granular/functions/mariadb-string-functions/SKILL.md", "status": "draft" },
-        { "name": "mariadb-date-time-functions", "path": "granular/functions/mariadb-date-time-functions/SKILL.md", "status": "draft" },
-        { "name": "mariadb-numeric-functions", "path": "granular/functions/mariadb-numeric-functions/SKILL.md", "status": "draft" },
-        { "name": "mariadb-aggregate-functions", "path": "granular/functions/mariadb-aggregate-functions/SKILL.md", "status": "draft" }
+        { "name": "mariadb-string-functions", "path": "granular/functions/mariadb-string-functions/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-date-time-functions", "path": "granular/functions/mariadb-date-time-functions/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-numeric-functions", "path": "granular/functions/mariadb-numeric-functions/SKILL.md", "status": "pilot" },
+        { "name": "mariadb-aggregate-functions", "path": "granular/functions/mariadb-aggregate-functions/SKILL.md", "status": "pilot" }
       ]
     },
     "granular-tools": {


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track.

The four Tier 2 function-category skills merged as `draft` in #629 — `mariadb-string-functions`, `mariadb-date-time-functions`, `mariadb-numeric-functions`, `mariadb-aggregate-functions` — have been **reviewed and verified** (the human verification gate per `dev-docs/agent-skills-maintenance.md`). This flips all four from `draft` to `pilot`, matching `mariadb-json-functions`.

After this, **every authored agent skill (Tier 1 statements + tools, Tier 2 functions) is `pilot`** — no drafts remain. Manifest-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)