### PR TITLE
DOCS-6301 Correct temp-table encryption variable name in TDE docs

### DIFF
--- a/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
+++ b/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
@@ -140,7 +140,7 @@ You can encrypt a number of database objects by setting the respective variables
 
 * InnoDB user tables – [innodb\_encrypt\_tables](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encrypt_tables)
 * InnoDB redo log – [innodb\_encrypt\_log](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encrypt_log)
-* InnoDB temporary files – [encrypt\_temporary\_tables](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encrypt_temporary_tables)\
+* InnoDB temporary files – [innodb\_encrypt\_temporary\_tables](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_encrypt_temporary_tables)\
   MariaDB creates temporary files on disk, for instance, files used for file sorts. It is recommended to encrypt those, too.
 * Aria user tables – [aria\_encrypt\_tables](../../../server-usage/storage-engines/aria/aria-system-variables.md#aria_encrypt_tables)
 * Aria temporary tables – [encrypt\_tmp\_disk\_tables](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#encrypt_tmp_disk_tables)
@@ -152,7 +152,7 @@ To configure global encryption for all of those objects, add this to your config
 [mariadb]
 innodb_encrypt_tables = ON
 innodb_encrypt_log = ON
-encrypt_temporary_tables = ON
+innodb_encrypt_temporary_tables = ON
 aria_encrypt_tables = ON
 encrypt_tmp_disk_tables = ON
 ```


### PR DESCRIPTION
## What

Fixes [DOCS-6301](https://mariadbcorp.atlassian.net/browse/DOCS-6301) — a Contact Us report that the data-at-rest TDE fundamentals page lists the wrong InnoDB temporary-table encryption option.

In the **Enabling Data-at-Rest Encryption** step, the option was written as `encrypt_temporary_tables` in two places:

- the bullet link text (the anchor target was already correct), and
- the `my.cnf` example code block.

The actual system variable is **`innodb_encrypt_temporary_tables`**.

## Verification

Verified against MariaDB server source @ `dcb8fdc7` (ref `main`):

- `storage/innobase/handler/ha_innodb.cc:20378` — `MYSQL_SYSVAR_BOOL(encrypt_temporary_tables, innodb_encrypt_temporary_tables, …)`; the InnoDB plugin framework prepends `innodb_`, so the user-facing variable is `innodb_encrypt_temporary_tables`.
- `git grep -nw encrypt_temporary_tables` returns only the macro suffix — no standalone `encrypt_temporary_tables` variable exists.

The rest of the page already used the correct name (the verify query and the **Disabling Data-at-Rest Encryption** section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6301]: https://mariadbcorp.atlassian.net/browse/DOCS-6301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ