### PR TITLE
DOCS-6271 Recharacterize Migrator as community, not Enterprise

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/README.md
@@ -7,7 +7,7 @@ description: >-
 # MySQL to MariaDB Migrator
 
 {% hint style="info" %}
-**Enterprise tooling.** The MySQL to MariaDB Migrator is proprietary MariaDB software, available to MariaDB customers and partners under approved usage terms. It is not open source and is not available for general public use. It is distributed from the [MariaDB downloads page](https://mariadb.com/downloads/) under **Enterprise Tooling**.
+**MariaDB tool.** The MySQL to MariaDB Migrator is proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms. It is distributed from the [MariaDB community downloads page](https://mariadb.com/downloads/community/).
 {% endhint %}
 
 The **MySQL to MariaDB Migrator** is a MariaDB tool that automates end-to-end migrations from MySQL to MariaDB in a repeatable, auditable way. It orchestrates schema migration, data transfer, user and privilege migration, and post-migration validation, and it drives the standard MariaDB client tools (`mariadb-dump`, the `mariadb` client, and the `mariadb-mtk` data-transfer engine) under a single launcher.
@@ -64,3 +64,13 @@ Preview a migration with **Assess & Plan** before committing to it; the assess a
 {% content-ref url="environment-variables.md" %}
 [environment-variables.md](environment-variables.md)
 {% endcontent-ref %}
+
+## Feedback
+
+Join the [MariaDB Community on Slack](https://app.gitbook.com/s/WCInJQ9cmGjq1lsTG91E/community/joining-the-community) to share your feedback.
+
+## License
+
+The [MariaDB Software License Terms](https://legal.mariadb.com/agreements/enterprise/MariaDB_Software_License_Terms_2026-05-15.pdf) apply to all MariaDB Software unless otherwise stated. They do not alter the license terms of any free and open-source software (FOSS) or software subject to the Business Source License (BSL); see Section 7 of the MariaDB Software License Terms.
+
+For additional legal information, see the [MariaDB Terms](https://mariadb.com/terms/).

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/application-user-migration.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/application-user-migration.md
@@ -7,7 +7,7 @@ description: >-
 # Application User Migration
 
 {% hint style="info" %}
-**Enterprise tooling.** The MySQL to MariaDB Migrator is proprietary MariaDB software, available to MariaDB customers and partners under approved usage terms. It is not open source and is not available for general public use.
+**MariaDB tool.** The MySQL to MariaDB Migrator is proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms.
 {% endhint %}
 
 When you answer `y` to the `Migrate application users? (y/n)` prompt, the migrator migrates application users and roles from the source MySQL server to the target MariaDB server during the run phase. This runs in every mode (`one_step`, `two_step`, `staged`, and `binlog`), and the assess phase produces a prediction report ahead of the run.

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/environment-variables.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/environment-variables.md
@@ -7,7 +7,7 @@ description: >-
 # Environment Variables
 
 {% hint style="info" %}
-**Enterprise tooling.** The MySQL to MariaDB Migrator is proprietary MariaDB software, available to MariaDB customers and partners under approved usage terms. It is not open source and is not available for general public use.
+**MariaDB tool.** The MySQL to MariaDB Migrator is proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms.
 {% endhint %}
 
 The migrator reads its configuration from environment variables (or the configuration file it writes from your interactive answers). This page lists the variables **required** to run each mode. A complete reference of every variable, with defaults and descriptions, ships with the tool.

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/installation-and-first-run.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/installation-and-first-run.md
@@ -7,10 +7,10 @@ description: >-
 # Installation and First Run
 
 {% hint style="info" %}
-**Enterprise tooling.** The MySQL to MariaDB Migrator is proprietary MariaDB software, available to MariaDB customers and partners under approved usage terms. It is not open source and is not available for general public use.
+**MariaDB tool.** The MySQL to MariaDB Migrator is proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms.
 {% endhint %}
 
-The MySQL to MariaDB Migrator is distributed as a release archive (`.tar.gz` or `.zip`) from the [MariaDB downloads page](https://mariadb.com/downloads/) under **Enterprise Tooling**. Extract it and run the launcher — it bootstraps its own Python environment, so there is no manual setup beyond the prerequisites below.
+The MySQL to MariaDB Migrator is distributed as a release archive (`.tar.gz` or `.zip`) from the [MariaDB community downloads page](https://mariadb.com/downloads/community/). Download the latest version (for example, `v1.3.1-beta`), extract it, and run the launcher — it bootstraps its own Python environment, so there is no manual setup beyond the prerequisites below.
 
 ```bash
 tar -xzf Mysql-to-MariaDB-Migration-<version>.tar.gz
@@ -20,7 +20,7 @@ cd Mysql-to-MariaDB-Migration-<version>
 
 The `.zip` archive is equivalent: `unzip` it, then change into the extracted directory and run `./mariadb-migrator`. The version embedded in the archive and directory names matches the release you download.
 
-The data-transfer engine used by Parallel Restartable Streaming Copy — `mariadb-mtk`, the MariaDB-packaged SQLines Data engine — is available from the same downloads page. See [Prerequisites](#prerequisites) below.
+The data-transfer engine used by Parallel Restartable Streaming Copy — `mariadb-mtk`, the MariaDB-packaged SQLines Data engine — is available from the same [MariaDB community downloads page](https://mariadb.com/downloads/community/). See [Prerequisites](#prerequisites) below.
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ The data-transfer engine used by Parallel Restartable Streaming Copy — `mariad
 * **Python 3.9 or later** on the host that runs the migrator. On the first run, the launcher creates a project-local virtual environment (`.venv`) and installs its Python dependencies into it automatically — no manual `pip install` is needed. On Debian and Ubuntu, install the venv module first: `sudo apt-get install -y python3-venv`.
 * **The `mariadb` client** on the host that runs the migrator, used for connectivity, version, and database checks. If it is missing, the launcher detects your platform and offers to install it on the first run. You can also install it manually, for example with `dnf install mariadb`, `apt-get install mariadb-client`, `zypper install mariadb-client`, or `brew install mariadb`.
 * **Network connectivity** from the host that runs the migrator to both the source MySQL server and the target MariaDB server. The exception is Offline Copy (`staged`) in its `dump_only` or `load_only` phase, which only needs connectivity to one side.
-* For **Parallel Restartable Streaming Copy** (`two_step`), the `mariadb-mtk` engine must be installed. The launcher auto-detects a `sqldata` (or `sqlinesdata`) binary on `PATH`; if it is installed under a different name or location, point the `SQLINESDATA_BIN` environment variable at its full path. The engine may provide a temporary license for evaluation — use a production license before production migration runs.
+* For **Parallel Restartable Streaming Copy** (`two_step`), the `mariadb-mtk` engine must be installed. It is available from the [MariaDB community downloads page](https://mariadb.com/downloads/community/). The launcher auto-detects a `sqldata` (or `sqlinesdata`) binary on `PATH`; if it is installed under a different name or location, point the `SQLINESDATA_BIN` environment variable at its full path. The engine may provide a temporary license for evaluation — use a production license before production migration runs.
 
 {% hint style="info" %}
 `pv` is recommended for live progress visibility but is optional. When it is missing, Offline Copy (`staged`) falls back to a 60-second file-size probe and Serial Streaming Copy (`one_step`) falls back to a 60-second heartbeat.

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migration-modes.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migration-modes.md
@@ -7,7 +7,7 @@ description: >-
 # Migration Modes
 
 {% hint style="info" %}
-**Enterprise tooling.** The MySQL to MariaDB Migrator is proprietary MariaDB software, available to MariaDB customers and partners under approved usage terms. It is not open source and is not available for general public use.
+**MariaDB tool.** The MySQL to MariaDB Migrator is proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms.
 {% endhint %}
 
 The MySQL to MariaDB Migrator offers four migration modes. This page describes how to select a mode and the playbook for each one. For the variables each mode requires, see [Environment Variables](environment-variables.md).


### PR DESCRIPTION
Follow-up to [DOCS-6271](https://mariadbcorp.atlassian.net/browse/DOCS-6271) review feedback from Manoj Vakeel (tool PM): the MySQL to MariaDB Migrator is distributed from the **MariaDB community downloads page**, not "Enterprise Tooling".

## Changes
- **Shared info block (all 5 pages):** `**Enterprise tooling.** … not open source and is not available for general public use` → `**MariaDB tool.** … proprietary MariaDB software, provided free to MariaDB customers and partners under approved usage terms`. (Kept "proprietary / approved usage terms" — unchanged in the source README — but dropped the now-inaccurate "not available for general public use".)
- **Download + prerequisite paragraphs** (`README.md`, `installation-and-first-run.md`): point at the [community downloads page](https://mariadb.com/downloads/community/) instead of the Enterprise Tooling section; `mariadb-mtk` likewise.
- **Landing page:** added **Feedback** and **License** sections (MariaDB Software License Terms + MariaDB Terms), per Manoj's review.

## One deviation from the review request
Manoj also asked to link "MariaDB Enterprise GIT" → `github.com/mariadb-corporation/Mysql-to-MariaDB-Migration/releases`. **Omitted:** that repo is private, so the URL 404s for the public and would break the lychee link check. The community downloads page is the public source. If the releases should be linked, the repo (or its releases) needs to be public first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6271]: https://mariadbcorp.atlassian.net/browse/DOCS-6271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ