### PR TITLE
Note --force is needed after restoring an older-version dump

### DIFF
--- a/server/clients-and-utilities/deployment-tools/mariadb-upgrade.md
+++ b/server/clients-and-utilities/deployment-tools/mariadb-upgrade.md
@@ -112,6 +112,10 @@ mariadb-upgrade --verbose --verbose other-options
 
 `mariadb-upgrade` also saves the MariaDB version number in a file named `mysql_upgrade_info` in the [data directory](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#datadir). This is used to quickly check whether all tables have been checked for this release so that table-checking can be skipped. For this reason,`mariadb-upgrade` needs to be run as a user with write access to the data directory. To ignore this file and perform the check regardless, use the `--force` option.
 
+{% hint style="warning" %}
+Because this check relies on the version recorded in `mysql_upgrade_info`, restoring a `mariadb-dump` (`mysqldump`) backup taken from an older server version can leave the restored system tables out of date while the file still shows the current version. In that case, `mariadb-upgrade` reports that no upgrade is needed, so run it with the `--force` option to upgrade the restored tables.
+{% endhint %}
+
 ## Options
 
 `mariadb-upgrade` supports the following options:


### PR DESCRIPTION
Follow-up to #636, from the same [#docs-talk discussion](https://mariadb.slack.com/archives/CHAMKU9PG/p1782484458216209) (Hartmut).

## What

Adds a brief note to the `mariadb-upgrade` page covering a gotcha: if you restore a `mariadb-dump`/`mysqldump` backup taken from an **older** server version, the out-of-date system tables are restored but the `mysql_upgrade_info` version stamp still shows the current version. `mariadb-upgrade` then reports "no upgrade needed" and skips the schema fixes — you must re-run it with `--force`.

The note is placed right where the `mysql_upgrade_info` version-stamp mechanism is explained, since that's the root cause.

## Scope

Deliberately a behavioral workaround note only — it does not document the underlying bug, so it stays correct regardless of if/when that's fixed. The Community→Enterprise same-major-version variant is already covered in the "Upgrading to a Minor Version, or to Enterprise Server" section, so it's untouched.

## Reference

Scenario tracked upstream in [MDEV-39343](https://jira.mariadb.org/browse/MDEV-39343) (Confirmed; affects 13.0, 10.6.25, 10.11.16, 11.4.10, 11.8.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)