### PR TITLE
DOCS-5973: Columnize curated SQL Statements & Variables and Modes landing pages

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Complete server system variables reference for MariaDB. Complete guide for
-  connection handling, caching, logging, and performance tuning for production
-  use.
+  Reference for MariaDB Server system variables — how to view and set them,
+  their scope and dynamism, and their effect on connections, caching, logging,
+  and performance.
 ---
 
 # Server System Variables

--- a/server/reference/sql-statements/README.md
+++ b/server/reference/sql-statements/README.md
@@ -7,50 +7,146 @@ description: >-
 
 # SQL Statements
 
+{% columns %}
+{% column %}
 {% content-ref url="data-definition/" %}
 [data-definition](data-definition/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn data definition language (DDL) statements in MariaDB Server. This section covers SQL commands for creating, altering, and dropping databases, tables, indexes, and other schema objects.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="data-manipulation/" %}
 [data-manipulation](data-manipulation/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn data manipulation language (DML) statements in MariaDB Server. This section covers SQL commands for inserting, updating, deleting, and selecting data within your databases.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="account-management-sql-statements/" %}
 [account-management-sql-statements](account-management-sql-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn account management SQL statements for MariaDB Server. This section covers commands like CREATE USER, GRANT, and REVOKE to securely manage user access and privileges within your database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="administrative-sql-statements/" %}
 [administrative-sql-statements](administrative-sql-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Explore administrative SQL statements for MariaDB Server. This section covers commands for server management, maintenance, and diagnostics, including BINLOG, KILL, SHUTDOWN, and SHOW.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../sql-functions/" %}
 [sql-functions](../sql-functions/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Discover functions and procedures in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="prepared-statements/" %}
 [prepared-statements](prepared-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn about prepared statements in MariaDB Server. This section details how to use them for efficient and secure execution of repetitive SQL queries, preventing SQL injection vulnerabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="programmatic-compound-statements/" %}
 [programmatic-compound-statements](programmatic-compound-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Explore programmatic compound statements in MariaDB Server. This section covers BEGIN...END blocks, loops, and conditional logic for writing complex stored routines and event definitions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../server-usage/stored-routines/" %}
 [stored-routines](../../server-usage/stored-routines/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Automate tasks in MariaDB Server with stored routines. Learn to create and manage stored procedures and functions for enhanced database efficiency and code reusability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="table-statements/" %}
 [table-statements](table-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn about table-related SQL statements in MariaDB Server. This section covers commands for creating, altering, dropping, and manipulating tables, essential for managing your database schema.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="transactions/" %}
 [transactions](transactions/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn about transactions in MariaDB Server. This section covers SQL statements for managing atomic operations (START TRANSACTION, COMMIT, ROLLBACK), ensuring data integrity and consistency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="comment-syntax.md" %}
 [comment-syntax.md](comment-syntax.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Complete SQL comment syntax: single-line # and -- (space required), multi-line /* */ blocks, MySQL /*!##### */ and MariaDB /*M!##### */ executable comments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="administrative-sql-statements/help-command.md" %}
 [help-command.md](administrative-sql-statements/help-command.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Displays help information from the server's help tables. Useful for looking up SQL syntax and command descriptions directly from the client.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/variables-and-modes/README.md
+++ b/server/server-management/variables-and-modes/README.md
@@ -23,34 +23,98 @@ layout:
 
 # Variables and Modes
 
+{% columns %}
+{% column %}
 {% content-ref url="../../reference/full-list-of-mariadb-options-system-and-status-variables.md" %}
 [full-list-of-mariadb-options-system-and-status-variables.md](../../reference/full-list-of-mariadb-options-system-and-status-variables.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+A comprehensive, alphabetical reference list of all server command-line options, system variables, and status variables available in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../ha-and-performance/optimization-and-tuning/system-variables/server-status-variables.md" %}
 [server-status-variables.md](../../ha-and-performance/optimization-and-tuning/system-variables/server-status-variables.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Documentation for server status variables, which provide information about the server's current state and operation (e.g., `Aborted_connects`, `Uptime`), accessed via `SHOW STATUS`.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md" %}
 [server-system-variables.md](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Reference for MariaDB Server system variables — how to view and set them, their scope and dynamism, and their effect on connections, caching, logging, and performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="new_mode.md" %}
 [new\_mode.md](new_mode.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Explains the `NEW_MODE` system variable (from MariaDB 11.4), which lets you opt in to new behaviors and optimizations in otherwise stable versions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="old_mode.md" %}
 [old\_mode.md](old_mode.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Describes the `OLD_MODE` system variable, used to revert specific behaviors to match older MariaDB or MySQL versions for compatibility purposes during upgrades.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="sql_mode.md" %}
 [sql\_mode.md](sql_mode.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Complete SQL_MODE reference: set via SET/SET GLOBAL/--sql-mode, view @@SQL_MODE, STRICT_TRANS_TABLES, ANSI_QUOTES, TRADITIONAL, and database emulation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modemssql" %}
 [SQL\_MODE=MSSQL](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modemssql)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+SQL_MODE=MSSQL enables Microsoft SQL Server compatibility behaviors in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modeoracle" %}
 [SQL\_MODE=ORACLE](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modeoracle)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+SQL_MODE=ORACLE enables Oracle Database compatibility behaviors in MariaDB.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/variables-and-modes/new_mode.md
+++ b/server/server-management/variables-and-modes/new_mode.md
@@ -1,8 +1,7 @@
 ---
 description: >-
-  Explains the `NEW_MODE` system variable, introduced in MariaDB 11.4, which
-  allows users to opt-in to new, potentially incompatible behaviors or
-  optimizations that will become default in future version
+  Explains the `NEW_MODE` system variable (from MariaDB 11.4), which lets you
+  opt in to new behaviors and optimizations in otherwise stable versions.
 ---
 
 # NEW\_MODE


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign. Two depth-3 landing pages were **hand-curated** with links to pages *outside their own section*, so regenerating from `server/SUMMARY.md` would have dropped or reordered links. Per the campaign owner's decision, these are handled differently: **keep the existing links exactly (set + order), wrap each in columns, and only add descriptions** — so they match the other landing pages without losing any links.

## What changed

- **`reference/sql-statements`** — 12 links preserved verbatim (incl. cross-section `../sql-functions/`, `../../server-usage/stored-routines/`, and `administrative-sql-statements/help-command.md`), each wrapped in columns with its description.
- **`server-management/variables-and-modes`** — 8 links preserved verbatim, incl. the 2 cross-space `SQL_MODE=MSSQL`/`SQL_MODE=ORACLE` links (descriptions authored for those two, since they point outside this repo).
- Fixed 2 target descriptions surfaced on these pages: `server-system-variables` (boilerplate "Complete…Complete") and `new_mode` (was truncated mid-sentence).

## Verification

- ✅ Link set and order **identical** to before (diff-checked) — nothing dropped or reordered.
- ✅ GitBook block balance (12/12 and 8/8 columns blocks).
- ✅ codespell clean. lychee runs in CI.

## Scope note

Complements #659 (no file overlap). The remaining depth-3 work — large third-party tool catalogs, three `##`-grouped/prose pages, and four page trees absent from `SUMMARY.md` — comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ