### PR TITLE
DOCS-6289 Note PARSEC authenticator available from MaxScale 25.10.0

### DIFF
--- a/maxscale/reference/maxscale-authenticators/maxscale-parsec-authenticator.md
+++ b/maxscale/reference/maxscale-authenticators/maxscale-parsec-authenticator.md
@@ -7,6 +7,10 @@ description: >-
 
 # MaxScale PARSEC Authenticator
 
+{% hint style="info" %}
+This functionality is available from MaxScale 25.10.0.
+{% endhint %}
+
 ## PARSEC Authenticator
 
 The [PARSEC](../../../server/reference/plugins/authentication-plugins/authentication-plugin-parsec.md) (Password Authentication using Response Signed with Elliptic Curve) authentication plugin uses salted passwords, key derivation, extensible password storage format, and both server-side and client-side scrambles.


### PR DESCRIPTION
## What

Adds a version-availability note to the [MaxScale PARSEC Authenticator](https://mariadb.com/docs/maxscale/reference/maxscale-authenticators/maxscale-parsec-authenticator) page, stating the plugin is available from **MaxScale 25.10.0**. Uses an `{% hint style="info" %}` block after the H1, matching the convention on the ExasolRouter page.

## Why

Per DOCS-6289: the page didn't mention which MaxScale version introduced PARSEC. The reporter noted it's listed in the 25.10.0 release notes but not on the plugin's own page.

## Verification

Fact-checked against MaxScale source:

- Introduced by **MXS-5130** (commit `504212b`, adds the `Parsec` authenticator module).
- First shipped in the **25.10 series** — listed in the 25.10.0 release notes as "MXS-5130 Support for PARSEC auth plugin".
- Absent from all `25.01.x` release tags and release notes, confirming `25.10.0` (not `25.10.1`) is the correct since-version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)