### PR TITLE
DOCS-6206 Add update-cadence plan + per-skill staleness tracking

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Index of all MariaDB agent skills for DOCS-6206. Hand-maintained for now; a CI step can regenerate it from the directory tree + frontmatter once the layout is final.",
+  "$comment": "Index of all MariaDB agent skills for DOCS-6206. Hand-maintained for now; a CI step can regenerate it from the directory tree + frontmatter once the layout is final. Per-skill `last_reviewed` (YYYY-MM-DD of the last human verification pass) and `baseline_version` (the MariaDB LTS the skill was last verified against) drive the staleness report — see dev-docs/agent-skills-maintenance.md.",
   "baseline": "11.8 LTS",
   "layers": {
     "granular-statements": {
@@ -7,18 +7,18 @@
       "path": "granular/statements",
       "author": "docs-team",
       "skills": [
-        { "name": "mariadb-create-table", "path": "granular/statements/mariadb-create-table/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-alter-table", "path": "granular/statements/mariadb-alter-table/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-select", "path": "granular/statements/mariadb-select/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-insert", "path": "granular/statements/mariadb-insert/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-update", "path": "granular/statements/mariadb-update/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-delete", "path": "granular/statements/mariadb-delete/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-create-view", "path": "granular/statements/mariadb-create-view/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-create-index", "path": "granular/statements/mariadb-create-index/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-drop-table", "path": "granular/statements/mariadb-drop-table/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-create-database", "path": "granular/statements/mariadb-create-database/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-load-data", "path": "granular/statements/mariadb-load-data/SKILL.md", "status": "pilot" }
+        { "name": "mariadb-create-table", "path": "granular/statements/mariadb-create-table/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-alter-table", "path": "granular/statements/mariadb-alter-table/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-select", "path": "granular/statements/mariadb-select/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-insert", "path": "granular/statements/mariadb-insert/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-update", "path": "granular/statements/mariadb-update/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-delete", "path": "granular/statements/mariadb-delete/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-replace", "path": "granular/statements/mariadb-replace/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-create-view", "path": "granular/statements/mariadb-create-view/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-create-index", "path": "granular/statements/mariadb-create-index/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-drop-table", "path": "granular/statements/mariadb-drop-table/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-create-database", "path": "granular/statements/mariadb-create-database/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-load-data", "path": "granular/statements/mariadb-load-data/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" }
       ]
     },
     "granular-functions": {
@@ -26,19 +26,19 @@
       "path": "granular/functions",
       "author": "docs-team+extractor",
       "skills": [
-        { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-string-functions", "path": "granular/functions/mariadb-string-functions/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-date-time-functions", "path": "granular/functions/mariadb-date-time-functions/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-numeric-functions", "path": "granular/functions/mariadb-numeric-functions/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-aggregate-functions", "path": "granular/functions/mariadb-aggregate-functions/SKILL.md", "status": "pilot" }
+        { "name": "mariadb-json-functions", "path": "granular/functions/mariadb-json-functions/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-string-functions", "path": "granular/functions/mariadb-string-functions/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-date-time-functions", "path": "granular/functions/mariadb-date-time-functions/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-numeric-functions", "path": "granular/functions/mariadb-numeric-functions/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-aggregate-functions", "path": "granular/functions/mariadb-aggregate-functions/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" }
       ]
     },
     "granular-tools": {
       "path": "granular/tools",
       "author": "docs-team",
       "skills": [
-        { "name": "mariadb-dump", "path": "granular/tools/mariadb-dump/SKILL.md", "status": "pilot" },
-        { "name": "mariadb-import", "path": "granular/tools/mariadb-import/SKILL.md", "status": "pilot" }
+        { "name": "mariadb-dump", "path": "granular/tools/mariadb-dump/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-import", "path": "granular/tools/mariadb-import/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" }
       ]
     },
     "topical": {
@@ -48,11 +48,11 @@
       "vendored_ref": "86623494f8051e766c973d35c1f07368c3b4c267",
       "vendored_license": "MIT",
       "skills": [
-        { "name": "mariadb-features", "path": "topical/mariadb-features/SKILL.md", "status": "vendored" },
-        { "name": "mariadb-query-optimization", "path": "topical/mariadb-query-optimization/SKILL.md", "status": "vendored" },
-        { "name": "mariadb-system-versioned-tables", "path": "topical/mariadb-system-versioned-tables/SKILL.md", "status": "vendored" },
-        { "name": "mysql-to-mariadb", "path": "topical/mysql-to-mariadb/SKILL.md", "status": "vendored" },
-        { "name": "mariadb-vector", "path": "topical/mariadb-vector/SKILL.md", "status": "vendored" }
+        { "name": "mariadb-features", "path": "topical/mariadb-features/SKILL.md", "status": "vendored", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-query-optimization", "path": "topical/mariadb-query-optimization/SKILL.md", "status": "vendored", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-system-versioned-tables", "path": "topical/mariadb-system-versioned-tables/SKILL.md", "status": "vendored", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mysql-to-mariadb", "path": "topical/mysql-to-mariadb/SKILL.md", "status": "vendored", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
+        { "name": "mariadb-vector", "path": "topical/mariadb-vector/SKILL.md", "status": "vendored", "last_reviewed": "2026-06-24", "baseline_version": "11.8" }
       ]
     }
   }

--- a/dev-docs/agent-skills-maintenance.md
+++ b/dev-docs/agent-skills-maintenance.md
@@ -90,22 +90,69 @@ The per-function entries are generated; the scaffold around them is not.
 - CI (`extract-function-skills.yml`, stub) re-runs the extractor when those
   pages change and opens a regeneration PR, preserving the scaffold sections.
 
-## Per-LTS update workflow
+## Update cadence and triggers
 
-Roughly annually, per LTS release:
+Skills need refreshing roughly **3–4 times a year** — but most of that frequency
+is **automated**, and the human part only touches the skills actually affected.
+Don't sweep all skills every cycle.
 
-1. **Structured review per Tier 1 skill** against its `server/reference/**`
-   page(s) and `mariadb-server/sql/` source. For every "since X.Y" / "removed in
-   X.Y" claim, verify. For every trap-table row, confirm the trap is still real.
-   Flag new doc content not yet reflected. ~15–30 min per skill — cheaper than
-   authoring.
-2. **Targeted review** for releases with notable removals/deprecations
-   (e.g. query cache removed in 13.0): review only the affected skills.
-3. **Tier 2:** re-run the extractor (CI handles this on doc change).
-4. **Topical:** re-vendor from upstream at the new pinned ref; update
-   `topical/VENDORED.md`.
-5. **Empirical-fresh-session sweep every 12–18 months.** As LLMs improve, some
-   traps stop being traps; prune them so the tables don't accumulate dead weight.
+| Trigger | Frequency | Scope |
+| --- | --- | --- |
+| MariaDB **minor release** (e.g. 11.8.1, 11.8.2) | ~quarterly — the main 3–4×/year driver | Event-driven: only skills whose statements/functions changed |
+| **Doc-page changes** under `server/reference/**` | continuous | Tier 2 auto-regenerates (CI); Tier 1 pages flagged by the staleness report |
+| **Major LTS** / notable removal or deprecation (e.g. query cache removed in 13.0) | ~annual | Full review pass; targeted review of the affected skills |
+| **LLM-prior drift** | every 12–18 months | Empirical fresh-session sweep — prune traps that stopped being traps |
+
+## What is automated vs. human
+
+**Automated (no human effort):**
+
+- **Tier 2 functions** — `.github/workflows/extract-function-skills.yml` re-runs
+  the extractor when the relevant `sql-functions/**` pages change and opens a
+  regeneration PR. The per-function catalog stays current; the hand-written
+  scaffold (frontmatter, intro, "What LLMs Often Miss") is preserved between the
+  `BEGIN/END GENERATED` markers.
+- **Topical** — `.github/workflows/sync-topical-skills.yml` re-vendors
+  `MariaDB/skills` at a new pinned ref and updates `topical/VENDORED.md`.
+
+**Human review (the editorial delta — can't be automated), per *affected* skill,
+~15–30 min each:**
+
+1. Walk each "What LLMs Often Miss" row and confirm the trap is still real.
+2. Verify every `*(since X.Y)*` / "removed in X.Y" claim against
+   `mariadb-server/sql/` or the canonical `server/reference/**` page.
+3. Diff the skill's source page(s) since its `last_reviewed` date for new
+   `{% hint %}` warnings or `{% tabs %}` version blocks — those are the docs team
+   flagging new traps.
+4. Check `mariadb-features` "Defaults Changed" / "Behavior Changed" for anything
+   newly relevant.
+
+After a review pass, bump that skill's `last_reviewed` (and `baseline_version`
+if re-verified against a newer LTS) in `.skills-manifest.json`.
+
+## Tracking staleness
+
+Each skill in `.skills-manifest.json` carries `last_reviewed` (date of the last
+human verification) and `baseline_version` (the LTS it was last verified
+against). A **staleness report** turns each cycle into a short worklist instead
+of a full sweep: for every skill, diff its referenced `server/reference/**`
+page(s) `git log` since `last_reviewed` and list only the skills with upstream
+changes (plus any whose `baseline_version` lags the current default LTS). A
+typical quarterly cycle then reviews ~2–4 skills, not all of them.
+
+## Per-LTS (annual) pass
+
+At each major LTS, do the fuller version of the above across **all** skills (not
+just the changed ones), plus:
+
+- **Tier 2:** confirm the extractor still parses the (possibly restructured)
+  function pages; re-run it.
+- **Topical:** re-vendor from upstream at the new pinned ref; update
+  `topical/VENDORED.md`.
+- **Empirical-fresh-session sweep** (also on its own 12–18-month clock): open a
+  fresh agent session with no MariaDB skill loaded, re-run representative
+  prompts, and prune trap rows that the current generation of LLMs no longer
+  gets wrong, so the tables don't accumulate dead weight.
 
 ## Scope discipline ("good enough" over "perfect")
 


### PR DESCRIPTION
Part of the MariaDB DX project (DOCS-6206) — agent-skills track. Implements the **maintenance/update plan** (skills need refreshing ~3–4×/year).

## `dev-docs/agent-skills-maintenance.md`

Expands the update section from a single annual pass to the real cadence:

- **Trigger table** — quarterly MariaDB minor releases are the main 3–4×/year driver; plus continuous doc-change, annual-LTS, and 12–18-month LLM-drift triggers.
- **Automated vs. human split** — the Tier 2 extractor regen (`extract-function-skills.yml`) and topical re-vendor (`sync-topical-skills.yml`) run in CI; humans only review the *editorial delta* of *affected* skills (~15–30 min each).
- **Staleness report** — diff each skill's referenced `server/reference/**` pages' `git log` since its `last_reviewed` date, so a typical cycle reviews ~2–4 skills, not all of them.
- The fuller **per-LTS (annual)** pass and the **empirical fresh-session sweep**.

## `.skills-manifest.json`

Adds per-skill **`last_reviewed`** (date of the last human verification) and **`baseline_version`** (the LTS it was last verified against) to all 24 skills, seeded `2026-06-24` / `11.8`. These drive the staleness report. The format-preserving one-line-per-skill layout is kept, and the new fields are documented in the `$comment`.

Manifest + doc only; no skill content changes. codespell passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)