### PR TITLE
DOCS-6126: Document FORMAT JSON columns in JSON_TABLE

### DIFF
--- a/server/reference/sql-functions/special-functions/json-functions/json_table.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json_table.md
@@ -31,6 +31,7 @@ column_list:
 column:
     name FOR ORDINALITY
     |  name type PATH path_str [on_empty] [on_error]
+    |  name type FORMAT JSON PATH path_str [on_empty] [on_error]
     |  name type EXISTS PATH path_str
     |  NESTED PATH path_str COLUMNS (column_list)
 ```
@@ -89,6 +90,45 @@ SELECT * FROM json_table(@json, '$[*]'
 ```
 
 The `on_empty` and `on_error` clauses specify the actions to be performed when the value was not found or there was an error condition. See the `ON EMPTY` and `ON ERROR` clauses section for details.
+
+#### FORMAT JSON Columns
+
+{% hint style="info" %}
+`FORMAT JSON` columns are available from MariaDB 13.1.1.
+{% endhint %}
+
+```sql
+name type FORMAT JSON PATH path_str [on_empty] [on_error]
+```
+
+Like a path column, but returns the JSON value located by `path_str` as-is, serialized to text — including arrays and objects, not only scalar values. This is useful for pulling a nested array or object into a single column without expanding it into multiple rows with `NESTED PATH`.
+
+The column must be declared with a string type, such as [VARCHAR](../../../data-types/string-data-types/varchar.md) or [TEXT](../../../data-types/string-data-types/text.md). Using `FORMAT JSON` with a non-string type raises an error.
+
+```sql
+SET @json='
+[
+  {"name":"Jeans",   "sizes": [32, 34, 36]},
+  {"name":"T-Shirt", "sizes":["Medium", "Large"]},
+  {"name":"Cellphone"}
+]';
+
+SELECT * FROM JSON_TABLE(@json, '$[*]'
+  COLUMNS(
+    name  VARCHAR(10)  PATH '$.name',
+    sizes VARCHAR(100) FORMAT JSON PATH '$.sizes'
+  )
+) AS jt;
++-----------+---------------------+
+| name      | sizes               |
++-----------+---------------------+
+| Jeans     | [32, 34, 36]        |
+| T-Shirt   | ["Medium", "Large"] |
+| Cellphone | NULL                |
++-----------+---------------------+
+```
+
+Without `FORMAT JSON`, a path column returns only scalar values; locating an array or object instead triggers the `ON ERROR` behavior (`NULL` by default). A column declared with the [JSON](../../../data-types/string-data-types/json.md) type applies `FORMAT JSON` implicitly — see [Extracting a Subdocument into a Column](#extracting-a-subdocument-into-a-column).
 
 #### ORDINALITY Columns
 


### PR DESCRIPTION
Documents the new `FORMAT JSON` column support in `JSON_TABLE` ([MDEV-25727](https://jira.mariadb.org/browse/MDEV-25727), release series 13.1).

## What changed

`server/reference/sql-functions/special-functions/json-functions/json_table.md`:

- Added the `name type FORMAT JSON PATH path_str [on_empty] [on_error]` variant to the `column:` grammar block.
- New **FORMAT JSON Columns** subsection covering:
  - the syntax and that it returns the located JSON value (arrays/objects/scalars) serialized to text, unlike a plain path column which returns scalars only;
  - the string-type requirement (non-string types raise an error);
  - a worked example (the ticket's `sizes` example);
  - the cross-reference that a `JSON`-typed column applies `FORMAT JSON` implicitly.

## Source verification

Verified against `mariadb-server` @ `dcb8fdc739c30622928f4d17fdef54f6dfbd34e6` (main, 13.1.0-alpha); feature commit `c3ec2dc368a`. Full claim→source table is posted to the Jira ticket on handoff.

- Syntax — `sql/sql_yacc.yy:12369`
- Serialized output — `sql/json_table.cc:617`
- String-type requirement — `sql/json_table.cc:934`
- Implicit FORMAT JSON for JSON-typed columns — `sql/json_table.cc:631`

**One caveat:** the "available from MariaDB 13.1.1" hint is the ticket's planned fixVersion — the feature is in `main` but not in any release tag yet, so the exact first-release version isn't source-provable. Confirm at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)