### PR TITLE
DOCS-6169 Add XXH32() and XXH3() hash function pages

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -1936,6 +1936,8 @@
       * [TAN](reference/sql-functions/numeric-functions/tan.md)
       * [TO\_NUMBER](reference/sql-functions/numeric-functions/to_number.md)
       * [TRUNCATE](reference/sql-functions/numeric-functions/truncate.md)
+      * [XXH3](reference/sql-functions/numeric-functions/xxh3.md)
+      * [XXH32](reference/sql-functions/numeric-functions/xxh32.md)
     * [Pseudo Columns](reference/sql-functions/pseudo-columns/README.md)
       * [\_rowid](reference/sql-functions/pseudo-columns/_rowid.md)
     * [Secondary Functions](reference/sql-functions/secondary-functions/README.md)

--- a/server/reference/sql-functions/numeric-functions/xxh3.md
+++ b/server/reference/sql-functions/numeric-functions/xxh3.md
@@ -1,0 +1,91 @@
+---
+description: >-
+  Compute a fast 64-bit xxHash. XXH3 returns the XXH3 hash of a text value as a
+  64-bit unsigned integer.
+---
+
+# XXH3
+
+{% hint style="info" %}
+`XXH3` was added in MariaDB 13.1.
+{% endhint %}
+
+## Syntax
+
+```bnf
+XXH3(expr)
+```
+
+## Description
+
+`XXH3` returns a fast, non-cryptographic [xxHash](https://xxhash.com/) of a text value as a 64-bit number (`BIGINT UNSIGNED`). It's useful for checksums, change detection, and grouping or bucketing rows. For a 32-bit result, use [XXH32()](xxh32.md).
+
+The argument must be a text value: a string, `BLOB`/`TEXT`, `JSON`, `ENUM`, or `SET`. Numbers, dates, and other non-text values are rejected with an error; [CAST()](../string-functions/cast.md) them to a string first.
+
+Hashing `NULL` returns `NULL`. Hashing an empty string returns `0`.
+
+The result depends on the [collation](../../data-types/string-data-types/character-sets/), not on the raw bytes. Values that count as equal under the collation hash to the same number (for example, `'abc'` and `'ABC'` under a case-insensitive collation). The same text in a different character set or collation gives a different number.
+
+{% hint style="warning" %}
+When comparing a column to a value, keep both sides in the same collation. If the hashed column and the value use different collations, they won't match, so a hash-based index or lookup can quietly find nothing. Hash the binary form with `CAST(... AS BINARY)` (or the `BINARY` operator) when you want a byte-exact hash that ignores collation.
+{% endhint %}
+
+### Predicting the partition for KEY partitioning
+
+The same XXH3 algorithm is available as a [KEY partitioning](../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) algorithm (`PARTITION BY KEY ALGORITHM=XXH3`). For a table partitioned on a single column, the partition a value lands in is `MOD(XXH3(value), number_of_partitions)` — handy for knowing where a row will go, or for partition pruning. The collation rule above still applies: the value must use the column's collation to predict correctly.
+
+This shortcut holds only for a plain, single-column `KEY`. It doesn't apply to [LINEAR KEY](../../../server-usage/partitioning-tables/partitioning-types/linear-key-partitioning-type.md) (unless the number of partitions is a power of two), to multi-column keys, or to `NULL` values (the server places those itself).
+
+{% hint style="info" %}
+`XXH32` is the 32-bit variant. The `XXH64()` and `XXH128()` functions are not part of this release.
+{% endhint %}
+
+## Examples
+
+```sql
+SELECT XXH3('abc');
++---------------------+
+| XXH3('abc')         |
++---------------------+
+| 2615927343983396622 |
++---------------------+
+```
+
+`NULL` and the empty string:
+
+```sql
+SELECT XXH3(NULL), XXH3('');
++------------+----------+
+| XXH3(NULL) | XXH3('') |
++------------+----------+
+|       NULL |        0 |
++------------+----------+
+```
+
+Equal values under a case-insensitive collation hash to the same number:
+
+```sql
+SELECT XXH3(_utf8mb4'ABC' COLLATE utf8mb4_general_ci)
+     = XXH3(_utf8mb4'abc' COLLATE utf8mb4_general_ci) AS equal_ci;
++----------+
+| equal_ci |
++----------+
+|        1 |
++----------+
+```
+
+A non-text argument is rejected:
+
+```sql
+SELECT XXH3(11223344);
+ERROR HY000: Illegal parameter data type int for operation 'XXH3'
+```
+
+## See Also
+
+* [XXH32()](xxh32.md) - the 32-bit variant
+* [CRC32()](crc32.md), [CRC32C()](crc32c.md) - other non-cryptographic checksums
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}

--- a/server/reference/sql-functions/numeric-functions/xxh3.md
+++ b/server/reference/sql-functions/numeric-functions/xxh3.md
@@ -47,8 +47,19 @@ SELECT XXH3('abc');
 +---------------------+
 | XXH3('abc')         |
 +---------------------+
-| 2615927343983396622 |
+| 5167207402487786768 |
 +---------------------+
+```
+
+The result depends on the session collation, so a bare literal reproduces only under the same collation (the result above is for the default `utf8mb4_uca1400_ai_ci`). For a byte-exact hash that doesn't depend on collation, hash the binary form:
+
+```sql
+SELECT XXH3(CAST('abc' AS BINARY));
++-----------------------------+
+| XXH3(CAST('abc' AS BINARY)) |
++-----------------------------+
+|         8696274497037089104 |
++-----------------------------+
 ```
 
 `NULL` and the empty string:
@@ -78,7 +89,7 @@ A non-text argument is rejected:
 
 ```sql
 SELECT XXH3(11223344);
-ERROR HY000: Illegal parameter data type int for operation 'XXH3'
+ERROR 4079 (HY000): Illegal parameter data type int for operation 'XXH3'
 ```
 
 ## See Also

--- a/server/reference/sql-functions/numeric-functions/xxh32.md
+++ b/server/reference/sql-functions/numeric-functions/xxh32.md
@@ -1,0 +1,91 @@
+---
+description: >-
+  Compute a fast 32-bit xxHash. XXH32 returns the XXH32 hash of a text value as
+  a 32-bit unsigned integer.
+---
+
+# XXH32
+
+{% hint style="info" %}
+`XXH32` was added in MariaDB 13.1.
+{% endhint %}
+
+## Syntax
+
+```bnf
+XXH32(expr)
+```
+
+## Description
+
+`XXH32` returns a fast, non-cryptographic [xxHash](https://xxhash.com/) of a text value as a 32-bit number (`INT UNSIGNED`). It's useful for checksums, change detection, and grouping or bucketing rows. For a 64-bit result, use [XXH3()](xxh3.md).
+
+The argument must be a text value: a string, `BLOB`/`TEXT`, `JSON`, `ENUM`, or `SET`. Numbers, dates, and other non-text values are rejected with an error; [CAST()](../string-functions/cast.md) them to a string first.
+
+Hashing `NULL` returns `NULL`. Hashing an empty string returns `0`.
+
+The result depends on the [collation](../../data-types/string-data-types/character-sets/), not on the raw bytes. Values that count as equal under the collation hash to the same number (for example, `'abc'` and `'ABC'` under a case-insensitive collation). The same text in a different character set or collation gives a different number.
+
+{% hint style="warning" %}
+When comparing a column to a value, keep both sides in the same collation. If the hashed column and the value use different collations, they won't match, so a hash-based index or lookup can quietly find nothing. Hash the binary form with `CAST(... AS BINARY)` (or the `BINARY` operator) when you want a byte-exact hash that ignores collation.
+{% endhint %}
+
+### Predicting the partition for KEY partitioning
+
+The same XXH32 algorithm is available as a [KEY partitioning](../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) algorithm (`PARTITION BY KEY ALGORITHM=XXH32`). For a table partitioned on a single column, the partition a value lands in is `MOD(XXH32(value), number_of_partitions)` — handy for knowing where a row will go, or for partition pruning. The collation rule above still applies: the value must use the column's collation to predict correctly.
+
+This shortcut holds only for a plain, single-column `KEY`. It doesn't apply to [LINEAR KEY](../../../server-usage/partitioning-tables/partitioning-types/linear-key-partitioning-type.md) (unless the number of partitions is a power of two), to multi-column keys, or to `NULL` values (the server places those itself).
+
+{% hint style="info" %}
+`XXH3` is the 64-bit variant. The `XXH64()` and `XXH128()` functions are not part of this release.
+{% endhint %}
+
+## Examples
+
+```sql
+SELECT XXH32('abc');
++--------------+
+| XXH32('abc') |
++--------------+
+|   2154901205 |
++--------------+
+```
+
+`NULL` and the empty string:
+
+```sql
+SELECT XXH32(NULL), XXH32('');
++-------------+-----------+
+| XXH32(NULL) | XXH32('') |
++-------------+-----------+
+|        NULL |         0 |
++-------------+-----------+
+```
+
+Equal values under a case-insensitive collation hash to the same number:
+
+```sql
+SELECT XXH32(_latin1'ABC' COLLATE latin1_swedish_ci)
+     = XXH32(_latin1'abc' COLLATE latin1_swedish_ci) AS equal_ci;
++----------+
+| equal_ci |
++----------+
+|        1 |
++----------+
+```
+
+A non-text argument is rejected:
+
+```sql
+SELECT XXH32(11223344);
+ERROR HY000: Illegal parameter data type int for operation 'XXH32'
+```
+
+## See Also
+
+* [XXH3()](xxh3.md) - the 64-bit variant
+* [CRC32()](crc32.md), [CRC32C()](crc32c.md) - other non-cryptographic checksums
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}

--- a/server/reference/sql-functions/numeric-functions/xxh32.md
+++ b/server/reference/sql-functions/numeric-functions/xxh32.md
@@ -47,8 +47,19 @@ SELECT XXH32('abc');
 +--------------+
 | XXH32('abc') |
 +--------------+
-|   2154901205 |
+|    560666315 |
 +--------------+
+```
+
+The result depends on the session collation, so a bare literal reproduces only under the same collation (the result above is for the default `utf8mb4_uca1400_ai_ci`). For a byte-exact hash that doesn't depend on collation, hash the binary form:
+
+```sql
+SELECT XXH32(CAST('abc' AS BINARY));
++------------------------------+
+| XXH32(CAST('abc' AS BINARY)) |
++------------------------------+
+|                    852579327 |
++------------------------------+
 ```
 
 `NULL` and the empty string:
@@ -65,8 +76,8 @@ SELECT XXH32(NULL), XXH32('');
 Equal values under a case-insensitive collation hash to the same number:
 
 ```sql
-SELECT XXH32(_latin1'ABC' COLLATE latin1_swedish_ci)
-     = XXH32(_latin1'abc' COLLATE latin1_swedish_ci) AS equal_ci;
+SELECT XXH32(_utf8mb4'ABC' COLLATE utf8mb4_general_ci)
+     = XXH32(_utf8mb4'abc' COLLATE utf8mb4_general_ci) AS equal_ci;
 +----------+
 | equal_ci |
 +----------+
@@ -78,7 +89,7 @@ A non-text argument is rejected:
 
 ```sql
 SELECT XXH32(11223344);
-ERROR HY000: Illegal parameter data type int for operation 'XXH32'
+ERROR 4079 (HY000): Illegal parameter data type int for operation 'XXH32'
 ```
 
 ## See Also


### PR DESCRIPTION
Documents the new **XXH32()** and **XXH3()** SQL functions added in MariaDB 13.1 ([MDEV-38180](https://jira.mariadb.org/browse/MDEV-38180)). Resolves [DOCS-6169](https://mariadbcorp.atlassian.net/browse/DOCS-6169).

Two new reference pages under `numeric-functions`, placed alongside `CRC32`/`CRC32C` (the closest integer-returning, non-cryptographic analogues) rather than the MD5 hashing folder, since both return integers (`INT UNSIGNED` / `BIGINT UNSIGNED`).

### Pages
- `server/reference/sql-functions/numeric-functions/xxh32.md`
- `server/reference/sql-functions/numeric-functions/xxh3.md`
- `server/SUMMARY.md` — nav entries

### Coverage
- Return types, fast non-cryptographic hash framing
- Accepted argument types (string/`BLOB`/`TEXT`/`JSON`/`ENUM`/`SET`); numbers/dates rejected — `CAST` to text first
- `NULL` → `NULL`, empty string → `0`
- Collation-dependent (not raw bytes); same-collation comparison caveat; `CAST(... AS BINARY)` for byte-exact
- `PARTITION BY KEY ALGORITHM=XXH32/XXH3` placement shortcut `MOD(XXH32(value), n)` and its limits (LINEAR, multi-column, NULL)
- Note that `XXH64()`/`XXH128()` are not in this release

### Verification
All 15 claims verified against `mariadb-server` @ `34dd2215` (ref `main`, VERSION 13.1.0) — implementation in `sql/item_strfunc.{h,cc}`, `sql/item_create.cc`, partition code in `sql/sql_partition.cc` / `sql/partition_info.cc`, plus the committed `mysql-test/main/func_xxh{,_partition}.result` expected outputs. Full fact-check report posted to the Jira ticket on handoff.

Note: ENUM/SET are documented as **accepted** — the MTR test hedges them with `--error 0,...` but the committed `.result` shows them returning hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6169]: https://mariadbcorp.atlassian.net/browse/DOCS-6169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ