### PR TITLE
DOCS-6296 Clarify Enterprise Server release identifiers vs Community point releases

### DIFF
--- a/release-notes/enterprise-server/about/enterprise-server-lifecycle.md
+++ b/release-notes/enterprise-server/about/enterprise-server-lifecycle.md
@@ -57,6 +57,15 @@ Releases of MariaDB Enterprise Server are given an identifier such as 'MariaDB E
 * The release postfix of MariaDB Enterprise Server starts with '-1' and is incremented for subsequent releases in that release series (-5, spoken "ten-five-eight-dash-five").
 * On the Debian and Ubuntu platforms, the release postfix contains a period instead of a dash, such that release postfixes start with .1 and increment for subsequent releases in that release series (.5, spoken "ten-five-eight-dot-five").
 
+{% hint style="info" %}
+**Note:** The release postfix (for example, the `-4` in `11.8.6-4`) increases consecutively with each new Enterprise Server release in a series, but the Community Server point release it is based on does not. As a result:
+
+* An Enterprise Server release can **skip** a Community Server point release. For example, `11.8.6-4` is followed by `11.8.8-5`, skipping `11.8.7`.
+* Two consecutive Enterprise Server releases can be based on the **same** Community Server point release. For example, `11.8.6-3` is followed by `11.8.6-4`.
+
+The release postfix — not the point release — is the reliable indicator of release order.
+{% endhint %}
+
 Additional information on the release numbering for MariaDB Enterprise Server can be found in [MariaDB Corporation Engineering Policy](https://mariadb.com/engineering-policies).
 
 ## Enterprise Server Support <a href="#enterprise-server-support" id="enterprise-server-support"></a>


### PR DESCRIPTION
## Summary

Adds a note to the **Enterprise Server Release Identifiers** section of the Enterprise Server Lifecycle page, clarifying that Enterprise Server (ES) releases are not fully in sync with Community Server (CS) point releases.

The release postfix (e.g. the `-4` in `11.8.6-4`) increments consecutively with each ES release in a series, but the CS point release it is based on does not. As a result, ES can:

- **skip** a CS point release (e.g. `11.8.6-4` → `11.8.8-5`, skipping `11.8.7`), or
- ship **two consecutive** releases on the **same** CS point release (e.g. `11.8.6-3` → `11.8.6-4`).

The postfix — not the point release — is the reliable indicator of release order.

Addresses [DOCS-6296](https://mariadbcorp.atlassian.net/browse/DOCS-6296) (customer confusion over a jump like `10.6.25-23` → `10.6.27-24`).

## Verification

All examples verified against the shipped ES release history (the `release-notes/enterprise-server/{10.6,11.4,11.8}/` per-release files): postfixes are gapless across each series, while point releases are both skipped and repeated. The ticket's original "skip" example ran backwards and was corrected to a real forward example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6296]: https://mariadbcorp.atlassian.net/browse/DOCS-6296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ