### PR TITLE
DOCS-6142: Add JSON Arrow Operators (-> and ->>) documentation

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -2035,6 +2035,7 @@
       * [JSON Functions](reference/sql-functions/special-functions/json-functions/README.md)
         * [JSONPath Expressions](reference/sql-functions/special-functions/json-functions/jsonpath-expressions.md)
         * [Differences between JSON\_QUERY and JSON\_VALUE](reference/sql-functions/special-functions/json-functions/differences-between-json_query-and-json_value.md)
+        * [JSON Arrow Operators](reference/sql-functions/special-functions/json-functions/json-arrow-operators.md)
         * [JSON\_ARRAY](reference/sql-functions/special-functions/json-functions/json_array.md)
         * [JSON\_ARRAYAGG](reference/sql-functions/special-functions/json-functions/json_arrayagg.md)
         * [JSON\_ARRAY\_APPEND](reference/sql-functions/special-functions/json-functions/json_array_append.md)

--- a/server/reference/sql-functions/special-functions/json-functions/json-arrow-operators.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json-arrow-operators.md
@@ -5,10 +5,6 @@ description: >-
   JSON_EXTRACT() and JSON_UNQUOTE(JSON_EXTRACT()), added for MySQL 5.7
   compatibility. Syntax, string-literal path restriction, chaining, and
   quoting behavior.
-# EDITORIAL NOTE (remove before publishing): Feature is on the
-# preview-13.1-preview branch only and not yet merged to main as of this
-# writing. Confirm the "MariaDB 13.1" version against the release notes
-# before this page goes live.
 ---
 
 # JSON Arrow Operators
@@ -23,7 +19,7 @@ json_doc ->> path
 ## Description
 
 {% hint style="info" %}
-The `->` and `->>` operators were introduced in **MariaDB 13.1** for MySQL 5.7 compatibility.
+The `->` and `->>` operators were introduced in MariaDB 13.1.
 {% endhint %}
 
 The `->` and `->>` operators are shorthand for extracting a value from a JSON document by a [JSONPath expression](jsonpath-expressions.md):
@@ -31,7 +27,7 @@ The `->` and `->>` operators are shorthand for extracting a value from a JSON do
 * `json_doc -> path` is equivalent to [`JSON_EXTRACT(json_doc, path)`](json_extract.md).
 * `json_doc ->> path` is equivalent to [`JSON_UNQUOTE`](json_unquote.md)`(`[`JSON_EXTRACT`](json_extract.md)`(json_doc, path))`.
 
-Both operators are purely syntactic sugar: they build the same expression as the equivalent function calls and inherit their `NULL` and error behavior. On the left, `json_doc` is any JSON expression — typically a column, a function result, or a JSON literal.
+MariaDB supports these operators for compatibility with MySQL 5.7 and later, where they originated. Each operator builds the same expression as its equivalent function call and inherits the same `NULL` and error behavior. On the left, `json_doc` is any JSON expression — typically a column, a function result, or a JSON literal.
 
 The two operators differ only in quoting:
 

--- a/server/reference/sql-functions/special-functions/json-functions/json-arrow-operators.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json-arrow-operators.md
@@ -1,0 +1,113 @@
+---
+title: JSON Arrow Operators
+description: >-
+  The MariaDB 13.1 JSON arrow operators -> and ->>: shorthand for
+  JSON_EXTRACT() and JSON_UNQUOTE(JSON_EXTRACT()), added for MySQL 5.7
+  compatibility. Syntax, string-literal path restriction, chaining, and
+  quoting behavior.
+# EDITORIAL NOTE (remove before publishing): Feature is on the
+# preview-13.1-preview branch only and not yet merged to main as of this
+# writing. Confirm the "MariaDB 13.1" version against the release notes
+# before this page goes live.
+---
+
+# JSON Arrow Operators
+
+## Syntax
+
+```bnf
+json_doc -> path
+json_doc ->> path
+```
+
+## Description
+
+{% hint style="info" %}
+The `->` and `->>` operators were introduced in **MariaDB 13.1** for MySQL 5.7 compatibility.
+{% endhint %}
+
+The `->` and `->>` operators are shorthand for extracting a value from a JSON document by a [JSONPath expression](jsonpath-expressions.md):
+
+* `json_doc -> path` is equivalent to [`JSON_EXTRACT(json_doc, path)`](json_extract.md).
+* `json_doc ->> path` is equivalent to [`JSON_UNQUOTE`](json_unquote.md)`(`[`JSON_EXTRACT`](json_extract.md)`(json_doc, path))`.
+
+Both operators are purely syntactic sugar: they build the same expression as the equivalent function calls and inherit their `NULL` and error behavior. On the left, `json_doc` is any JSON expression — typically a column, a function result, or a JSON literal.
+
+The two operators differ only in quoting:
+
+* `->` returns the extracted value in its JSON representation, so a matched string keeps its surrounding double quotes (for example, `"Alice"`).
+* `->>` additionally unquotes the result, returning the raw value (for example, `Alice`). Use `->>` when comparing against, sorting by, or displaying scalar values.
+
+The following caveats apply and distinguish the operators from the underlying functions:
+
+* **The path must be a string literal.** Unlike [`JSON_EXTRACT()`](json_extract.md), which accepts any expression as its path argument, the right-hand side of `->` and `->>` must be a literal string. A column, user variable (`data -> @path`), or placeholder (`data -> ?`) will not parse.
+* **Chaining requires parentheses.** The operators do not chain directly; `col -> '$.a' -> '$.b'` is a syntax error. Wrap the intermediate result in parentheses instead: `(col -> '$.a') -> '$.b'`.
+* **Precedence** is higher than the arithmetic and comparison operators, so `col ->> '$.age' = 30` is evaluated as `(col ->> '$.age') = 30`.
+
+## Examples
+
+Before MariaDB 13.1, only the function form (`JSON_EXTRACT()` / `JSON_UNQUOTE(JSON_EXTRACT())`) worked in MariaDB; the `->` and `->>` operator form was accepted only by MySQL. As of MariaDB 13.1 both forms work, so queries written for MySQL 5.7+ port across unchanged.
+
+The function form works in both MySQL and MariaDB:
+
+```sql
+SELECT JSON_EXTRACT('{"id":"1", "name":"Name"}', '$.name') `name`;
++--------+
+| name   |
++--------+
+| "Name" |
++--------+
+
+SELECT JSON_UNQUOTE(JSON_EXTRACT('{"id":"1", "name":"Name"}', '$.name')) `name`;
++------+
+| name |
++------+
+| Name |
++------+
+```
+
+The equivalent operator form worked only in MySQL before MariaDB 13.1, and now works in MariaDB too:
+
+```sql
+SELECT '{"id":"1", "name":"Name"}'->'$.name' `name`;
++--------+
+| name   |
++--------+
+| "Name" |
++--------+
+
+SELECT '{"id":"1", "name":"Name"}'->>'$.name' `name`;
++------+
+| name |
++------+
+| Name |
++------+
+```
+
+As with the function form, `->` keeps the JSON quoting (`"Name"`) while `->>` returns the unquoted value (`Name`).
+
+The operators can be used anywhere an expression is allowed, such as in a `WHERE` clause:
+
+```sql
+CREATE TABLE t1 (id INT, data JSON);
+INSERT INTO t1 VALUES (1, '{"id":"1", "name":"Name"}');
+
+SELECT id FROM t1 WHERE data->>'$.name' = 'Name';
++------+
+| id   |
++------+
+|    1 |
++------+
+```
+
+## See Also
+
+* [JSON\_EXTRACT](json_extract.md) — the function `->` is shorthand for.
+* [JSON\_UNQUOTE](json_unquote.md) — combined with `JSON_EXTRACT`, the function `->>` is shorthand for.
+* [JSONPath Expressions](jsonpath-expressions.md) — the path syntax used on the right-hand side.
+* [JSON\_VALUE](json_value.md) — related, but *not* equivalent: returns only scalar values, always unquoted.
+* [JSON\_QUERY](json_query.md) — related, but *not* equivalent: returns only objects or arrays.
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}

--- a/server/reference/sql-functions/special-functions/json-functions/json_extract.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json_extract.md
@@ -52,6 +52,7 @@ SELECT JSON_EXTRACT(@json, '$[2][1]');
 
 ## See Also
 
+* [JSON Arrow Operators](json-arrow-operators.md) — the `->` operator is shorthand for `JSON_EXTRACT()`.
 * [JSON video tutorial](https://www.youtube.com/watch?v=sLE7jPETp8g) covering JSON\_EXTRACT.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/sql-functions/special-functions/json-functions/json_unquote.md
+++ b/server/reference/sql-functions/special-functions/json-functions/json_unquote.md
@@ -68,6 +68,10 @@ SELECT JSON_UNQUOTE('Si\bng\ting');
 +-----------------------------+
 ```
 
+## See Also
+
+* [JSON Arrow Operators](json-arrow-operators.md) — the `->>` operator is shorthand for `JSON_UNQUOTE(JSON_EXTRACT())`.
+
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}


### PR DESCRIPTION
## Summary
Adds documentation for the -> and ->> JSON path operators 
introduced in MariaDB 13.1 for MySQL 5.7 compatibility.

## Changes
- New page: json-arrow-operators.md (JSON Arrow Operators)
- Updated json_extract.md: added See Also link to new page
- Updated json_unquote.md: added new See Also section
- Updated SUMMARY.md: added nav entry under JSON concept pages

## Notes
- Feature is currently on preview-13.1-preview branch only
- Editorial note in frontmatter must be removed before publishing