### PR TITLE
DOCS-5973: Convert 22 depth-3 landing pages to columns (batch 3a)

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -4,3 +4,4 @@ ist
 inout
 numbe
 characte
+clienta

--- a/server/clients-and-utilities/deployment-tools/README.md
+++ b/server/clients-and-utilities/deployment-tools/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Deployment Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-install-db.md" %}
+[mariadb-install-db.md](mariadb-install-db.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Definitive mariadb-install-db guide: initialize data directory, --user/--datadir syntax, --auth-root-authentication-method=socket, and --skip-test-db.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-upgrade.md" %}
+[mariadb-upgrade.md](mariadb-upgrade.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete mariadb-upgrade reference: update mysql system tables, CHECK TABLE FOR UPGRADE, ALTER TABLE FORCE, and --upgrade-system-tables option.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-secure-installation.md" %}
+[mariadb-secure-installation.md](mariadb-secure-installation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB installation guide. Complete setup instructions for Linux, Windows, and macOS with configuration and verification for production use.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/logging-tools/README.md
+++ b/server/clients-and-utilities/logging-tools/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Logging Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-binlog/" %}
+[mariadb-binlog](mariadb-binlog/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Use mariadb-binlog to process binary log files. This utility is essential for examining replication events, recovering from data loss, and auditing changes in your MariaDB Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-dumpslow.md" %}
+[mariadb-dumpslow.md](mariadb-dumpslow.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Summarize and analyze the MariaDB slow query log with mariadb-dumpslow (formerly mysqldumpslow), grouping similar queries to surface the slowest statements.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/logging-tools/mariadb-dumpslow.md
+++ b/server/clients-and-utilities/logging-tools/mariadb-dumpslow.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Summarize and analyze the MariaDB slow query log with mariadb-dumpslow
+  (formerly mysqldumpslow), grouping similar queries to surface the slowest
+  statements.
+---
+
 # mariadb-dumpslow
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/mariadb-client/README.md
+++ b/server/clients-and-utilities/mariadb-client/README.md
@@ -6,3 +6,26 @@ description: >-
 
 # mariadb Client
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-command-line-client.md" %}
+[mariadb-command-line-client.md](mariadb-command-line-client.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB command-line client guide. Complete reference for server connections, query execution, data import, and batch processing for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-command-line-client.md" %}
+[mysql-command-line-client.md](mysql-command-line-client.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql command-line client is the former name of the mariadb SQL shell, still available as a symlink or alternate binary for compatibility.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/mariadb-client/mysql-command-line-client.md
+++ b/server/clients-and-utilities/mariadb-client/mysql-command-line-client.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The mysql command-line client is the former name of the mariadb SQL shell,
+  still available as a symlink or alternate binary for compatibility.
+---
+
 # mysql Command-Line Client
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/networking-tools/README.md
+++ b/server/clients-and-utilities/networking-tools/README.md
@@ -7,3 +7,14 @@ description: >-
 
 # Networking Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="resolveip.md" %}
+[resolveip.md](resolveip.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Resolve host names to IP addresses and the reverse with the resolveip utility, useful when configuring host-based privileges.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/networking-tools/resolveip.md
+++ b/server/clients-and-utilities/networking-tools/resolveip.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Resolve host names to IP addresses and the reverse with the resolveip
+  utility, useful when configuring host-based privileges.
+---
+
 # resolveip
 
 resolveip is a utility for resolving IP addresses to host names and vice versa.

--- a/server/ha-and-performance/standard-replication/README.md
+++ b/server/ha-and-performance/standard-replication/README.md
@@ -23,3 +23,350 @@ layout:
 
 # Replication
 
+{% columns %}
+{% column %}
+{% content-ref url="replication-overview.md" %}
+[replication-overview.md](replication-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the core concepts of MariaDB standard replication. Learn about the primary-replica architecture, data redundancy strategies, and how to scale read operations effectively.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="choosing-a-replication-strategy.md" %}
+[choosing-a-replication-strategy.md](choosing-a-replication-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Choose a MariaDB replication strategy by matching the replication method and format to your goal — reducing downtime, scaling reads, or aggregating data — and weigh the trade-offs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-based-binary-log.md" %}
+[innodb-based-binary-log.md](innodb-based-binary-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+From MariaDB 12.3, the binary log can be stored in InnoDB-managed, page-structured files integrated with InnoDB crash recovery, instead of traditional flat binary log files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-based-binary-log.md" %}
+[innodb-based-binary-log.md](innodb-based-binary-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+From MariaDB 12.3, the binary log can be stored in InnoDB-managed, page-structured files integrated with InnoDB crash recovery, instead of traditional flat binary log files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-statements.md" %}
+[replication-statements.md](replication-statements.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Access the complete reference of SQL statements used to manage replication. This guide covers commands for controlling primaries, configuring replicas, and monitoring status.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setting-up-replication.md" %}
+[setting-up-replication.md](setting-up-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to MariaDB replication setup. Complete walkthrough for primary-replica topology with binary logging and GTID configuration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="gtid.md" %}
+[gtid.md](gtid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete GTID replication reference: CHANGE MASTER master_use_gtid=current_pos|slave_pos, gtid_slave_pos table (InnoDB), START REPLICA UNTIL master_gtid_pos.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="read-only-replicas.md" %}
+[read-only-replicas.md](read-only-replicas.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to configure replicas as read-only instances. This ensures data integrity by preventing accidental writes on the replica while allowing it to process replication events.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="multi-source-replication.md" %}
+[multi-source-replication.md](multi-source-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover how to replicate data from multiple primaries to a single replica. This guide covers the configuration for aggregating data from different sources into one MariaDB instance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="multi-master-ring-replication.md" %}
+[multi-master-ring-replication.md](multi-master-ring-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the ring topology where each server acts as both primary and replica. Learn the configuration steps and caveats for setting up a circular replication environment.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="delayed-replication.md" %}
+[delayed-replication.md](delayed-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn to configure a time lag for your replica. Delayed replication helps recover from human errors on the primary, such as accidental drop commands, by preserving older states.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="parallel-replication.md" %}
+[parallel-replication.md](parallel-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Boost MariaDB Server replication performance with parallel replication. This section explains how to configure replicas to apply events concurrently, reducing lag and improving throughput.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="semisynchronous-replication.md" %}
+[semisynchronous-replication.md](semisynchronous-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Enhance data consistency with semisynchronous replication. Ensure that the primary waits for at least one replica to acknowledge receipt of a transaction before committing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="row-based-replication-with-no-primary-key.md" %}
+[row-based-replication-with-no-primary-key.md](row-based-replication-with-no-primary-key.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the performance implications and best practices for replicating tables without primary keys when using row-based logging, including how to avoid full table scans.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="unsafe-statements-for-statement-based-replication.md" %}
+[unsafe-statements-for-statement-based-replication.md](unsafe-statements-for-statement-based-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Identify SQL statements that are non-deterministic and unsafe for statement-based replication. Learn why these queries cause divergence and how to switch to row-based logging.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-filters.md" %}
+[replication-filters.md](replication-filters.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to filter specific databases or tables from being replicated. This guide covers configuration options to replicate only the data you need on specific replicas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-threads.md" %}
+[replication-threads.md](replication-threads.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Gain insight into the background threads that drive replication. Understand the roles of the I/O thread, SQL thread, and binlog dump thread in moving data between servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-and-foreign-keys.md" %}
+[replication-and-foreign-keys.md](replication-and-foreign-keys.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how foreign key constraints interact with replication. Learn best practices for managing cascading deletes and updates across primary and replica servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-and-binary-log-system-variables.md" %}
+[replication-and-binary-log-system-variables.md](replication-and-binary-log-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Replication and Binary Log System Variables reference for MariaDB. Complete guide for configuration values, scope settings, and performance impact.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-and-binary-log-status-variables.md" %}
+[replication-and-binary-log-status-variables.md](replication-and-binary-log-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+View the status variables used to monitor replication health. Learn how to interpret metrics regarding log positions, connection status, and event counts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binlog-event-checksum-interoperability.md" %}
+[binlog-event-checksum-interoperability.md](binlog-event-checksum-interoperability.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about checksum compatibility between different MariaDB versions. Ensure older replicas can correctly verify binary log events generated by newer primaries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binlog-event-checksums.md" %}
+[binlog-event-checksums.md](binlog-event-checksums.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Configure checksums to detect data corruption in binary logs. Learn how to enable verification to ensure the integrity of replication events during transmission and storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="changing-a-replica-to-become-the-primary.md" %}
+[changing-a-replica-to-become-the-primary.md](changing-a-replica-to-become-the-primary.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Follow the procedure to promote a replica to a primary role. This guide details the steps for planned failovers or topology reorganization with minimal downtime.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-when-the-primary-and-replica-have-different-table-definitions.md" %}
+[replication-when-the-primary-and-replica-have-different-table-definitions.md](replication-when-the-primary-and-replica-have-different-table-definitions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the rules and limitations when replicating between tables with differing structures. Learn how attribute promotion and column handling work in row-based replication.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="enhancements-for-start-transaction-with-consistent-snapshot.md" %}
+[enhancements-for-start-transaction-with-consistent-snapshot.md](enhancements-for-start-transaction-with-consistent-snapshot.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to start a consistent transaction for backups or replication setup. This command ensures a consistent view of the database without locking tables unnecessarily.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="restricting-speed-of-reading-binlog-from-primary-by-a-replica.md" %}
+[restricting-speed-of-reading-binlog-from-primary-by-a-replica.md](restricting-speed-of-reading-binlog-from-primary-by-a-replica.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Configure throughput limits for replication traffic. Learn to throttle the binlog download speed to prevent replication from consuming all available network bandwidth.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="running-triggers-on-the-replica-for-row-based-events.md" %}
+[running-triggers-on-the-replica-for-row-based-events.md](running-triggers-on-the-replica-for-row-based-events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how triggers behave under row-based replication. Learn when and why triggers are not executed on the replica and how to manage complex logic in this mode.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="selectively-skipping-replication-of-binlog-events.md" %}
+[selectively-skipping-replication-of-binlog-events.md](selectively-skipping-replication-of-binlog-events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn techniques to bypass specific replication events. This guide explains how to ignore individual transactions or errors to restore replication flow after a stoppage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="obsolete-replication-information/" %}
+[obsolete-replication-information](obsolete-replication-information/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Access documentation for deprecated or removed replication features. Review this historical context when upgrading legacy systems or migrating to newer MariaDB versions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/standard-replication/choosing-a-replication-strategy.md
+++ b/server/ha-and-performance/standard-replication/choosing-a-replication-strategy.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Choose a MariaDB replication strategy by matching the replication method and
+  format to your goal — reducing downtime, scaling reads, or aggregating data —
+  and weigh the trade-offs.
+---
+
 # Choosing a Replication Strategy
 
 Choosing the right replication strategy in MariaDB is less about the underlying technology itself and more about which specific "pain point" your architecture needs to solve: preventing downtime, accelerating slow reads, securing data across distances, or aggregating data for analytics.

--- a/server/reference/data-types/README.md
+++ b/server/reference/data-types/README.md
@@ -6,3 +6,122 @@ description: >-
 
 # Data Types
 
+{% columns %}
+{% column %}
+{% content-ref url="data-type-storage-requirements.md" %}
+[data-type-storage-requirements.md](data-type-storage-requirements.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for storage space usage. This page lists the disk space consumed by each data type, helping with capacity planning and schema optimization.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="auto_increment.md" %}
+[auto_increment.md](auto_increment.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete AUTO_INCREMENT data type guide for MariaDB. Complete reference for syntax, valid values, storage requirements, and range limits for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="auto_increment-faq.md" %}
+[auto_increment-faq.md](auto_increment-faq.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Answers to common questions about AUTO_INCREMENT. Learn about gaps in sequences, resetting values, and behavior in different storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="null-values.md" %}
+[null-values.md](null-values.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the concept of NULL. This page explains how NULL represents missing or unknown data and how it interacts with comparison operators and functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="row-type-of.md" %}
+[row-type-of.md](row-type-of.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Declare row-based variables. This PL/SQL compatibility feature allows declaring variables that match the structure of a table row or cursor.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="serial.md" %}
+[serial.md](serial.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE. This shorthand data type is often used to define primary keys.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="type-of.md" %}
+[type-of.md](type-of.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Declare variables based on existing types. This feature allows defining variables or parameters that inherit the data type of a table column or another variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="numeric-data-types/" %}
+[numeric-data-types](numeric-data-types/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete numeric types reference: INT/BIGINT ranges, DECIMAL(M,D) precision/scale, FLOAT/DOUBLE storage sizes, and numeric type selection guidelines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date-and-time-data-types/" %}
+[date-and-time-data-types](date-and-time-data-types/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Store temporal values. This section covers data types for dates, times, and timestamps, including DATE, DATETIME, TIMESTAMP, TIME, and YEAR.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="string-data-types/" %}
+[string-data-types](string-data-types/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Store text and binary data. This section covers character types like CHAR, VARCHAR, and TEXT, as well as binary types like BLOB and BINARY.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/plugins/README.md
+++ b/server/reference/plugins/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="plugin-overview.md" %}
+[plugin-overview.md](plugin-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB supports loading plugins at startup or runtime to extend functionality, including storage engines, security features, and logging capabilities, without rebuilding the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="information-on-plugins/list-of-plugins.md" %}
+[list-of-plugins.md](information-on-plugins/list-of-plugins.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page lists the maturity level (Alpha, Beta, Gamma, Stable) of various MariaDB plugins, helping users determine which are suitable for production environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-audit.md" %}
+[mariadb-enterprise-audit.md](mariadb-enterprise-audit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The MariaDB Enterprise Audit plugin logs detailed data access and configuration changes, offering advanced filtering to meet security and compliance requirements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin/" %}
+[mariadb-audit-plugin](mariadb-audit-plugin/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB Audit Plugin reference: server_audit activity logging, connection/query event tracking, file/syslog output, and compliance configuration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugins/" %}
+[authentication-plugins](authentication-plugins/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the authentication plugins available in MariaDB, such as ed25519, GSSAPI, and PAM, which provide flexible and secure methods for user verification.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-replication-cluster-plugins/" %}
+[mariadb-replication-cluster-plugins](mariadb-replication-cluster-plugins/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section covers plugins specifically designed for high availability and clustering, including the wsrep_provider plugin used for Galera Cluster integration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="other-plugins/" %}
+[other-plugins](other-plugins/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover additional plugins that extend MariaDB Server functionality, such as the Disks, Feedback, and Query Response Time plugins, for specialized use cases.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="password-validation-plugins/" %}
+[password-validation-plugins](password-validation-plugins/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Password validation plugins, like simple_password_check and cracklib, enforce strong password policies by checking new passwords against defined complexity rules.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/README.md
+++ b/server/reference/sql-functions/README.md
@@ -4,3 +4,122 @@ description: Discover functions and procedures in MariaDB.
 
 # SQL Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="function-and-operator-reference.md" %}
+[function-and-operator-reference.md](function-and-operator-reference.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Comprehensive reference of all SQL functions and operators. This index lists built-in functions for string manipulation, math, date/time, and more.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aggregate-functions/" %}
+[aggregate-functions](aggregate-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform calculations on multiple rows to return a single value. Includes standard SQL functions like SUM, AVG, COUNT, MIN, and MAX, often used with GROUP BY.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="control-flow-functions/" %}
+[control-flow-functions](control-flow-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about control flow functions in MariaDB Server. This section details SQL functions like IF, CASE, and NULLIF, which enable conditional logic within your queries and stored routines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date-time-functions/" %}
+[date-time-functions](date-time-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB date and time functions guide. Complete reference for formatting, calculations, conversions, time zones, and operations for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="numeric-functions/" %}
+[numeric-functions](numeric-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about numeric functions in MariaDB Server. This section details SQL functions for performing mathematical calculations, rounding, and manipulating numeric values in your queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="pseudo-columns/" %}
+[pseudo-columns](pseudo-columns/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB has pseudo columns that can be used for different purposes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="secondary-functions/" %}
+[secondary-functions](secondary-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore secondary functions in MariaDB Server. This section details various SQL functions that support specialized operations, enhancing data manipulation and analysis beyond core functionalities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="special-functions/" %}
+[special-functions](special-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore special functions in MariaDB Server. This section details unique SQL functions that provide specialized capabilities, often related to server internals, diagnostics, or specific data handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="string-functions/" %}
+[string-functions](string-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about string functions in MariaDB Server. This section details SQL functions for manipulating, searching, and formatting text strings, essential for data cleansing and presentation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vector-functions/" %}
+[vector-functions](vector-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore vector functions. This section details SQL functions for manipulating and querying vector data types, enabling efficient similarity search and AI/ML applications within your  database.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/README.md
+++ b/server/reference/sql-structure/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # SQL Structure
 
+{% columns %}
+{% column %}
+{% content-ref url="sql-language-structure/" %}
+[sql-language-structure](sql-language-structure/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the SQL language structure in MariaDB Server. This section provides fundamental concepts, syntax rules, and common elements that form the building blocks of SQL queries and commands.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="joins-subqueries-set.md" %}
+[joins-subqueries-set.md](joins-subqueries-set.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore joins, subqueries, and set operations in MariaDB SQL. This section details how to combine data from multiple tables, nest queries, and perform set-based operations for complex data retrieval.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="geometry/" %}
+[geometry](geometry/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore geometric data types and functions in MariaDB Server. This section details how to store, query, and manipulate spatial data, enabling geospatial applications within your database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nosql/" %}
+[nosql](nosql/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore MariaDB Server's NoSQL capabilities. This section details how to store and query schemaless data, including JSON, and how to integrate with other NoSQL data sources, enhancing flexibility.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="operators/" %}
+[operators](operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about operators in MariaDB Server SQL. This section details arithmetic, comparison, logical, and bitwise operators used in expressions and conditions for data manipulation and querying.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sequences/" %}
+[sequences](sequences/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about sequences in MariaDB Server. This section details how to create and manage sequences for generating unique numbers, often used for primary keys and other auto-incrementing values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="temporal-tables/" %}
+[temporal-tables](temporal-tables/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore temporal tables in MariaDB Server. This section details how to manage data with system-versioning and application-time periods, enabling historical data tracking and time-aware queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vectors/" %}
+[vectors](vectors/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore vector data types. This section details how to store and manage numerical arrays, enabling efficient vector similarity search and machine learning applications within your database.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/authentication-with-enterprise-server/README.md
+++ b/server/security/authentication-with-enterprise-server/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Authentication with Enterprise Server
 
+{% columns %}
+{% column %}
+{% content-ref url="authentication-for-mariadb-enterprise-server.md" %}
+[authentication-for-mariadb-enterprise-server.md](authentication-for-mariadb-enterprise-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of user account authentication using plugins like pam or unix_socket and managing security with password validation plugins.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-with-gssapi.md" %}
+[authentication-with-gssapi.md](authentication-with-gssapi.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for installing and configuring the gssapi plugin to validate user credentials against services like Kerberos or NTLM.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/limiting-size-of-created-disk-temporary-files-and-tables/README.md
+++ b/server/security/limiting-size-of-created-disk-temporary-files-and-tables/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # Limiting Size of Created Disk Temporary Files and Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="limiting-size-of-created-disk-temporary-files-and-tables-overview.md" %}
+[limiting-size-of-created-disk-temporary-files-and-tables-overview.md](limiting-size-of-created-disk-temporary-files-and-tables-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of the feature introduced in MariaDB 11.5 to limit disk space used by temporary files and internal on-disk temporary tables to prevent disk exhaustion.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="max_tmp_session_space_usage-system-variable.md" %}
+[max_tmp_session_space_usage-system-variable.md](max_tmp_session_space_usage-system-variable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the system variable that restricts the maximum total size of temporary files and tables allowed for an individual user session.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="max_tmp_total_space_usage-system-variable.md" %}
+[max_tmp_total_space_usage-system-variable.md](max_tmp_total_space_usage-system-variable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for the global system variable that defines the maximum cumulative disk space all user connections can consume for temporary files and tables.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/user-account-management/README.md
+++ b/server/security/user-account-management/README.md
@@ -23,3 +23,74 @@ layout:
 
 # User Account Management
 
+{% columns %}
+{% column %}
+{% content-ref url="roles/" %}
+[roles](roles/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage roles in MariaDB Server for streamlined user access control. This section explains how to create, assign, and manage roles to simplify privilege management and enhance security.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="account-locking.md" %}
+[account-locking.md](account-locking.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to lock and unlock user accounts using CREATE USER and ALTER USER statements to prevent login access without deleting the account.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-from-mariadb-10-4.md" %}
+[authentication-from-mariadb-10-4.md](authentication-from-mariadb-10-4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the authentication changes introduced in MariaDB 10.4, including multiple authentication plugins per user, the mysql.global_priv table, and the default unix_socket authentication for root.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="incrementing-of-the-access_denied_errors-status-variable.md" %}
+[incrementing-of-the-access_denied_errors-status-variable.md](incrementing-of-the-access_denied_errors-status-variable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the conditions that trigger the access_denied_errors status variable, such as failed logins, invalid privileges, or missing SSL requirements, aiding in security monitoring.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-password-expiry.md" %}
+[user-password-expiry.md](user-password-expiry.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide to configuring password expiration policies, including setting global lifetimes via default_password_lifetime or per-user limits, and handling expired password connections.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="catalogs/" %}
+[catalogs](catalogs/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to Catalogs, a multi-tenancy feature for isolating database objects and users, planned for future MariaDB releases.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/automated-mariadb-deployment-and-administration/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/README.md
@@ -23,3 +23,134 @@ layout:
 
 # Automated Deployment & Administration
 
+{% columns %}
+{% column %}
+{% content-ref url="why-to-automate-mariadb-deployments-and-management.md" %}
+[why-to-automate-mariadb-deployments-and-management.md](why-to-automate-mariadb-deployments-and-management.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the benefits of automating database deployment and management, such as consistency, scalability, and the adoption of Infrastructure as Code principles.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="a-comparison-between-automation-systems.md" %}
+[a-comparison-between-automation-systems.md](a-comparison-between-automation-systems.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compares different automation tools like Ansible and Puppet, highlighting differences in their architecture (agentless vs. agent-based) and code structure to help users choose the right tool.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="automating-mariadb-tasks-with-events.md" %}
+[automating-mariadb-tasks-with-events.md](automating-mariadb-tasks-with-events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes how to use the MariaDB Event Scheduler to automate recurring SQL tasks directly within the database server, similar to cron jobs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="automating-upgrades-with-mariadborg-downloads-rest-api.md" %}
+[automating-upgrades-with-mariadborg-downloads-rest-api.md](automating-upgrades-with-mariadborg-downloads-rest-api.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide on using the MariaDB Downloads REST API to programmatically retrieve information about software versions, facilitating automated upgrade scripts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hashicorp-vault-and-mariadb.md" %}
+[hashicorp-vault-and-mariadb.md](hashicorp-vault-and-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discusses the integration of HashiCorp Vault with MariaDB for managing secrets, including using MariaDB as a storage backend for Vault.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="orchestrator-overview.md" %}
+[orchestrator-overview.md](orchestrator-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to Orchestrator, a tool for managing MySQL and MariaDB replication topologies, providing high availability and automated failover capabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ansible-and-mariadb/" %}
+[ansible-and-mariadb](ansible-and-mariadb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides general information and resources for using Ansible to automate the deployment and configuration of MariaDB servers using playbooks.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="automated-mariadb-deployment-and-administration-puppet-and-mariadb/" %}
+[automated-mariadb-deployment-and-administration-puppet-and-mariadb](automated-mariadb-deployment-and-administration-puppet-and-mariadb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+General information and hints on how to automate MariaDB deployments and configuration with Puppet, an open source tool for deployment, configuration, and operations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="docker-and-mariadb/" %}
+[docker-and-mariadb](docker-and-mariadb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discusses running MariaDB in Docker containers, covering the benefits of isolation and ease of deployment for development and testing environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="kubernetes-and-mariadb/" %}
+[kubernetes-and-mariadb](kubernetes-and-mariadb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+General information and hints on deploying MariaDB Kubernetes (K8s) containers, an open source container orchestration system which automates deployments, horizontal scaling, configuration, and operat
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vagrant-and-mariadb/" %}
+[vagrant-and-mariadb](vagrant-and-mariadb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Vagrant is an open source tool to quickly setup machines that can be used for development and testing. They can be local virtual machines, Docker containers, AWS EC2 instances, and so on
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/server-monitoring-logs/README.md
+++ b/server/server-management/server-monitoring-logs/README.md
@@ -23,3 +23,134 @@ layout:
 
 # Server Monitoring & Logs
 
+{% columns %}
+{% column %}
+{% content-ref url="overview-of-mariadb-logs.md" %}
+[overview-of-mariadb-logs.md](overview-of-mariadb-logs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introductory guide to the various logs available in MariaDB, including the Error Log, General Query Log, Slow Query Log, and Binary Log, and how to enable or disable them.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../security/securing-mariadb/securing-mariadb-logs.md" %}
+[securing-mariadb-logs.md](../../security/securing-mariadb/securing-mariadb-logs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to harden MariaDB log files by implementing at-rest encryption, TLS for transit, strict OS permissions, and automated rotation to ensure data integrity and regulatory compliance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary-log/" %}
+[binary-log](binary-log/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the binary log in MariaDB Server. This section explains its role in replication and point-in-time recovery, detailing its format, management, and use for data integrity.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="error-log.md" %}
+[error-log.md](error-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Error Log guide for MariaDB. Complete reference documentation for implementation, configuration, and usage with comprehensive examples and best.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="general-query-log.md" %}
+[general-query-log.md](general-query-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete General Query Log guide for MariaDB. Complete reference documentation for implementation, configuration, and usage with comprehensive examples.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam-log.md" %}
+[myisam-log.md](myisam-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the MyISAM log (`myisam.log`), a specialized log for recording changes to MyISAM tables for debugging purposes, enabled via the `--log-isam` option.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rotating-logs-on-unix-and-linux.md" %}
+[rotating-logs-on-unix-and-linux.md](rotating-logs-on-unix-and-linux.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to using the `logrotate` utility on Linux to manage MariaDB log files, ensuring they don't consume excessive disk space by rotating, compressing, and archiving them.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="slow-query-log/" %}
+[slow-query-log](slow-query-log/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Utilize the slow query log in MariaDB Server. This section helps you identify and optimize inefficient queries, improving overall database performance and responsiveness.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sql-error-log-plugin.md" %}
+[sql-error-log-plugin.md](sql-error-log-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the SQL Error Log Plugin, which allows logging of errors sent to clients to a file, enabling analysis of application-side errors that might otherwise be missed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transaction-coordinator-log/" %}
+[transaction-coordinator-log](transaction-coordinator-log/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the Transaction Coordinator Log (tc.log), used to maintain consistency in distributed transactions (XA) across multiple storage engines or servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="writing-logs-into-tables.md" %}
+[writing-logs-into-tables.md](writing-logs-into-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on directing the General Query Log and Slow Query Log to tables (`mysql.general_log`, `mysql.slow_log`) instead of files using the `log_output=TABLE` system variable.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/starting-and-stopping-mariadb/README.md
+++ b/server/server-management/starting-and-stopping-mariadb/README.md
@@ -23,3 +23,170 @@ layout:
 
 # Starting & Stopping
 
+{% columns %}
+{% column %}
+{% content-ref url="starting-and-stopping-mariadb-automatically.md" %}
+[starting-and-stopping-mariadb-automatically.md](starting-and-stopping-mariadb-automatically.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Starting and Stopping Overview guide for MariaDB. Complete reference documentation for implementation, configuration, and usage for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="launchd.md" %}
+[launchd.md](launchd.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for configuring MariaDB to start automatically on macOS using a launchd plist file in /Library/LaunchDaemons.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="systemd/" %}
+[systemd](systemd/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB on systemd (Linux): overview, supported distributions, and links to operational and configuration guidance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sysvinit.md" %}
+[sysvinit.md](sysvinit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes how to manage MariaDB using SysVinit scripts (mysql.server), common on older Linux distributions, using commands like `service` and `chkconfig`.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadbd-safe.md" %}
+[mariadbd-safe.md](mariadbd-safe.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the `mariadbd-safe` wrapper script, which adds safety features like auto-restart upon crash and error logging to syslog.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadbd-multi.md" %}
+[mariadbd-multi.md](mariadbd-multi.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use `mariadbd-multi` to manage multiple MariaDB server processes on a single host using GNR groups in the configuration file.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadbd-options.md" %}
+[mariadbd-options.md](mariadbd-options.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A reference list of command-line options available for the `mariadbd` server binary, covering configuration, replication, and service installation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadbd.md" %}
+[mariadbd.md](mariadbd.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the `mariadbd` binary (formerly `mysqld`), which is the core database server executable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-server.md" %}
+[mysql-server.md](mysql-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the `mysql.server` script, a SysVinit-style wrapper used to start and stop `mariadbd-safe`.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="running-mariadb-from-the-build-directory.md" %}
+[running-mariadb-from-the-build-directory.md](running-mariadb-from-the-build-directory.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for developers on how to run MariaDB directly from the source build directory without installing it to system paths.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="running-multiple-mariadb-server-processes.md" %}
+[running-multiple-mariadb-server-processes.md](running-multiple-mariadb-server-processes.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide on configuring and running multiple independent MariaDB instances on the same machine by isolating data directories, ports, and sockets.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="specifying-permissions-for-schema-data-directories-and-tables.md" %}
+[specifying-permissions-for-schema-data-directories-and-tables.md](specifying-permissions-for-schema-data-directories-and-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains default file permissions for data directories and how to customize them using `UMASK` and `UMASK_DIR` environment variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="switching-between-different-installed-mariadb-versions.md" %}
+[switching-between-different-installed-mariadb-versions.md](switching-between-different-installed-mariadb-versions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Techniques for managing parallel installations of different MariaDB versions, typically using symlinks and separate data directories for testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="what-to-do-if-mariadb-doesnt-start.md" %}
+[what-to-do-if-mariadb-doesnt-start.md](what-to-do-if-mariadb-doesnt-start.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete What to Do if MariaDB Doesn't Start guide for MariaDB. Complete reference documentation for implementation, configuration, and usage.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/backup-and-restore/README.md
+++ b/server/server-usage/backup-and-restore/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # Backup & Restore
 
+{% columns %}
+{% column %}
+{% content-ref url="backup-and-restore-overview.md" %}
+[backup-and-restore-overview.md](backup-and-restore-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB backup and recovery guide. Complete resource for backup methods, mariabackup usage, scheduling, and restoration for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-and-restore-with-mariadb-enterprise-server/forming-a-backup-strategy.md" %}
+[forming-a-backup-strategy.md](backup-and-restore-with-mariadb-enterprise-server/forming-a-backup-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to design a robust backup strategy tailored to your business needs, balancing recovery time objectives and data retention policies.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-and-restore-with-mariadb-enterprise-server/backup-optimization.md" %}
+[backup-optimization.md](backup-and-restore-with-mariadb-enterprise-server/backup-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover techniques to optimize your backup processes, including multithreading, incremental backups, and leveraging storage snapshots.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-and-restore-with-mariadb-enterprise-server/mariadb-enterprise-backup.md" %}
+[mariadb-enterprise-backup.md](backup-and-restore-with-mariadb-enterprise-server/mariadb-enterprise-backup.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page details MariaDB Enterprise Backup, an enhanced version of mariadb-backup with enterprise-specific optimizations and support.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-backup/" %}
+[mariadb-backup](mariadb-backup/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Get an overview of MariaDB Backup. This section introduces the hot physical backup tool, explaining its capabilities for efficient and consistent backups of your MariaDB Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-log-archive-pitr.md" %}
+[innodb-log-archive-pitr.md](innodb-log-archive-pitr.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform point-in-time recovery in MariaDB by replaying archived InnoDB write-ahead logs at startup to restore the server to a specific Log Sequence Number (LSN).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-as-a-backup-solution.md" %}
+[replication-as-a-backup-solution.md](replication-as-a-backup-solution.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore how to use replication as part of your backup strategy, allowing you to offload backup tasks to a replica server to reduce load on the primary.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-and-restore-via-dbforge-studio.md" %}
+[backup-and-restore-via-dbforge-studio.md](backup-and-restore-via-dbforge-studio.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to use dbForge Studio, a GUI tool, to perform backup and restore operations for MariaDB databases visually.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/backup-and-restore/innodb-log-archive-pitr.md
+++ b/server/server-usage/backup-and-restore/innodb-log-archive-pitr.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Perform point-in-time recovery in MariaDB by replaying archived InnoDB
+  write-ahead logs at startup to restore the server to a specific Log Sequence
+  Number (LSN).
+---
+
 # Point-In-Time Recovery (InnoDB Log Archiving)
 
 {% hint style="info" %}

--- a/server/server-usage/basics/README.md
+++ b/server/server-usage/basics/README.md
@@ -7,3 +7,74 @@ description: >-
 
 # Basics
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-usage-guide-1.md" %}
+[mariadb-usage-guide-1.md](mariadb-usage-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A beginner-friendly primer on using the mariadb command-line client to log in, create databases, and execute basic SQL commands.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-advanced-usage-guide-1.md" %}
+[mariadb-advanced-usage-guide-1.md](mariadb-advanced-usage-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide covers the fundamentals of creating database structures, inserting data, and retrieving information using the default MariaDB client.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-sql-debugging-guide-1.md" %}
+[mariadb-sql-debugging-guide-1.md](mariadb-sql-debugging-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn strategies for debugging SQL queries, including formatting for readability, using aliases effectively, and interpreting syntax errors.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-sql-cheat-cheat-guide-1.md" %}
+[mariadb-sql-cheat-cheat-guide-1.md](mariadb-sql-cheat-cheat-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A quick reference guide for essential SQL statements in MariaDB, categorized by Data Definition, Data Manipulation, and Transaction Control.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-advanced-sql-guide-1.md" %}
+[mariadb-advanced-sql-guide-1.md](mariadb-advanced-sql-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide provides examples of frequent SQL patterns, such as finding maximum values, calculating averages, and using auto-increment columns.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-string-functions-guide-1.md" %}
+[mariadb-string-functions-guide-1.md](mariadb-string-functions-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore MariaDB's built-in string functions for formatting, extracting, and manipulating text data within your queries.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/data-handling/README.md
+++ b/server/server-usage/data-handling/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Data Handling
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-adding-and-changing-data-guide.md" %}
+[mariadb-adding-and-changing-data-guide.md](mariadb-adding-and-changing-data-guide.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide provides a walkthrough of the INSERT, UPDATE, and DELETE statements, demonstrating how to add, modify, and remove data in tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-datetime-guide-1.md" %}
+[mariadb-datetime-guide-1.md](mariadb-datetime-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Master date and time handling in MariaDB with this guide on temporal data types, current time functions, and formatting dates for display.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-selecting-data-guide-1.md" %}
+[mariadb-selecting-data-guide-1.md](mariadb-selecting-data-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide explains how to retrieve data from MariaDB using the SELECT statement, progressing from basic syntax to more involved queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-importing-data-guide-1.md" %}
+[mariadb-importing-data-guide-1.md](mariadb-importing-data-guide-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Importing Data into MariaDB guide for MariaDB. Complete reference documentation for implementation, configuration, and usage for production use.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/stored-routines/README.md
+++ b/server/server-usage/stored-routines/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Stored Routines
 
+{% columns %}
+{% column %}
+{% content-ref url="stored-procedures/" %}
+[stored-procedures](stored-procedures/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Master stored procedures in MariaDB Server. This section covers creating, executing, and managing these powerful routines to encapsulate complex logic and improve application performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stored-functions/" %}
+[stored-functions](stored-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Utilize stored functions in MariaDB Server. This section details creating, using, and managing user-defined functions to extend SQL capabilities and streamline data manipulation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary-logging-of-stored-routines.md" %}
+[binary-logging-of-stored-routines.md](binary-logging-of-stored-routines.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+When binary logging is enabled, stored routines may require special handling (like SUPER privileges) if they are non-deterministic, to ensure consistent replication.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stored-routine-limitations.md" %}
+[stored-routine-limitations.md](stored-routine-limitations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Stored routines have specific restrictions, such as prohibiting certain SQL statements (e.g., LOAD DATA) and disallowing result sets in functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dbms_output.md" %}
+[dbms_output.md](dbms_output.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The DBMS_OUTPUT plugin provides Oracle-compatible output buffering functions (like PUT_LINE), allowing stored procedures to send messages to the client.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/triggers-events/README.md
+++ b/server/server-usage/triggers-events/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Triggers & Events
 
+{% columns %}
+{% column %}
+{% content-ref url="event-scheduler/" %}
+[event-scheduler](event-scheduler/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Utilize the Event Scheduler in MariaDB Server to automate tasks. Learn how to create, manage, and schedule events to execute SQL statements at specified intervals or times.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="triggers/" %}
+[triggers](triggers/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Automate actions in MariaDB Server with triggers. Learn how to create and manage triggers that execute automatically before or after data modifications, ensuring data integrity and business logic enfo
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/user-defined-functions/README.md
+++ b/server/server-usage/user-defined-functions/README.md
@@ -7,3 +7,74 @@ description: >-
 
 # User-Defined Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="user-defined-functions-overview.md" %}
+[user-defined-functions-overview.md](user-defined-functions-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to User-Defined Functions (UDFs) in MariaDB, explaining how they extend the server's functionality by adding new native-like functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="creating-user-defined-functions.md" %}
+[creating-user-defined-functions.md](creating-user-defined-functions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide for developers on writing UDFs in C/C++, covering the required interface functions, memory allocation, and thread safety.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-function-udf.md" %}
+[create-function-udf.md](create-function-udf.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Install a user-defined function from a shared library. This command loads an external compiled function into the server for extended capabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-function-udf.md" %}
+[drop-function-udf.md](drop-function-udf.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the DROP FUNCTION statement, which uninstalls a UDF and removes its entry from the system table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-defined-functions-calling-sequences.md" %}
+[user-defined-functions-calling-sequences.md](user-defined-functions-calling-sequences.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Technical details on the execution flow of UDFs, explaining the sequence in which initialization, processing, and de-initialization functions are called.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-defined-functions-security.md" %}
+[user-defined-functions-security.md](user-defined-functions-security.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of security measures for UDFs, including file location restrictions, required privileges, and system variable configurations.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/views/README.md
+++ b/server/server-usage/views/README.md
@@ -7,3 +7,74 @@ description: >-
 
 # Views
 
+{% columns %}
+{% column %}
+{% content-ref url="alter-view.md" %}
+[alter-view.md](alter-view.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the ALTER VIEW statement, which is used to modify an existing view's definition without dropping and recreating it.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-view.md" %}
+[create-view.md](create-view.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CREATE VIEW reference: OR REPLACE/IF NOT EXISTS, ALGORITHM=MERGE|TEMPTABLE|UNDEFINED, DEFINER/CURRENT_USER, and SQL SECURITY DEFINER|INVOKER.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-view.md" %}
+[drop-view.md](drop-view.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use the DROP VIEW statement to remove one or more views from the database, including required privileges.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="information-schema-views-table.md" %}
+[information-schema-views-table.md](information-schema-views-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the VIEWS table in the Information Schema, which provides metadata about all views in the database, such as definition and check options.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="inserting-and-updating-with-views.md" %}
+[inserting-and-updating-with-views.md](inserting-and-updating-with-views.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Covers the conditions under which a view is updatable, allowing INSERT, UPDATE, and DELETE operations to modify the underlying base tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="view-algorithms.md" %}
+[view-algorithms.md](view-algorithms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the different algorithms (MERGE, TEMPTABLE, UNDEFINED) MariaDB uses to process views and how they impact performance and updatability.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — **Batch 3a** of the Server landing-page columns campaign. Converts **22 auto-populated depth-3 landing pages** into "optimal" ones: one `{% columns %}` block per child (a `content-ref` link + the child's page description), modeled on `server/reference/product-development`.

Batches 1–2 (root, 6 sections, Quickstart) merged in #656 and #657.

## What changed

- **22 landing pages → columns**, in `server/SUMMARY.md` nav order.
- **5 child descriptions authored** (they feed these columns): `choosing-a-replication-strategy`, `innodb-log-archive-pitr`, `mariadb-dumpslow`, `mysql-command-line-client`, `resolveip`.
- **`.codespellignore`**: added `clienta` — a mermaid diagram actor ID (`actor ClientA as Doctor/App A`) on a page a frontmatter edit brought into CI scope.

## Method & safety

Only **genuinely auto-populated** pages are converted. The generator now enforces three guards, so curated pages are never silently damaged:

1. **Duplicate SUMMARY entries** — a path can appear twice (a childless cross-link plus its real nested location); the child set is taken from the occurrence that actually has children.
2. **Curated-page gate** — pages whose content-refs are grouped under `##` headings or wrapped in prose are left untouched.
3. **Data-loss gate** — any page where a currently-linked child would be dropped (curated ref set ≠ nav), or that links cross-space `http(s)` URLs, is left untouched.

**Deliberately deferred for individual handling (not in this PR):** `reference/clientserver-protocol`, `security/cve`, `mariadb-quickstart-guides/database-applications`, `reference/sql-statements`, `server-management/variables-and-modes`. Separately, four page trees are absent from `SUMMARY.md` and need their own triage (`mariadb-binlog`, `mariadb-test`, `server-management/upgrades`, `server-usage/programmatic-compound-statements`).

## Verification

- ✅ GitBook block balance on all 22 pages (2 columns + 1 content-ref per block).
- ✅ Column order matches `SUMMARY.md`.
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **30 of 323** Server landing pages. The remaining depth-3 work — the large tool catalogs and the deferred curated pages — comes next as Batch 3b, handled with more per-page care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ