### PR TITLE
DOCS-6298 Fix railroad-backed BNF errors in data-manipulation pages

### DIFF
--- a/server/.gitbook/assets/delete-railroad.svg
+++ b/server/.gitbook/assets/delete-railroad.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="897" height="441">
+<svg xmlns="http://www.w3.org/2000/svg" width="985" height="407">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -78,192 +78,191 @@
       <rect x="647" y="1" width="80" height="32" class="nonterminal"/>
       <text class="nonterminal" x="657" y="21">tbl_name</text>
    </a>
-   <rect x="295" y="117" width="98" height="32" rx="10"/>
-   <rect x="293"
-         y="115"
+   <rect x="789" y="67" width="38" height="32" rx="10"/>
+   <rect x="787"
+         y="65"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="797" y="85">AS</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#alias"
+      xlink:title="alias">
+      <rect x="867" y="35" width="50" height="32"/>
+      <rect x="865" y="33" width="50" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="875" y="53">alias</text>
+   </a>
+   <rect x="339" y="149" width="98" height="32" rx="10"/>
+   <rect x="337"
+         y="147"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="303" y="135">PARTITION</text>
-   <rect x="413" y="117" width="26" height="32" rx="10"/>
-   <rect x="411"
-         y="115"
+   <text class="terminal" x="347" y="167">PARTITION</text>
+   <rect x="457" y="149" width="26" height="32" rx="10"/>
+   <rect x="455"
+         y="147"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="421" y="135">(</text>
+   <text class="terminal" x="465" y="167">(</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#partition_list"
       xlink:title="partition_list">
-      <rect x="459" y="117" width="100" height="32"/>
-      <rect x="457" y="115" width="100" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="467" y="135">partition_list</text>
+      <rect x="503" y="149" width="100" height="32"/>
+      <rect x="501" y="147" width="100" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="511" y="167">partition_list</text>
    </a>
-   <rect x="579" y="117" width="26" height="32" rx="10"/>
-   <rect x="577"
-         y="115"
+   <rect x="623" y="149" width="26" height="32" rx="10"/>
+   <rect x="621"
+         y="147"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="587" y="135">)</text>
-   <rect x="69" y="199" width="48" height="32" rx="10"/>
-   <rect x="67"
-         y="197"
+   <text class="terminal" x="631" y="167">)</text>
+   <rect x="45" y="231" width="48" height="32" rx="10"/>
+   <rect x="43"
+         y="229"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="77" y="217">FOR</text>
-   <rect x="137" y="199" width="84" height="32" rx="10"/>
-   <rect x="135"
-         y="197"
+   <text class="terminal" x="53" y="249">FOR</text>
+   <rect x="113" y="231" width="84" height="32" rx="10"/>
+   <rect x="111"
+         y="229"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="217">PORTION</text>
-   <rect x="241" y="199" width="38" height="32" rx="10"/>
-   <rect x="239"
-         y="197"
+   <text class="terminal" x="121" y="249">PORTION</text>
+   <rect x="217" y="231" width="38" height="32" rx="10"/>
+   <rect x="215"
+         y="229"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="249" y="217">OF</text>
-   <rect x="299" y="199" width="74" height="32" rx="10"/>
-   <rect x="297"
-         y="197"
-         width="74"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="307" y="217">PERIOD</text>
-   <rect x="393" y="199" width="60" height="32" rx="10"/>
-   <rect x="391"
-         y="197"
+   <text class="terminal" x="225" y="249">OF</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#period_name"
+      xlink:title="period_name">
+      <rect x="275" y="231" width="104" height="32"/>
+      <rect x="273" y="229" width="104" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="283" y="249">period_name</text>
+   </a>
+   <rect x="399" y="231" width="60" height="32" rx="10"/>
+   <rect x="397"
+         y="229"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="401" y="217">FROM</text>
+   <text class="terminal" x="407" y="249">FROM</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#expr1"
       xlink:title="expr1">
-      <rect x="473" y="199" width="56" height="32"/>
-      <rect x="471" y="197" width="56" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="481" y="217">expr1</text>
+      <rect x="479" y="231" width="56" height="32"/>
+      <rect x="477" y="229" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="487" y="249">expr1</text>
    </a>
-   <rect x="549" y="199" width="38" height="32" rx="10"/>
-   <rect x="547"
-         y="197"
+   <rect x="555" y="231" width="38" height="32" rx="10"/>
+   <rect x="553"
+         y="229"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="557" y="217">TO</text>
+   <text class="terminal" x="563" y="249">TO</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#expr2"
       xlink:title="expr2">
-      <rect x="607" y="199" width="56" height="32"/>
-      <rect x="605" y="197" width="56" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="615" y="217">expr2</text>
+      <rect x="613" y="231" width="56" height="32"/>
+      <rect x="611" y="229" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="621" y="249">expr2</text>
    </a>
-   <rect x="723" y="199" width="38" height="32" rx="10"/>
-   <rect x="721"
-         y="197"
-         width="38"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="731" y="217">AS</text>
-   <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#alias"
-      xlink:title="alias">
-      <rect x="781" y="199" width="50" height="32"/>
-      <rect x="779" y="197" width="50" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="789" y="217">alias</text>
-   </a>
-   <rect x="45" y="281" width="70" height="32" rx="10"/>
-   <rect x="43"
-         y="279"
+   <rect x="729" y="231" width="70" height="32" rx="10"/>
+   <rect x="727"
+         y="229"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="299">WHERE</text>
+   <text class="terminal" x="737" y="249">WHERE</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#where_condition"
       xlink:title="where_condition">
-      <rect x="135" y="281" width="124" height="32"/>
-      <rect x="133" y="279" width="124" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="143" y="299">where_condition</text>
+      <rect x="819" y="231" width="124" height="32"/>
+      <rect x="817" y="229" width="124" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="827" y="249">where_condition</text>
    </a>
-   <rect x="319" y="281" width="68" height="32" rx="10"/>
-   <rect x="317"
-         y="279"
+   <rect x="87" y="373" width="68" height="32" rx="10"/>
+   <rect x="85"
+         y="371"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="327" y="299">ORDER</text>
-   <rect x="407" y="281" width="38" height="32" rx="10"/>
-   <rect x="405"
-         y="279"
+   <text class="terminal" x="95" y="391">ORDER</text>
+   <rect x="175" y="373" width="38" height="32" rx="10"/>
+   <rect x="173"
+         y="371"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="415" y="299">BY</text>
+   <text class="terminal" x="183" y="391">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#order_by_specification"
       xlink:title="order_by_specification">
-      <rect x="465" y="281" width="164" height="32"/>
-      <rect x="463" y="279" width="164" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="473" y="299">order_by_specification</text>
+      <rect x="233" y="373" width="164" height="32"/>
+      <rect x="231" y="371" width="164" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="241" y="391">order_by_specification</text>
    </a>
-   <rect x="689" y="281" width="60" height="32" rx="10"/>
-   <rect x="687"
-         y="279"
+   <rect x="457" y="373" width="60" height="32" rx="10"/>
+   <rect x="455"
+         y="371"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="697" y="299">LIMIT</text>
+   <text class="terminal" x="465" y="391">LIMIT</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#row_count"
       xlink:title="row_count">
-      <rect x="769" y="281" width="86" height="32"/>
-      <rect x="767" y="279" width="86" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="777" y="299">row_count</text>
+      <rect x="537" y="373" width="86" height="32"/>
+      <rect x="535" y="371" width="86" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="545" y="391">row_count</text>
    </a>
-   <rect x="595" y="391" width="100" height="32" rx="10"/>
-   <rect x="593"
-         y="389"
+   <rect x="683" y="341" width="100" height="32" rx="10"/>
+   <rect x="681"
+         y="339"
          width="100"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="603" y="409">RETURNING</text>
+   <text class="terminal" x="691" y="359">RETURNING</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#select_expr"
       xlink:title="select_expr">
-      <rect x="735" y="391" width="94" height="32"/>
-      <rect x="733" y="389" width="94" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="743" y="409">select_expr</text>
+      <rect x="823" y="341" width="94" height="32"/>
+      <rect x="821" y="339" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="831" y="359">select_expr</text>
    </a>
-   <rect x="735" y="347" width="24" height="32" rx="10"/>
-   <rect x="733"
-         y="345"
+   <rect x="823" y="297" width="24" height="32" rx="10"/>
+   <rect x="821"
+         y="295"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="743" y="365">,</text>
+   <text class="terminal" x="831" y="315">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -32 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-498 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-620 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h604 m-634 0 h20 m614 0 h20 m-654 0 q10 0 10 10 m634 0 q0 -10 10 -10 m-644 10 v12 m634 0 v-12 m-634 12 q0 10 10 10 m614 0 q10 0 10 -10 m-624 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h118 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v12 m148 0 v-12 m-148 12 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m38 0 h10 m0 0 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-870 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m70 0 h10 m0 0 h10 m124 0 h10 m40 -32 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m164 0 h10 m40 -32 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m60 0 h10 m0 0 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-344 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
-   <polygon points="887 405 895 401 895 409"/>
-   <polygon points="887 405 879 401 879 409"/>
+         d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -32 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-158 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m50 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-662 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m98 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-688 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h634 m-664 0 h20 m644 0 h20 m-684 0 q10 0 10 10 m664 0 q0 -10 10 -10 m-674 10 v12 m664 0 v-12 m-664 12 q0 10 10 10 m644 0 q10 0 10 -10 m-654 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m104 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m70 0 h10 m0 0 h10 m124 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-940 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h320 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v12 m350 0 v-12 m-350 12 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m68 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m164 0 h10 m40 -32 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m60 0 h10 m0 0 h10 m86 0 h10 m40 -32 h10 m100 0 h10 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m-274 44 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m23 -34 h-3"/>
+   <polygon points="975 355 983 351 983 359"/>
+   <polygon points="975 355 967 351 967 359"/>
 </svg>

--- a/server/.gitbook/assets/load-data-infile-railroad.svg
+++ b/server/.gitbook/assets/load-data-infile-railroad.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1229" height="783">
+<svg xmlns="http://www.w3.org/2000/svg" width="1229" height="827">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -121,203 +121,234 @@
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#tbl_name"
       xlink:title="tbl_name">
-      <rect x="398" y="145" width="80" height="32"/>
-      <rect x="396" y="143" width="80" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="406" y="163">tbl_name</text>
+      <rect x="185" y="189" width="80" height="32"/>
+      <rect x="183" y="187" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="193" y="207">tbl_name</text>
    </a>
-   <rect x="518" y="177" width="102" height="32" rx="10"/>
-   <rect x="516"
-         y="175"
+   <rect x="305" y="189" width="98" height="32" rx="10"/>
+   <rect x="303"
+         y="187"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="313" y="207">PARTITION</text>
+   <rect x="423" y="189" width="26" height="32" rx="10"/>
+   <rect x="421"
+         y="187"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="431" y="207">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#partition_name"
+      xlink:title="partition_name">
+      <rect x="489" y="189" width="116" height="32"/>
+      <rect x="487" y="187" width="116" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="497" y="207">partition_name</text>
+   </a>
+   <rect x="489" y="145" width="24" height="32" rx="10"/>
+   <rect x="487"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="497" y="163">,</text>
+   <rect x="645" y="189" width="26" height="32" rx="10"/>
+   <rect x="643"
+         y="187"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="653" y="207">)</text>
+   <rect x="731" y="221" width="102" height="32" rx="10"/>
+   <rect x="729"
+         y="219"
          width="102"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="526" y="195">CHARACTER</text>
-   <rect x="640" y="177" width="44" height="32" rx="10"/>
-   <rect x="638"
-         y="175"
+   <text class="terminal" x="739" y="239">CHARACTER</text>
+   <rect x="853" y="221" width="44" height="32" rx="10"/>
+   <rect x="851"
+         y="219"
          width="44"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="648" y="195">SET</text>
+   <text class="terminal" x="861" y="239">SET</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#charset_name"
       xlink:title="charset_name">
-      <rect x="704" y="177" width="110" height="32"/>
-      <rect x="702" y="175" width="110" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="712" y="195">charset_name</text>
+      <rect x="917" y="221" width="110" height="32"/>
+      <rect x="915" y="219" width="110" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="925" y="239">charset_name</text>
    </a>
-   <rect x="65" y="259" width="70" height="32" rx="10"/>
+   <rect x="65" y="303" width="70" height="32" rx="10"/>
    <rect x="63"
-         y="257"
+         y="301"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="277">FIELDS</text>
-   <rect x="65" y="303" width="88" height="32" rx="10"/>
+   <text class="terminal" x="73" y="321">FIELDS</text>
+   <rect x="65" y="347" width="88" height="32" rx="10"/>
    <rect x="63"
-         y="301"
+         y="345"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="321">COLUMNS</text>
-   <rect x="213" y="291" width="108" height="32" rx="10"/>
+   <text class="terminal" x="73" y="365">COLUMNS</text>
+   <rect x="213" y="335" width="108" height="32" rx="10"/>
    <rect x="211"
-         y="289"
+         y="333"
          width="108"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="221" y="309">TERMINATED</text>
-   <rect x="341" y="291" width="38" height="32" rx="10"/>
+   <text class="terminal" x="221" y="353">TERMINATED</text>
+   <rect x="341" y="335" width="38" height="32" rx="10"/>
    <rect x="339"
-         y="289"
+         y="333"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="349" y="309">BY</text>
+   <text class="terminal" x="349" y="353">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#string"
       xlink:title="string">
-      <rect x="399" y="291" width="56" height="32"/>
-      <rect x="397" y="289" width="56" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="407" y="309">string</text>
+      <rect x="399" y="335" width="56" height="32"/>
+      <rect x="397" y="333" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="407" y="353">string</text>
    </a>
-   <rect x="535" y="323" width="110" height="32" rx="10"/>
+   <rect x="535" y="367" width="110" height="32" rx="10"/>
    <rect x="533"
-         y="321"
+         y="365"
          width="110"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="543" y="341">OPTIONALLY</text>
-   <rect x="685" y="291" width="92" height="32" rx="10"/>
+   <text class="terminal" x="543" y="385">OPTIONALLY</text>
+   <rect x="685" y="335" width="92" height="32" rx="10"/>
    <rect x="683"
-         y="289"
+         y="333"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="693" y="309">ENCLOSED</text>
-   <rect x="797" y="291" width="38" height="32" rx="10"/>
+   <text class="terminal" x="693" y="353">ENCLOSED</text>
+   <rect x="797" y="335" width="38" height="32" rx="10"/>
    <rect x="795"
-         y="289"
+         y="333"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="805" y="309">BY</text>
+   <text class="terminal" x="805" y="353">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#char"
       xlink:title="char">
-      <rect x="855" y="291" width="46" height="32"/>
-      <rect x="853" y="289" width="46" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="863" y="309">char</text>
+      <rect x="855" y="335" width="46" height="32"/>
+      <rect x="853" y="333" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="863" y="353">char</text>
    </a>
-   <rect x="961" y="291" width="82" height="32" rx="10"/>
+   <rect x="961" y="335" width="82" height="32" rx="10"/>
    <rect x="959"
-         y="289"
+         y="333"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="969" y="309">ESCAPED</text>
-   <rect x="1063" y="291" width="38" height="32" rx="10"/>
+   <text class="terminal" x="969" y="353">ESCAPED</text>
+   <rect x="1063" y="335" width="38" height="32" rx="10"/>
    <rect x="1061"
-         y="289"
+         y="333"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="1071" y="309">BY</text>
+   <text class="terminal" x="1071" y="353">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#char"
       xlink:title="char">
-      <rect x="1121" y="291" width="46" height="32"/>
-      <rect x="1119" y="289" width="46" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="1129" y="309">char</text>
+      <rect x="1121" y="335" width="46" height="32"/>
+      <rect x="1119" y="333" width="46" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1129" y="353">char</text>
    </a>
-   <rect x="292" y="405" width="62" height="32" rx="10"/>
+   <rect x="292" y="449" width="62" height="32" rx="10"/>
    <rect x="290"
-         y="403"
+         y="447"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="300" y="423">LINES</text>
-   <rect x="394" y="437" width="90" height="32" rx="10"/>
+   <text class="terminal" x="300" y="467">LINES</text>
+   <rect x="394" y="481" width="90" height="32" rx="10"/>
    <rect x="392"
-         y="435"
+         y="479"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="402" y="455">STARTING</text>
-   <rect x="504" y="437" width="38" height="32" rx="10"/>
+   <text class="terminal" x="402" y="499">STARTING</text>
+   <rect x="504" y="481" width="38" height="32" rx="10"/>
    <rect x="502"
-         y="435"
+         y="479"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="512" y="455">BY</text>
+   <text class="terminal" x="512" y="499">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#string"
       xlink:title="string">
-      <rect x="562" y="437" width="56" height="32"/>
-      <rect x="560" y="435" width="56" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="570" y="455">string</text>
+      <rect x="562" y="481" width="56" height="32"/>
+      <rect x="560" y="479" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="570" y="499">string</text>
    </a>
-   <rect x="678" y="437" width="108" height="32" rx="10"/>
+   <rect x="678" y="481" width="108" height="32" rx="10"/>
    <rect x="676"
-         y="435"
+         y="479"
          width="108"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="686" y="455">TERMINATED</text>
-   <rect x="806" y="437" width="38" height="32" rx="10"/>
+   <text class="terminal" x="686" y="499">TERMINATED</text>
+   <rect x="806" y="481" width="38" height="32" rx="10"/>
    <rect x="804"
-         y="435"
+         y="479"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="814" y="455">BY</text>
+   <text class="terminal" x="814" y="499">BY</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#string"
       xlink:title="string">
-      <rect x="864" y="437" width="56" height="32"/>
-      <rect x="862" y="435" width="56" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="872" y="455">string</text>
+      <rect x="864" y="481" width="56" height="32"/>
+      <rect x="862" y="479" width="56" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="872" y="499">string</text>
    </a>
-   <rect x="295" y="579" width="74" height="32" rx="10"/>
+   <rect x="295" y="623" width="74" height="32" rx="10"/>
    <rect x="293"
-         y="577"
+         y="621"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="303" y="597">IGNORE</text>
+   <text class="terminal" x="303" y="641">IGNORE</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#number"
       xlink:title="number">
-      <rect x="389" y="579" width="68" height="32"/>
-      <rect x="387" y="577" width="68" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="397" y="597">number</text>
+      <rect x="389" y="623" width="68" height="32"/>
+      <rect x="387" y="621" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="397" y="641">number</text>
    </a>
-   <rect x="497" y="579" width="62" height="32" rx="10"/>
-   <rect x="495"
-         y="577"
-         width="62"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="505" y="597">LINES</text>
    <rect x="497" y="623" width="62" height="32" rx="10"/>
    <rect x="495"
          y="621"
@@ -325,78 +356,86 @@
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="505" y="641">ROWS</text>
-   <rect x="639" y="547" width="26" height="32" rx="10"/>
+   <text class="terminal" x="505" y="641">LINES</text>
+   <rect x="497" y="667" width="62" height="32" rx="10"/>
+   <rect x="495"
+         y="665"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="685">ROWS</text>
+   <rect x="639" y="591" width="26" height="32" rx="10"/>
    <rect x="637"
-         y="545"
+         y="589"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="647" y="565">(</text>
+   <text class="terminal" x="647" y="609">(</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#col_name_or_user_var"
       xlink:title="col_name_or_user_var">
-      <rect x="705" y="547" width="166" height="32"/>
-      <rect x="703" y="545" width="166" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="713" y="565">col_name_or_user_var</text>
+      <rect x="705" y="591" width="166" height="32"/>
+      <rect x="703" y="589" width="166" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="713" y="609">col_name_or_user_var</text>
    </a>
-   <rect x="705" y="503" width="24" height="32" rx="10"/>
+   <rect x="705" y="547" width="24" height="32" rx="10"/>
    <rect x="703"
-         y="501"
+         y="545"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="713" y="521">,</text>
-   <rect x="911" y="547" width="26" height="32" rx="10"/>
+   <text class="terminal" x="713" y="565">,</text>
+   <rect x="911" y="591" width="26" height="32" rx="10"/>
    <rect x="909"
-         y="545"
+         y="589"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="919" y="565">)</text>
-   <rect x="879" y="733" width="44" height="32" rx="10"/>
+   <text class="terminal" x="919" y="609">)</text>
+   <rect x="879" y="777" width="44" height="32" rx="10"/>
    <rect x="877"
-         y="731"
+         y="775"
          width="44"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="887" y="751">SET</text>
+   <text class="terminal" x="887" y="795">SET</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#col_name"
       xlink:title="col_name">
-      <rect x="963" y="733" width="80" height="32"/>
-      <rect x="961" y="731" width="80" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="971" y="751">col_name</text>
+      <rect x="963" y="777" width="80" height="32"/>
+      <rect x="961" y="775" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="971" y="795">col_name</text>
    </a>
-   <rect x="1063" y="733" width="30" height="32" rx="10"/>
+   <rect x="1063" y="777" width="30" height="32" rx="10"/>
    <rect x="1061"
-         y="731"
+         y="775"
          width="30"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="1071" y="751">=</text>
+   <text class="terminal" x="1071" y="795">=</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#expr"
       xlink:title="expr">
-      <rect x="1113" y="733" width="48" height="32"/>
-      <rect x="1111" y="731" width="48" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="1121" y="751">expr</text>
+      <rect x="1113" y="777" width="48" height="32"/>
+      <rect x="1111" y="775" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="1121" y="795">expr</text>
    </a>
-   <rect x="963" y="689" width="24" height="32" rx="10"/>
+   <rect x="963" y="733" width="24" height="32" rx="10"/>
    <rect x="961"
-         y="687"
+         y="731"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="971" y="707">,</text>
+   <text class="terminal" x="971" y="751">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m114 0 h10 m0 0 h16 m40 -76 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m66 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m74 0 h10 m0 0 h6 m20 -76 h10 m56 0 h10 m0 0 h10 m62 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-611 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m0 0 h306 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v12 m336 0 v-12 m-336 12 q0 10 10 10 m316 0 q10 0 10 -10 m-326 10 h10 m102 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m110 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-853 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1152 m-1182 0 h20 m1162 0 h20 m-1202 0 q10 0 10 10 m1182 0 q0 -10 10 -10 m-1192 10 v12 m1182 0 v-12 m-1182 12 q0 10 10 10 m1162 0 q10 0 10 -10 m-1152 10 h10 m70 0 h10 m0 0 h18 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h396 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v12 m426 0 v-12 m-426 12 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -32 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m82 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-979 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m62 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-729 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-314 10 h10 m74 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m62 0 h10 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -76 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m44 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-238 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m218 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-218 0 h10 m24 0 h10 m0 0 h174 m-322 44 h20 m322 0 h20 m-362 0 q10 0 10 10 m342 0 q0 -10 10 -10 m-352 10 v14 m342 0 v-14 m-342 14 q0 10 10 10 m322 0 q10 0 10 -10 m-332 10 h10 m0 0 h312 m23 -34 h-3"/>
-   <polygon points="1219 747 1227 743 1227 751"/>
-   <polygon points="1219 747 1211 743 1211 751"/>
+         d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m114 0 h10 m0 0 h16 m40 -76 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m66 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m74 0 h10 m0 0 h6 m20 -76 h10 m56 0 h10 m0 0 h10 m62 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-824 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m20 44 h10 m26 0 h10 m-406 0 h20 m386 0 h20 m-426 0 q10 0 10 10 m406 0 q0 -10 10 -10 m-416 10 v14 m406 0 v-14 m-406 14 q0 10 10 10 m386 0 q10 0 10 -10 m-396 10 h10 m0 0 h376 m40 -34 h10 m0 0 h306 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v12 m336 0 v-12 m-336 12 q0 10 10 10 m316 0 q10 0 10 -10 m-326 10 h10 m102 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m110 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-1066 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h1152 m-1182 0 h20 m1162 0 h20 m-1202 0 q10 0 10 10 m1182 0 q0 -10 10 -10 m-1192 10 v12 m1182 0 v-12 m-1182 12 q0 10 10 10 m1162 0 q10 0 10 -10 m-1152 10 h10 m70 0 h10 m0 0 h18 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h396 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v12 m426 0 v-12 m-426 12 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -32 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m82 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m46 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-979 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m62 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m108 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m56 0 h10 m42 -64 l2 0 m2 0 l2 0 m2 0 l2 0 m-729 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-314 10 h10 m74 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m62 0 h10 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -76 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m44 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m-238 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m218 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-218 0 h10 m24 0 h10 m0 0 h174 m-322 44 h20 m322 0 h20 m-362 0 q10 0 10 10 m342 0 q0 -10 10 -10 m-352 10 v14 m342 0 v-14 m-342 14 q0 10 10 10 m322 0 q10 0 10 -10 m-332 10 h10 m0 0 h312 m23 -34 h-3"/>
+   <polygon points="1219 791 1227 787 1227 795"/>
+   <polygon points="1219 791 1211 787 1211 795"/>
 </svg>

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete.md
@@ -17,9 +17,9 @@ Single-table syntax:
 
 ```bnf
 DELETE [LOW_PRIORITY] [QUICK] [IGNORE] 
-  FROM tbl_name [PARTITION (partition_list)]
-  [FOR PORTION OF PERIOD FROM expr1 TO expr2]
-  [AS alias]                    -- from MariaDB 11.6
+  FROM tbl_name [[AS] alias]    -- alias from MariaDB 11.6
+  [PARTITION (partition_list)]
+  [FOR PORTION OF period_name FROM expr1 TO expr2]
   [{USE|FORCE|IGNORE} {INDEX|KEY}
     [FOR {JOIN|ORDER BY|GROUP BY}]
     (index_list)]               -- from MariaDB 11.8.1

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/update.md
@@ -25,7 +25,6 @@ UPDATE [LOW_PRIORITY] [IGNORE] table_reference
   [LIMIT row_count]
   [RETURNING select_expr 
     [, select_expr ...]]
-  RETURNING OLD_VALUE(val) AS old [, val as new]
 ```
 
 ![Railroad diagram of single-table UPDATE — equivalent to the BNF above](../../../../.gitbook/assets/update-railroad.svg)

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md
@@ -12,6 +12,7 @@ description: >-
 LOAD DATA [LOW_PRIORITY | CONCURRENT] [LOCAL] INFILE 'file_name'
     [REPLACE | IGNORE]
     INTO TABLE tbl_name
+    [PARTITION (partition_name, ...)]
     [CHARACTER SET charset_name]
     [{FIELDS | COLUMNS}
         [TERMINATED BY 'string']


### PR DESCRIPTION
Follow-up to [DOCS-6290](https://mariadbcorp.atlassian.net/browse/DOCS-6290) — the BNF findings deferred because each `bnf` block is mirrored by a generated railroad SVG. Fixes the BNF text **and** regenerates the diagrams so the two stay in sync.

## Diagram regeneration

The SVGs were reproduced with the same tool that made them (bottlecaps **RR** Railroad Diagram Generator, default theme). Fidelity-checked: regenerating each diagram from the *un*corrected EBNF produced output **byte-identical** to the committed SVG, so the corrected versions match the existing house style exactly.

## Changes

- **`delete.md`** + `delete-railroad.svg` — move `[[AS] alias]` ahead of `[PARTITION …]` / `[FOR PORTION OF …]` (the grammar's `delete_single_table` parses the alias first), and render the period token as the user-supplied name `period_name` rather than the literal `PERIOD` (`sql_yacc.yy:9559` parses an `ident`).
- **`load-data-infile.md`** + `load-data-infile-railroad.svg` — add the optional `[PARTITION (partition_name, …)]` clause after `INTO TABLE tbl_name` (`opt_use_partition`).
- **`update.md`** — collapse the single-table BNF to one `RETURNING select_expr` clause and drop the misleading standalone `RETURNING OLD_VALUE(…)` line. `OLD_VALUE()` is already documented in the note below the BNF. **No SVG change** — `update-railroad.svg` already showed a single RETURNING.

All re-verified against `mariadb-server @ dcb8fdc7`.

Note (out of scope): `delete-railroad.svg` still omits the `[{USE|FORCE|IGNORE} {INDEX|KEY} …]` index-hint clause that the BNF lists — a pre-existing gap from the original diagram, not part of this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6290]: https://mariadbcorp.atlassian.net/browse/DOCS-6290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ