### PR TITLE
DOCS-5973: Columnize 3 curated depth-3 landing pages (batch 3d)

### DIFF
--- a/server/mariadb-quickstart-guides/database-applications/README.md
+++ b/server/mariadb-quickstart-guides/database-applications/README.md
@@ -38,3 +38,53 @@ Here's a summary of key areas and advice covered; find the full guide on the sub
   * Views: Create separate databases for new versions with views referencing data in older or newer schemas to manage transitions.
   * Replication: Use MariaDB replication, particularly statement-based replication (SBR), for canary testing by replicating from the production system to a new server with the updated schema.
   * Invisible Columns: A MariaDB feature allowing columns to exist without being exposed by default, useful in scenarios where old applications use `SELECT *` or `INSERT` without column names, allowing new columns to be added without breaking existing code.
+
+## In This Guide
+
+{% columns %}
+{% column %}
+{% content-ref url="introduction-and-background.md" %}
+[introduction-and-background.md](introduction-and-background.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section provides an introduction to developing database-backed applications with MariaDB, discussing maintenance, upgrades, and separation of concerns.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="database-design.md" %}
+[database-design.md](database-design.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about best practices for database schema design, including naming conventions, choosing appropriate data types, and using views to abstract complexity.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="application-code.md" %}
+[application-code.md](application-code.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide covers application-side considerations, such as using ORMs, stored procedures, and writing robust SQL that handles schema changes gracefully.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="canary-testing.md" %}
+[canary-testing.md](canary-testing.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore strategies for safely testing schema and application changes using canary deployments, replication, and features like invisible columns.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/clientserver-protocol/README.md
+++ b/server/reference/clientserver-protocol/README.md
@@ -9,38 +9,102 @@ description: >-
 
 ## Client/Server Protocol Overview
 
+{% columns %}
+{% column %}
 {% content-ref url="protocol-data-types.md" %}
 [protocol-data-types.md](protocol-data-types.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+This page defines the fundamental data types used in the MariaDB client/server protocol, including integers, strings, and binary representations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="mariadb-protocol-differences-with-mysql.md" %}
 [mariadb-protocol-differences-with-mysql.md](mariadb-protocol-differences-with-mysql.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the specific extensions and differences in the MariaDB protocol compared to MySQL, such as extended capability flags and metadata.
+{% endcolumn %}
+{% endcolumns %}
 
 ## Client/Server Protocol Documentation
 
+{% columns %}
+{% column %}
 {% content-ref url="0-packet.md" %}
 [0-packet.md](0-packet.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Understand the standard packet structure in the MariaDB protocol, including the packet header, length, sequence number, and payload handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="1-connecting/" %}
 [1-connecting](1-connecting/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Learn about the connection phase in the client/server protocol. This section details how clients establish initial communication with the server, including handshaking and authentication processes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="2-text-protocol/" %}
 [2-text-protocol](2-text-protocol/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Understand the text protocol in the Server's client/server communication. This section details how SQL commands and results are exchanged as plain text, including command types and packet structures.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="3-binary-protocol-prepared-statements/" %}
 [3-binary-protocol-prepared-statements](3-binary-protocol-prepared-statements/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Understand the binary protocol for prepared statements. This section details how prepared statements are exchanged efficiently between client and server, optimizing performance and security.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="4-server-response-packets/" %}
 [4-server-response-packets](4-server-response-packets/)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand server response packets in MariaDB's client/server protocol. This section details the various types of packets sent by the server, including OK, Error, and Result Set packets.
+{% endcolumn %}
+{% endcolumns %}
 
 ## Replication Protocol Documentation
 
+{% columns %}
+{% column %}
 {% content-ref url="replication-protocol/" %}
 [replication-protocol](replication-protocol/)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the replication protocol. This section details how primary and replica servers communicate, exchanging binary log events to ensure data consistency and enable high availability.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/cve/README.md
+++ b/server/security/cve/README.md
@@ -28,13 +28,29 @@ For additional information, see [Vulnerability Metrics](https://nvd.nist.gov/vul
 
 ## Fixed Security Vulnerabilities
 
+{% columns %}
+{% column %}
 {% content-ref url="enterprise-server.md" %}
 [enterprise-server.md](enterprise-server.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+This page contains a full list of CVEs fixed in all versions and series of MariaDB Enterprise Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="community-server.md" %}
 [community-server.md](community-server.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page contains a full list of CVEs fixed in all versions and series of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
 
 Some CVE apply to MySQL but are not present in MariaDB Enterprise Server or MariaDB Community Server; these are listed on the [Security Vulnerabilities fixed in Oracle MySQL that did not exist in MariaDB](security-vulnerabilities-in-oracle-mysql-that-did-not-exist-in-mariadb.md) page.
 


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page campaign. Three depth-3 pages were **hand-curated** (grouped headings, hint boxes, prose, or a full article), so the mechanical generator was not safe. This PR converts them by hand, preserving all existing structure. **Completes depth-3.**

## What changed

- **`reference/clientserver-protocol`** — wrap the 8 existing content-refs in columns **in place**, keeping the three `##` group headings (Overview / Documentation / Replication).
- **`security/cve`** — wrap the 2 existing content-refs in columns, keeping both hint boxes, all three `##` sections, the trailing "Some CVE apply to MySQL…" prose (with its inline link to the third child), and the license + marketo footer.
- **`mariadb-quickstart-guides/database-applications`** — a full article; its body is left untouched and an `## In This Guide` columns section is appended for its 4 sub-pages.

All column descriptions are sourced from child frontmatter; none authored.

## Verification

- ✅ GitBook block balance across all 3 pages (columns and content-ref open == close).
- ✅ All 14 card link targets exist.
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **61 of 323** Server landing pages — **depth 1, 2, and 3 now complete**, except four page trees absent from `SUMMARY.md` (tracked in a separate ticket). Depth 4–9 (~271 pages) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ