### PR TITLE
DOCS-5973: Convert 8 depth-3 tool/topology landing pages to columns (batch 3b)

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -5,3 +5,4 @@ inout
 numbe
 characte
 clienta
+hax

--- a/server/architecture/topologies/README.md
+++ b/server/architecture/topologies/README.md
@@ -7,3 +7,146 @@ description: >-
 
 # Topologies
 
+{% columns %}
+{% column %}
+{% content-ref url="topologies-overview.md" %}
+[topologies-overview.md](topologies-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB offers varied deployment topologies by workload and technology, each named and diagrammed with benefits listed. Custom configurations are also supported.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="compatibility.md" %}
+[compatibility.md](compatibility.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Operating-system support for MariaDB products and versions, with links to the engineering policies that list supported platforms.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="columnstore-object-storage/" %}
+[columnstore-object-storage](columnstore-object-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy the MariaDB ColumnStore object-storage topology, a columnar OLAP store that keeps data on S3-compatible object storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="columnstore-shared-local-storage/" %}
+[columnstore-shared-local-storage](columnstore-shared-local-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy the MariaDB ColumnStore shared-local-storage topology, a columnar OLAP store for analytical workloads.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="galera-cluster/" %}
+[galera-cluster](galera-cluster/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy the Galera Cluster topology for MariaDB — synchronous, multi-primary replication for high availability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="htap/" %}
+[htap](htap/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy the HTAP topology, pairing MariaDB row storage with ColumnStore columnar storage for mixed transactional and analytical workloads.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="primary-replica/" %}
+[primary-replica](primary-replica/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains how to set up a standard Primary/Replica replication topology for MariaDB Enterprise Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="single-node-topologies/" %}
+[single-node-topologies](single-node-topologies/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Install and configure single-node MariaDB deployments, including a single- node columnar store with optional S3-compatible object storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-storage-engine.md" %}
+[spider-storage-engine.md](spider-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Scale MariaDB horizontally with the Spider storage engine, which shards tables across remote nodes through virtual federated tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-spider-topologies/" %}
+[mariadb-enterprise-spider-topologies](mariadb-enterprise-spider-topologies/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore MariaDB Enterprise Spider topologies with MaxScale. This section details how it integrates with Spider to manage & route traffic efficiently across sharded & distributed database environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-federated/" %}
+[spider-federated](spider-federated/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy Spider Federated Topology
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-sharded/" %}
+[spider-sharded](spider-sharded/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deploy Spider Sharded Topology
+{% endcolumn %}
+{% endcolumns %}

--- a/server/architecture/topologies/columnstore-object-storage/README.md
+++ b/server/architecture/topologies/columnstore-object-storage/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Deploy the MariaDB ColumnStore object-storage topology, a columnar OLAP
+  store that keeps data on S3-compatible object storage.
+---
+
 # Columnstore Object Storage
 
 ## Overview

--- a/server/architecture/topologies/columnstore-shared-local-storage/README.md
+++ b/server/architecture/topologies/columnstore-shared-local-storage/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Deploy the MariaDB ColumnStore shared-local-storage topology, a columnar
+  OLAP store for analytical workloads.
+---
+
 # ColumnStore Shared Local Storage
 
 ## Overview

--- a/server/architecture/topologies/compatibility.md
+++ b/server/architecture/topologies/compatibility.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Operating-system support for MariaDB products and versions, with links to
+  the engineering policies that list supported platforms.
+---
+
 # Compatibility
 
 Operating System support varies by product and product version. Operating System support is detailed in [MariaDB plc Engineering Policies](https://mariadb.com/engineering-policies/?_ga=2.131247821.336363194.1760619221-718962001.1750121826).

--- a/server/architecture/topologies/galera-cluster/README.md
+++ b/server/architecture/topologies/galera-cluster/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Deploy the Galera Cluster topology for MariaDB — synchronous, multi-primary
+  replication for high availability.
+---
+
 # Galera Cluster
 
 ## Overview

--- a/server/architecture/topologies/htap/README.md
+++ b/server/architecture/topologies/htap/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Deploy the HTAP topology, pairing MariaDB row storage with ColumnStore
+  columnar storage for mixed transactional and analytical workloads.
+---
+
 # HTAP
 
 ## Overview

--- a/server/architecture/topologies/single-node-topologies/README.md
+++ b/server/architecture/topologies/single-node-topologies/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Install and configure single-node MariaDB deployments, including a single-
+  node columnar store with optional S3-compatible object storage.
+---
+
 # Single Node Topologies
 
 ## Overview

--- a/server/architecture/topologies/spider-storage-engine.md
+++ b/server/architecture/topologies/spider-storage-engine.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Scale MariaDB horizontally with the Spider storage engine, which shards
+  tables across remote nodes through virtual federated tables.
+---
+
 # Spider Storage Engine
 
 ### Spider Topologies

--- a/server/clients-and-utilities/analyzing-tools/README.md
+++ b/server/clients-and-utilities/analyzing-tools/README.md
@@ -1,2 +1,25 @@
 # Analyzing Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="explain-analyzer.md" %}
+[explain-analyzer.md](explain-analyzer.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The EXPLAIN Analyzer was an online tool for analyzing and sharing EXPLAIN output. It is no longer active.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="explain-analyzer-api.md" %}
+[explain-analyzer-api.md](explain-analyzer-api.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The EXPLAIN Analyzer API let applications submit EXPLAIN output to the online analyzer. It is no longer active.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/analyzing-tools/explain-analyzer-api.md
+++ b/server/clients-and-utilities/analyzing-tools/explain-analyzer-api.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The EXPLAIN Analyzer API let applications submit EXPLAIN output to the
+  online analyzer. It is no longer active.
+---
+
 # EXPLAIN Analyzer API
 
 {% hint style="warning" %}

--- a/server/clients-and-utilities/analyzing-tools/explain-analyzer.md
+++ b/server/clients-and-utilities/analyzing-tools/explain-analyzer.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The EXPLAIN Analyzer was an online tool for analyzing and sharing EXPLAIN
+  output. It is no longer active.
+---
+
 # EXPLAIN Analyzer
 
 {% hint style="warning" %}

--- a/server/clients-and-utilities/aria-clients-and-utilities/README.md
+++ b/server/clients-and-utilities/aria-clients-and-utilities/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Aria Clients and Utilities
 
+{% columns %}
+{% column %}
+{% content-ref url="aria_chk.md" %}
+[aria_chk.md](aria_chk.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check, repair, optimize, and report information about Aria tables with the aria_chk command-line tool.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria_pack.md" %}
+[aria_pack.md](aria_pack.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compress Aria tables into read-only form that is typically 40 to 70 percent smaller with aria_pack.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria_read_log.md" %}
+[aria_read_log.md](aria_read_log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Display and apply records from the Aria transaction log with the aria_read_log tool.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/aria-clients-and-utilities/aria_chk.md
+++ b/server/clients-and-utilities/aria-clients-and-utilities/aria_chk.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Check, repair, optimize, and report information about Aria tables with the
+  aria_chk command-line tool.
+---
+
 # aria\_chk
 
 `aria_chk` is used to check, repair, optimize, sort and get information about [Aria](../../server-usage/storage-engines/aria/aria-storage-engine.md) tables.

--- a/server/clients-and-utilities/aria-clients-and-utilities/aria_pack.md
+++ b/server/clients-and-utilities/aria-clients-and-utilities/aria_pack.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Compress Aria tables into read-only form that is typically 40 to 70 percent
+  smaller with aria_pack.
+---
+
 # aria\_pack
 
 `aria_pack` is a tool for compressing [Aria](../../server-usage/storage-engines/aria/) tables. The resulting tables are read-only, and usually about 40% to 70% smaller.

--- a/server/clients-and-utilities/aria-clients-and-utilities/aria_read_log.md
+++ b/server/clients-and-utilities/aria-clients-and-utilities/aria_read_log.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Display and apply records from the Aria transaction log with the
+  aria_read_log tool.
+---
+
 # aria\_read\_log
 
 `aria_read_log` is a tool for displaying and applying log records from an [Aria](../../server-usage/storage-engines/aria/) [transaction log](../../server-usage/storage-engines/aria/aria-storage-engine.md#aria-log-files).

--- a/server/clients-and-utilities/backup-restore-and-import-clients/README.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Backup, Restore and Import Clients
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-dump.md" %}
+[mariadb-dump.md](mariadb-dump.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB backup and recovery guide. Complete resource for backup methods, mariabackup usage, scheduling, and restoration for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-hotcopy.md" %}
+[mariadb-hotcopy.md](mariadb-hotcopy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Quickly back up MyISAM and Aria tables by copying table files with the mariadb-hotcopy Perl script (formerly mysqlhotcopy).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-import.md" %}
+[mariadb-import.md](mariadb-import.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete mariadb-import reference: load tables from text files, --fields-terminated-by delimiter, --local file option, and --parallel/-j processing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md" %}
+[backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md](backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+dbForge Studio is a proprietary third-party tool, not included with MariaDB, for backup, restore, and data export and import.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/backup-restore-and-import-clients/backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/backup-restore-and-import-clients-backuprestore-data-exportimport-via-dbfor.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  dbForge Studio is a proprietary third-party tool, not included with MariaDB,
+  for backup, restore, and data export and import.
+---
+
 # dbForge Studio
 
 {% hint style="info" %}

--- a/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-hotcopy.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-hotcopy.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Quickly back up MyISAM and Aria tables by copying table files with the
+  mariadb-hotcopy Perl script (formerly mysqlhotcopy).
+---
+
 # mariadb-hotcopy
 
 `mariadb-hotcopy` is a Perl script that was originally written and contributed by Tim Bunce. It uses [FLUSH TABLES](../../reference/sql-statements/administrative-sql-statements/flush-commands/flush.md), [LOCK TABLES](../../reference/sql-statements/transactions/lock-tables.md), and cp or scp to make a database backup.

--- a/server/clients-and-utilities/myisam-clients-and-utilities/README.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # MyISAM Clients and Utilities
 
+{% columns %}
+{% column %}
+{% content-ref url="memory-and-disk-use-with-myisamchk.md" %}
+[memory-and-disk-use-with-myisamchk.md](memory-and-disk-use-with-myisamchk.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Tune myisamchk memory and disk usage to speed up checking and repairing large MyISAM tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam-database-management-using-gui-client.md" %}
+[myisam-database-management-using-gui-client.md](myisam-database-management-using-gui-client.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of managing MyISAM tables through graphical (GUI) client tools.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam_ftdump.md" %}
+[myisam_ftdump.md](myisam_ftdump.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Display information about MyISAM FULLTEXT indexes with the myisam_ftdump utility.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisamchk-table-information.md" %}
+[myisamchk-table-information.md](myisamchk-table-information.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Use myisamchk options to report information about MyISAM tables and their indexes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisamchk.md" %}
+[myisamchk.md](myisamchk.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check, repair, and optimize non-partitioned MyISAM tables from the command line with myisamchk.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisamlog.md" %}
+[myisamlog.md](myisamlog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Process and display the contents of a MyISAM log file with the myisamlog utility.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisampack.md" %}
+[myisampack.md](myisampack.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compress MyISAM tables into read-only form that is typically 40 to 70 percent smaller with myisampack.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/myisam-clients-and-utilities/memory-and-disk-use-with-myisamchk.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/memory-and-disk-use-with-myisamchk.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Tune myisamchk memory and disk usage to speed up checking and repairing
+  large MyISAM tables.
+---
+
 # Memory and Disk Use With myisamchk
 
 myisamchk's performance can be dramatically enhanced for larger tables by making sure that its memory-related variables are set to an optimum level.

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisam-database-management-using-gui-client.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisam-database-management-using-gui-client.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  An overview of managing MyISAM tables through graphical (GUI) client tools.
+---
+
 # MyISAM Database Management using GUI Client
 
 Navigating the complexities of database management requires the right tools and know-how, especially when dealing with specialized storage engines like MyISAM in MySQL and MariaDB environments. This comprehensive guide demystifies the role and functionality of MyISAM clients, offering you a deep dive into their essential features and operations. From initiating CRUD operations to optimizing table performance, we cover it all. We also spotlight dbForge Studio for MySQL, a feature-rich IDE that simplifies your interactions with MyISAM tables and databases. Whether you're a seasoned DBA or a developer looking to sharpen your database skills, this article serves as your go-to resource for understanding MyISAM clients and maximizing their capabilities.

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisam_ftdump.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisam_ftdump.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Display information about MyISAM FULLTEXT indexes with the myisam_ftdump
+  utility.
+---
+
 # myisam\_ftdump
 
 myisam\_ftdump is a utility for displaying information about [MyISAM](../../server-usage/storage-engines/myisam-storage-engine/) [FULLTEXT](../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/full-text-indexes/) indexes. It will scan and dump the entire index, and can be a lengthy process.

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisamchk-table-information.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisamchk-table-information.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Use myisamchk options to report information about MyISAM tables and their
+  indexes.
+---
+
 # myisamchk Table Information
 
 [myisamchk](myisamchk.md) can be used to obtain information about MyISAM tables, particularly with the _-d_, _-e_, _-i_ and _-v_ options.

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisamchk.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisamchk.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Check, repair, and optimize non-partitioned MyISAM tables from the command
+  line with myisamchk.
+---
+
 # myisamchk
 
 ## myisamchk

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisamlog.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisamlog.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Process and display the contents of a MyISAM log file with the myisamlog
+  utility.
+---
+
 # myisamlog
 
 `myisamlog` processes and returns the contents of a [MyISAM log file](../../server-management/server-monitoring-logs/myisam-log.md).

--- a/server/clients-and-utilities/myisam-clients-and-utilities/myisampack.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/myisampack.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Compress MyISAM tables into read-only form that is typically 40 to 70
+  percent smaller with myisampack.
+---
+
 # myisampack
 
 ## myisampack

--- a/server/clients-and-utilities/server-client-software/README.md
+++ b/server/clients-and-utilities/server-client-software/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Server & Client Software
 
+{% columns %}
+{% column %}
+{% content-ref url="about-mariadb-software.md" %}
+[about-mariadb-software.md](about-mariadb-software.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of MariaDB, the open-source relational database — its background, licensing, and widespread adoption.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="applications-supporting-mariadb.md" %}
+[applications-supporting-mariadb.md](applications-supporting-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of projects and applications that officially support MariaDB or its enhanced features.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-foundation.md" %}
+[mariadb-foundation.md](mariadb-foundation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The MariaDB Foundation is the custodian of the MariaDB code and steward of its open, vendor-neutral development.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="client-libraries/" %}
+[client-libraries](client-libraries/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore server and client software for MariaDB. This section introduces various tools and applications for connecting to, managing, and interacting with your MariaDB Server instances effectively.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="download/" %}
+[download](download/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Where to download MariaDB — tarballs, source, and Linux and Windows binaries, plus distribution packages.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/server-client-software/about-mariadb-software.md
+++ b/server/clients-and-utilities/server-client-software/about-mariadb-software.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  An overview of MariaDB, the open-source relational database — its
+  background, licensing, and widespread adoption.
+---
+
 # About MariaDB Software
 
 MariaDB is an open-source, multi-threaded, relational database management system, released under the [GNU Public License](https://app.gitbook.com/s/WCInJQ9cmGjq1lsTG91E/community/community/faq/licensing-questions/licensing-faq) (GPL). MariaDB's lead developer is Michael "Monty" Widenius, who is one of the founders of MySQL AB.

--- a/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
+++ b/server/clients-and-utilities/server-client-software/applications-supporting-mariadb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  A list of projects and applications that officially support MariaDB or its
+  enhanced features.
+---
+
 # Applications Supporting MariaDB
 
 This page lists projects which officially implement MariaDB's enhanced features, or state that they work with MariaDB. If you know of a project which officially supports MariaDB and it isn't listed here, please let us know in the comments.

--- a/server/clients-and-utilities/server-client-software/download/README.md
+++ b/server/clients-and-utilities/server-client-software/download/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Where to download MariaDB — tarballs, source, and Linux and Windows
+  binaries, plus distribution packages.
+---
+
 # Downloads
 
 #### Latest Packages

--- a/server/clients-and-utilities/server-client-software/mariadb-foundation.md
+++ b/server/clients-and-utilities/server-client-software/mariadb-foundation.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The MariaDB Foundation is the custodian of the MariaDB code and steward of
+  its open, vendor-neutral development.
+---
+
 # About the MariaDB Foundation
 
 The [MariaDB Foundation](https://mariadb.org) ensures that there is not just one person or one company driving MariaDB/MySQL development. It is the custodian of the MariaDB code and guardian of the MariaDB community.

--- a/server/clients-and-utilities/table-tools/README.md
+++ b/server/clients-and-utilities/table-tools/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Table Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-check.md" %}
+[mariadb-check.md](mariadb-check.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete mariadb-check reference: CHECK/REPAIR/ANALYZE/OPTIMIZE TABLE operations, --all-databases/--databases flags, --auto-repair, and option files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-convert-table-format.md" %}
+[mariadb-convert-table-format.md](mariadb-convert-table-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert every table in a database to a given storage engine (MyISAM by default) with mariadb-convert-table-format (formerly mysql_convert_table_format).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-fix-extensions.md" %}
+[mariadb-fix-extensions.md](mariadb-fix-extensions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fix the file extensions of MyISAM table files with mariadb-fix-extensions (formerly mysql_fix_extensions).
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/table-tools/mariadb-convert-table-format.md
+++ b/server/clients-and-utilities/table-tools/mariadb-convert-table-format.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Convert every table in a database to a given storage engine (MyISAM by
+  default) with mariadb-convert-table-format (formerly
+  mysql_convert_table_format).
+---
+
 # mariadb-convert-table-format
 
 `mariadb-convert-table-format` converts the tables in a database to use a particular storage engine ([MyISAM](../../server-usage/storage-engines/myisam-storage-engine/) by default).

--- a/server/clients-and-utilities/table-tools/mariadb-fix-extensions.md
+++ b/server/clients-and-utilities/table-tools/mariadb-fix-extensions.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Fix the file extensions of MyISAM table files with mariadb-fix-extensions
+  (formerly mysql_fix_extensions).
+---
+
 # mariadb-fix-extensions
 
 `mariadb-fix-extensions` converts the extensions for [MyISAM](https://github.com/mariadb-corporation/docs-server/blob/test/server/clients-and-utilities/reference/storage-engines/myisam-storage-engine/README.md) (or ISAM) table files to their canonical forms.

--- a/server/clients-and-utilities/testing-tools/README.md
+++ b/server/clients-and-utilities/testing-tools/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Testing Tools
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-slap.md" %}
+[mariadb-slap.md](mariadb-slap.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Load-test MariaDB with mariadb-slap by emulating many concurrent clients running a set of queries repeatedly (formerly mysqlslap).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-stress-test.md" %}
+[mariadb-stress-test.md](mariadb-stress-test.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Stress-test a MariaDB server by running test scenarios repeatedly with mariadb-stress-test (a symlink to mysql-stress-test).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-test/" %}
+[mariadb-test](mariadb-test/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB uses mariadb-test to test functionality. It is an all-in-one test framework doing unit, regression, and conformance testing
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/testing-tools/mariadb-slap.md
+++ b/server/clients-and-utilities/testing-tools/mariadb-slap.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Load-test MariaDB with mariadb-slap by emulating many concurrent clients
+  running a set of queries repeatedly (formerly mysqlslap).
+---
+
 # mariadb-slap
 
 `mariadb-slap` is a tool for load-testing MariaDB. It allows you to emulate multiple concurrent connections, and run a set of queries multiple times.

--- a/server/clients-and-utilities/testing-tools/mariadb-stress-test.md
+++ b/server/clients-and-utilities/testing-tools/mariadb-stress-test.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Stress-test a MariaDB server by running test scenarios repeatedly with
+  mariadb-stress-test (a symlink to mysql-stress-test).
+---
+
 # mariadb-stress-test
 
 `mariadb-stress-test` is a symlink to `mysql-stress-test`, the script for assisting with adding users or databases or changing passwords in MariaDB.


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign. Converts **8 auto-populated depth-3 landing pages** into "optimal" ones (one `{% columns %}` block per child: a `content-ref` link + the child's description), modeled on `server/reference/product-development`.

These are the MariaDB-native tool/topology pages — the clean, high-confidence tier of the depth-3 tail.

## What changed

- **8 landing pages → columns**, in `server/SUMMARY.md` nav order: `architecture/topologies` and the client/utility sections `myisam-`, `aria-`, `analyzing-`, `table-`, `testing-tools`, `server-client-software`, `backup-restore-and-import-clients`.
- **29 child descriptions authored** from each page's own content (MariaDB-native tools/topologies — `myisamchk`, `aria_chk`, `mariadb-slap`, Galera/HTAP/Spider topologies, etc.).
- **`.codespellignore`**: added `hax` — a URL path fragment (`?id=hax:…`) on a page a frontmatter edit brought into CI scope.

## Method & safety

Only genuinely auto-populated pages are converted. The generator's guards remain in force: child set/order from `SUMMARY.md`; pages with `##`-grouped or prose content are skipped; any page where a currently-linked child would be dropped is skipped; cross-space `http` links are skipped. (3 curated depth-3 pages were correctly deferred by these guards.)

## Verification

- ✅ GitBook block balance on all 8 pages (2 columns + 1 content-ref per block).
- ✅ Column order matches `SUMMARY.md`.
- ✅ codespell clean (with `.codespellignore`, as CI runs it). lychee runs in CI.

## Note for separate cleanup

`clients-and-utilities/testing-tools/mariadb-stress-test.md` — the page **body** is self-contradictory (title = stress-test, but the prose describes "adding users/databases/changing passwords", which looks like a wrong copy-paste). This PR only adds an accurate frontmatter description; the body is untouched and worth a separate fix.

## Scope note

Campaign progress: **40 of 323** Server landing pages. Remaining depth-3: the large third-party tool catalogs (planned as lighter-treatment), `error-codes` (formulaic), 3 curated pages (hand edits), and 4 page trees absent from `SUMMARY.md` (separate ticket). Depth 4–9 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ