### PR TITLE
Add missing link in docs

### DIFF
--- a/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
+++ b/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
@@ -81,8 +81,10 @@ asyncFunction().then(() => {
 });
 ```
 
-The MariaDB Connector can use different APIs on the back-end: [Promise](connector-nodejs-promise-api.md) and [Callback](connector-nodejs-callback-api.md).
-API is the same for TypeScript, but please read specific   
-The default API is Promise. The callback API is provided for compatibility with the mysql and mysql2 APIs.
+The MariaDB Connector has a [Promise](connector-nodejs-promise-api.md) *(Default)* and [callback](connector-nodejs-callback-api.md)[^1] API.
+
+[Typescript specific docs are also available](https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api#typescript-usage).
+
+[^1]: The callback API is provided for compatibility with the mysql and mysql2 APIs.
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
+++ b/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
@@ -83,7 +83,7 @@ asyncFunction().then(() => {
 
 The MariaDB Connector has a [Promise](connector-nodejs-promise-api.md) *(Default)* and [callback](connector-nodejs-callback-api.md)[^1] API.
 
-[Typescript specific docs are also available](https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api#typescript-usage).
+[Typescript specific docs are also available](../mariadb-connector-nodejs/connector-nodejs-promise-api#typescript-usage).
 
 [^1]: The callback API is provided for compatibility with the mysql and mysql2 APIs.
 


### PR DESCRIPTION
Hi,

The "Getting Started With the Node.js Connector" documentation page has a sentence that seems to be incomplete. I've added what I presume is the missing link to the Typescript docs. I've also slightly altered the sentence for readability.

Page in question: https://mariadb.com/docs/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector

You can let me know if this is helpful or not.

Thanks,

Brian