### PR TITLE
Refresh mariadb-upgrade examples; clarify automatic invocation

### DIFF
--- a/server/clients-and-utilities/deployment-tools/mariadb-upgrade.md
+++ b/server/clients-and-utilities/deployment-tools/mariadb-upgrade.md
@@ -14,7 +14,7 @@ Previously, the client was called `mysql_upgrade`. It can still be accessed unde
 
 ## Overview
 
-You should run `mariadb-upgrade` after upgrading from one major MySQL/MariaDB release to another, such as from MySQL 5.0 or MariaDB 10.4 to MariaDB 10.5. You also have to use `mariadb-upgrade` after a direct "horizontal" migration, for example from MySQL 5.5.40 to MariaDB 5.5.40. It's also safe to run `mariadb-upgrade` for minor upgrades, as, if there are no incompatibilities, nothing is changed.
+You should run `mariadb-upgrade` after upgrading from one major MariaDB release to another, such as from MariaDB 10.11 to MariaDB 11.4. You also have to use `mariadb-upgrade` after migrating to MariaDB from MySQL. It's also safe to run `mariadb-upgrade` for minor upgrades, as, if there are no incompatibilities, nothing is changed.
 
 {% tabs %}
 {% tab title="Current" %}
@@ -29,6 +29,12 @@ Starting from [mariadb-upgrade 2.0](mariadb-upgrade.md#mariadb-upgrade-2.0), the
 {% endtabs %}
 
 `mariadb-upgrade` is run after starting the new MariaDB server. Running it before you shut down the old version will not hurt anything and will allow you to make sure it works and figure out authentication for it ahead of time.
+
+{% hint style="info" %}
+The MariaDB server never performs the upgrade itself. On startup, if it detects an out-of-date system table or a version mismatch, it only writes a message to the [error log](../../server-management/server-monitoring-logs/error-log.md) recommending that you run `mariadb-upgrade`.
+
+On Debian and Ubuntu, the server packages run `mariadb-upgrade` for you automatically after a package upgrade: once the new server has started, the startup script runs it in the background, using `--version-check` so the work is only done once per major version. On RPM-based distributions, and whenever you start the server directly (for example with `systemd` or by running `mariadbd`), `mariadb-upgrade` is not run automatically and you must run it yourself.
+{% endhint %}
 
 {% hint style="success" %}
 It is recommended to make a [backup](../../server-usage/backup-and-restore/) of all databases before running `mariadb-upgrade`.


### PR DESCRIPTION
Triggered by a [#docs-talk discussion](https://mariadb.slack.com/archives/CHAMKU9PG/p1782481728175029) (Hartmut, Sunny).

## What

Two changes to the `mariadb-upgrade` page:

1. **Refresh EOL example versions** in the Overview. The page used `MySQL 5.0`/`MariaDB 10.4 → 10.5` and a same-version `MySQL 5.5.40 → MariaDB 5.5.40` "horizontal migration" example. Updated the major-upgrade example to current LTS releases (`10.11 → 11.4`) and reframed the migration sentence as a plain MySQL-to-MariaDB migration — MariaDB and MySQL version numbers no longer track each other, so the identical-version "horizontal migration" framing is obsolete.

2. **Document automatic invocation.** The thread surfaced confusion about whether the upgrade happens automatically at server startup. Added a note clarifying that:
   - The MariaDB server **never** runs the upgrade itself; on a version/system-table mismatch it only logs a recommendation to run `mariadb-upgrade`.
   - On **Debian/Ubuntu**, the package startup script runs `mariadb-upgrade` automatically after a package upgrade (with `--version-check`, so it runs once per major version).
   - On **RPM-based** distros and direct server starts (`systemd`/`mariadbd`), it must be run manually.

## Source verification

Checked against the local `mariadb-server` tree:
- `debian/additions/debian-start` (lines 27–39) — runs `mariadb-upgrade --version-check` in the background after start.
- `support-files/rpm/server-prein.sh` — only *checks* upgrade safety and prints manual instructions; does not auto-run.
- `sql/mysqld.cc` / server init — no upgrade execution; advisory log message only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)