### PR TITLE
DOCS-5973: Convert 3 tool catalogs to card lists (batch 3c)

### DIFF
--- a/server/clients-and-utilities/administrative-tools/README.md
+++ b/server/clients-and-utilities/administrative-tools/README.md
@@ -7,3 +7,70 @@ description: >-
 
 # Administrative Tools
 
+{% content-ref url="dbdeployer.md" %}
+[dbdeployer.md](dbdeployer.md)
+{% endcontent-ref %}
+
+{% content-ref url="innochecksum.md" %}
+[innochecksum.md](innochecksum.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-access.md" %}
+[mariadb-access.md](mariadb-access.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-admin.md" %}
+[mariadb-admin.md](mariadb-admin.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-conv.md" %}
+[mariadb-conv.md](mariadb-conv.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-setpermission.md" %}
+[mariadb-setpermission.md](mariadb-setpermission.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-show.md" %}
+[mariadb-show.md](mariadb-show.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-plugin.md" %}
+[mariadb-plugin.md](mariadb-plugin.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-report.md" %}
+[mariadb-report.md](mariadb-report.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-find-rows.md" %}
+[mariadb-find-rows.md](mariadb-find-rows.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-tzinfo-to-sql.md" %}
+[mariadb-tzinfo-to-sql.md](mariadb-tzinfo-to-sql.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-waitpid.md" %}
+[mariadb-waitpid.md](mariadb-waitpid.md)
+{% endcontent-ref %}
+
+{% content-ref url="my_print_defaults.md" %}
+[my_print_defaults.md](my_print_defaults.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-embedded.md" %}
+[mariadb-embedded.md](mariadb-embedded.md)
+{% endcontent-ref %}
+
+{% content-ref url="perror.md" %}
+[perror.md](perror.md)
+{% endcontent-ref %}
+
+{% content-ref url="replace-utility.md" %}
+[replace-utility.md](replace-utility.md)
+{% endcontent-ref %}
+
+{% content-ref url="resolve_stack_dump.md" %}
+[resolve_stack_dump.md](resolve_stack_dump.md)
+{% endcontent-ref %}

--- a/server/clients-and-utilities/graphical-and-enhanced-clients/README.md
+++ b/server/clients-and-utilities/graphical-and-enhanced-clients/README.md
@@ -7,3 +7,146 @@ description: >-
 
 # Graphical and Enhanced Clients
 
+{% content-ref url="adminer.md" %}
+[adminer.md](adminer.md)
+{% endcontent-ref %}
+
+{% content-ref url="beekeeper-studio.md" %}
+[beekeeper-studio.md](beekeeper-studio.md)
+{% endcontent-ref %}
+
+{% content-ref url="cost-effective-agentless-mariadb-database-performance-management.md" %}
+[cost-effective-agentless-mariadb-database-performance-management.md](cost-effective-agentless-mariadb-database-performance-management.md)
+{% endcontent-ref %}
+
+{% content-ref url="database-workbench.md" %}
+[database-workbench.md](database-workbench.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-data-compare.md" %}
+[dbforge-data-compare.md](dbforge-data-compare.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-data-generator.md" %}
+[dbforge-data-generator.md](dbforge-data-generator.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-documenter-for-mariadb-and-mysql.md" %}
+[dbforge-documenter-for-mariadb-and-mysql.md](dbforge-documenter-for-mariadb-and-mysql.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-edge.md" %}
+[dbforge-edge.md](dbforge-edge.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-fusion-mysql-mariadb-plugin-for-vs.md" %}
+[dbforge-fusion-mysql-mariadb-plugin-for-vs.md](dbforge-fusion-mysql-mariadb-plugin-for-vs.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-query-builder-for-mysql-mariadb.md" %}
+[dbforge-query-builder-for-mysql-mariadb.md](dbforge-query-builder-for-mysql-mariadb.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-schema-compare-for-mariadb-mysql.md" %}
+[dbforge-schema-compare-for-mariadb-mysql.md](dbforge-schema-compare-for-mariadb-mysql.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md" %}
+[dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md](dbforge-studio-for-mariadb-universal-gui-tool-for-management-administration.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbschema.md" %}
+[dbschema.md](dbschema.md)
+{% endcontent-ref %}
+
+{% content-ref url="dbvisualizer.md" %}
+[dbvisualizer.md](dbvisualizer.md)
+{% endcontent-ref %}
+
+{% content-ref url="dezign-for-databases.md" %}
+[dezign-for-databases.md](dezign-for-databases.md)
+{% endcontent-ref %}
+
+{% content-ref url="erbuilder-data-modeler.md" %}
+[erbuilder-data-modeler.md](erbuilder-data-modeler.md)
+{% endcontent-ref %}
+
+{% content-ref url="graphical-and-enhanced-clients-dbeaver.md" %}
+[graphical-and-enhanced-clients-dbeaver.md](graphical-and-enhanced-clients-dbeaver.md)
+{% endcontent-ref %}
+
+{% content-ref url="graphical-and-enhanced-clients-omnidb.md" %}
+[graphical-and-enhanced-clients-omnidb.md](graphical-and-enhanced-clients-omnidb.md)
+{% endcontent-ref %}
+
+{% content-ref url="graphical-and-enhanced-clients-sequel-pro.md" %}
+[graphical-and-enhanced-clients-sequel-pro.md](graphical-and-enhanced-clients-sequel-pro.md)
+{% endcontent-ref %}
+
+{% content-ref url="heidisql.md" %}
+[heidisql.md](heidisql.md)
+{% endcontent-ref %}
+
+{% content-ref url="ks-db-merge-tools-for-mysql-and-mariadb.md" %}
+[ks-db-merge-tools-for-mysql-and-mariadb.md](ks-db-merge-tools-for-mysql-and-mariadb.md)
+{% endcontent-ref %}
+
+{% content-ref url="libreoffice-base.md" %}
+[libreoffice-base.md](libreoffice-base.md)
+{% endcontent-ref %}
+
+{% content-ref url="luna-modeler.md" %}
+[luna-modeler.md](luna-modeler.md)
+{% endcontent-ref %}
+
+{% content-ref url="mycli.md" %}
+[mycli.md](mycli.md)
+{% endcontent-ref %}
+
+{% content-ref url="navicat.md" %}
+[navicat.md](navicat.md)
+{% endcontent-ref %}
+
+{% content-ref url="ocelotgui.md" %}
+[ocelotgui.md](ocelotgui.md)
+{% endcontent-ref %}
+
+{% content-ref url="pgmanage.md" %}
+[pgmanage.md](pgmanage.md)
+{% endcontent-ref %}
+
+{% content-ref url="phpmyadmin.md" %}
+[phpmyadmin.md](phpmyadmin.md)
+{% endcontent-ref %}
+
+{% content-ref url="querious.md" %}
+[querious.md](querious.md)
+{% endcontent-ref %}
+
+{% content-ref url="sb-data-generator.md" %}
+[sb-data-generator.md](sb-data-generator.md)
+{% endcontent-ref %}
+
+{% content-ref url="sqlpro-studio.md" %}
+[sqlpro-studio.md](sqlpro-studio.md)
+{% endcontent-ref %}
+
+{% content-ref url="sqlyog-community-edition.md" %}
+[sqlyog-community-edition.md](sqlyog-community-edition.md)
+{% endcontent-ref %}
+
+{% content-ref url="tableplus.md" %}
+[tableplus.md](tableplus.md)
+{% endcontent-ref %}
+
+{% content-ref url="toad-edge.md" %}
+[toad-edge.md](toad-edge.md)
+{% endcontent-ref %}
+
+{% content-ref url="valentina-studio.md" %}
+[valentina-studio.md](valentina-studio.md)
+{% endcontent-ref %}
+
+{% content-ref url="mariadb-direct-query-adapter-for-microsoft-power-bi.md" %}
+[mariadb-direct-query-adapter-for-microsoft-power-bi.md](mariadb-direct-query-adapter-for-microsoft-power-bi.md)
+{% endcontent-ref %}

--- a/server/clients-and-utilities/legacy-clients-and-utilities/README.md
+++ b/server/clients-and-utilities/legacy-clients-and-utilities/README.md
@@ -7,3 +7,118 @@ description: >-
 
 # Legacy Clients and Utilities
 
+{% content-ref url="../analyzing-tools/" %}
+[analyzing-tools](../analyzing-tools/)
+{% endcontent-ref %}
+
+{% content-ref url="mariadbd_safe.md" %}
+[mariadbd_safe.md](mariadbd_safe.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql-sandbox.md" %}
+[mysql-sandbox.md](mysql-sandbox.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_convert_table_format.md" %}
+[mysql_convert_table_format.md](mysql_convert_table_format.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_embedded.md" %}
+[mysql_embedded.md](mysql_embedded.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_find_rows.md" %}
+[mysql_find_rows.md](mysql_find_rows.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_fix_extensions.md" %}
+[mysql_fix_extensions.md](mysql_fix_extensions.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_install_db.md" %}
+[mysql_install_db.md](mysql_install_db.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_plugin.md" %}
+[mysql_plugin.md](mysql_plugin.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_secure_installation.md" %}
+[mysql_secure_installation.md](mysql_secure_installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_setpermission.md" %}
+[mysql_setpermission.md](mysql_setpermission.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_tzinfo_to_sql.md" %}
+[mysql_tzinfo_to_sql.md](mysql_tzinfo_to_sql.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_upgrade.md" %}
+[mysql_upgrade.md](mysql_upgrade.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_waitpid.md" %}
+[mysql_waitpid.md](mysql_waitpid.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysql_zap.md" %}
+[mysql_zap.md](mysql_zap.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlaccess.md" %}
+[mysqlaccess.md](mysqlaccess.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqladmin.md" %}
+[mysqladmin.md](mysqladmin.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlcheck.md" %}
+[mysqlcheck.md](mysqlcheck.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqld_multi.md" %}
+[mysqld_multi.md](mysqld_multi.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqldump.md" %}
+[mysqldump.md](mysqldump.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqldumpslow.md" %}
+[mysqldumpslow.md](mysqldumpslow.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlhotcopy.md" %}
+[mysqlhotcopy.md](mysqlhotcopy.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlimport.md" %}
+[mysqlimport.md](mysqlimport.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlreport.md" %}
+[mysqlreport.md](mysqlreport.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlshow.md" %}
+[mysqlshow.md](mysqlshow.md)
+{% endcontent-ref %}
+
+{% content-ref url="mysqlslap.md" %}
+[mysqlslap.md](mysqlslap.md)
+{% endcontent-ref %}
+
+{% content-ref url="backing-up-and-restoring-databases-percona-xtrabackup/" %}
+[backing-up-and-restoring-databases-percona-xtrabackup](backing-up-and-restoring-databases-percona-xtrabackup/)
+{% endcontent-ref %}
+
+{% content-ref url="msql2mysql.md" %}
+[msql2mysql.md](msql2mysql.md)
+{% endcontent-ref %}
+
+{% content-ref url="xtstat.md" %}
+[xtstat.md](xtstat.md)
+{% endcontent-ref %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page campaign. Converts the three large **third-party tool catalog** landing pages, which are mostly description-less listings of external products.

## What changed

- `clients-and-utilities/graphical-and-enhanced-clients` (36), `legacy-clients-and-utilities` (29), `administrative-tools` (17) → a plain sequence of **full-width `content-ref` cards**, one per row, in `server/SUMMARY.md` order. 82 cards total.

## Method — lighter treatment (by design)

Per the campaign owner's decision, per-tool descriptions are **not authored** here (these are third-party products; rich descriptions are deferred / left to tool owners). Because the descriptions are blank, full-width cards are used rather than the `{% columns %}` two-column layout, which would leave an empty right column on every row. GitBook still auto-renders a card's description for the few target pages that already have one.

## Verification

- ✅ All 82 card link targets exist.
- ✅ `content-ref` blocks balanced (36/29/17 open == close).
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **58 of 323** Server landing pages; depth-3 nearly complete. Remaining depth-3: 3 curated pages needing hand edits (`clientserver-protocol`, `cve`, `database-applications`) and 4 page trees absent from `SUMMARY.md` (proposed as a separate ticket). Depth 4–9 follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ