### PR TITLE
DOCS-5973: Convert 24 depth-4 reference landing pages to columns (batch 4a)

### DIFF
--- a/server/reference/plugins/authentication-plugins/README.md
+++ b/server/reference/plugins/authentication-plugins/README.md
@@ -7,3 +7,134 @@ description: >-
 
 # Authentication Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="pluggable-authentication-overview.md" %}
+[pluggable-authentication-overview.md](pluggable-authentication-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Pluggable authentication allows MariaDB to use various authentication methods, enabling external validation, different hashing algorithms, and role-based access control.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-caching_sha2_password.md" %}
+[authentication-plugin-caching_sha2_password.md](authentication-plugin-caching_sha2_password.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MySQL-compatible caching_sha2_password authentication plugin, for migrating MySQL users to MariaDB without changing their passwords (migration use; PARSEC is recommended otherwise).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-ed25519.md" %}
+[authentication-plugin-ed25519.md](authentication-plugin-ed25519.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The ed25519 authentication plugin provides high-security password authentication using the Elliptic Curve Digital Signature Algorithm, a modern alternative to SHA-1.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-gssapi.md" %}
+[authentication-plugin-gssapi.md](authentication-plugin-gssapi.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete GSSAPI authentication setup: Kerberos/SSPI single sign-on, INSTALL SONAME 'auth_gssapi', gssapi_keytab_path/principal_name, CREATE USER syntax.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-mysql_native_password.md" %}
+[authentication-plugin-mysql_native_password.md](authentication-plugin-mysql_native_password.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Authentication Plugin - mysql_native_password guide for MariaDB. Complete reference documentation for implementation, configuration, and usage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-mysql_old_password.md" %}
+[authentication-plugin-mysql_old_password.md](authentication-plugin-mysql_old_password.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This plugin provides backward compatibility for pre-4.1 clients using an older, insecure password hashing algorithm and should not be used for new installations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-named-pipe.md" %}
+[authentication-plugin-named-pipe.md](authentication-plugin-named-pipe.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The named_pipe authentication plugin allows Windows users connecting via named pipes to authenticate using their operating system credentials without a password.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-parsec.md" %}
+[authentication-plugin-parsec.md](authentication-plugin-parsec.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+PARSEC is a modern, secure authentication plugin that uses salted passwords and elliptic curve cryptography to prevent replay attacks and secure user credentials.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-sha-256.md" %}
+[authentication-plugin-sha-256.md](authentication-plugin-sha-256.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The SHA-256 authentication plugin uses the SHA-256 hashing algorithm for password storage, offering stronger security than the default SHA-1 method.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-plugin-unix-socket.md" %}
+[authentication-plugin-unix-socket.md](authentication-plugin-unix-socket.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Official Unix socket authentication: OS user login via SO_PEERCRED/uid matching, CREATE USER IDENTIFIED VIA unix_socket, and unix_socket force modes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="authentication-with-pluggable-authentication-modules-pam/" %}
+[authentication-with-pluggable-authentication-modules-pam](authentication-with-pluggable-authentication-modules-pam/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about authentication with Pluggable Authentication Modules (PAM) in MariaDB Server. This section details how to integrate MariaDB with PAM for centralized and flexible user authentication.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/plugins/authentication-plugins/authentication-plugin-caching_sha2_password.md
+++ b/server/reference/plugins/authentication-plugins/authentication-plugin-caching_sha2_password.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  MySQL-compatible caching_sha2_password authentication plugin, for migrating
+  MySQL users to MariaDB without changing their passwords (migration use;
+  PARSEC is recommended otherwise).
+---
+
 # Authentication Plugin - caching\_sha2\_password
 
 {% hint style="info" %}

--- a/server/reference/plugins/mariadb-audit-plugin/README.md
+++ b/server/reference/plugins/mariadb-audit-plugin/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # MariaDB Community Audit Plugin
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-overview.md" %}
+[mariadb-audit-plugin-overview.md](mariadb-audit-plugin-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The MariaDB Audit Plugin records server activity, including connections, queries, and table access, to help meet organizational auditing and compliance regulations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-installation.md" %}
+[mariadb-audit-plugin-installation.md](mariadb-audit-plugin-installation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Follow this guide to install the Audit Plugin on your MariaDB server. Learn how to verify the plugin file's location, load it dynamically, or configure it to load automatically at startup.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-configuration.md" %}
+[mariadb-audit-plugin-configuration.md](mariadb-audit-plugin-configuration.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Configure the Audit Plugin to suit your monitoring requirements. Learn how to enable logging, select specific event types to record, and exclude specific users from the audit trail.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-log-settings.md" %}
+[mariadb-audit-plugin-log-settings.md](mariadb-audit-plugin-log-settings.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control where and how the audit data is stored. This section explains how to direct output to a file or the system syslog, and how to configure logging parameters for different environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-location-and-rotation-of-logs.md" %}
+[mariadb-audit-plugin-location-and-rotation-of-logs.md](mariadb-audit-plugin-location-and-rotation-of-logs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage your audit log files effectively. Learn how to define the log file path, set size limits, and configure rotation strategies to prevent log files from consuming all available disk space.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-log-format.md" %}
+[mariadb-audit-plugin-log-format.md](mariadb-audit-plugin-log-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the structure of audit log entries. This guide breaks down the fields in the log records, including timestamps, server IDs, user details, and the specific operations performed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-options-and-system-variables.md" %}
+[mariadb-audit-plugin-options-and-system-variables.md](mariadb-audit-plugin-options-and-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Browse the complete reference of system variables for the Audit Plugin. Use these settings to fine-tune logging behavior, control performance impact, and manage log file handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-status-variables.md" %}
+[mariadb-audit-plugin-status-variables.md](mariadb-audit-plugin-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Monitor the performance and status of the Audit Plugin. View variables that track the number of logged events and current settings to ensure the auditing system is functioning correctly.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-audit-plugin-versions.md" %}
+[mariadb-audit-plugin-versions.md](mariadb-audit-plugin-versions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Review the version history of the MariaDB Audit Plugin. Check compatibility with different MariaDB Server releases and identify which features or bug fixes are included in each version.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/plugins/mariadb-replication-cluster-plugins/README.md
+++ b/server/reference/plugins/mariadb-replication-cluster-plugins/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # MariaDB Replication & Cluster Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="wsrep_info-plugin.md" %}
+[wsrep_info-plugin.md](wsrep_info-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The WSREP_INFO plugin adds the WSREP_MEMBERSHIP and WSREP_STATUS tables to the Information Schema, providing detailed insights into Galera Cluster membership and status.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="wsrep_provider.md" %}
+[wsrep_provider.md](wsrep_provider.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The wsrep_provider plugin exposes Galera Cluster provider options as individual system variables, allowing for easier configuration and validation of cluster settings.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/plugins/other-plugins/README.md
+++ b/server/reference/plugins/other-plugins/README.md
@@ -7,3 +7,122 @@ description: >-
 
 # Other Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="disks-plugin.md" %}
+[disks-plugin.md](disks-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Disks plugin adds the DISKS table to the Information Schema, providing metadata about the system's disk storage and usage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="feedback-plugin.md" %}
+[feedback-plugin.md](feedback-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Feedback plugin collects and sends anonymous server usage and configuration data to MariaDB to help improve the software.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="inet4.md" %}
+[inet4.md](inet4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The inet4 plugin provides the INET4 data type, allowing for efficient native storage and manipulation of IPv4 addresses as 4-byte binary strings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="metadata-lock-info-plugin.md" %}
+[metadata-lock-info-plugin.md](metadata-lock-info-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This plugin creates the METADATA_LOCK_INFO table in the Information Schema, allowing users to view active metadata locks and their owners.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql_json.md" %}
+[mysql_json.md](mysql_json.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The MYSQL_JSON plugin provides a JSON data type alias for compatibility, ensuring that tables created with the MySQL JSON type can be read by MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mhnsw.md" %}
+[mhnsw.md](mhnsw.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mhnsw plugin implements the Hierarchical Navigable Small World algorithm, enabling high-performance approximate nearest neighbor search for vector data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="online_alter_log.md" %}
+[online_alter_log.md](online_alter_log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The online_alter_log plugin provides logging capabilities for online ALTER TABLE operations, helping administrators monitor and debug schema changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="query-cache-information-plugin.md" %}
+[query-cache-information-plugin.md](query-cache-information-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This plugin exposes the contents of the query cache via the QUERY_CACHE_INFO table in the Information Schema, aiding in performance analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="query-response-time-plugin.md" %}
+[query-response-time-plugin.md](query-response-time-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Query Response Time plugin collects and displays the distribution of query execution times, helping to identify performance bottlenecks.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-variables-plugin.md" %}
+[user-variables-plugin.md](user-variables-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The User Variables plugin adds the USER_VARIABLES table to the Information Schema, allowing users to inspect defined user variables and their values.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/plugins/password-validation-plugins/README.md
+++ b/server/reference/plugins/password-validation-plugins/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Password Validation Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="password-validation.md" %}
+[password-validation.md](password-validation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+General introduction into plugins that enforce specific security policies and complexity rules for user passwords.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cracklib-password-check-plugin.md" %}
+[cracklib-password-check-plugin.md](cracklib-password-check-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Cracklib Password Check Plugin enforces password strength by validating new passwords against the CrackLib library and its dictionary.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="password-reuse-check-plugin.md" %}
+[password-reuse-check-plugin.md](password-reuse-check-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Password Reuse Check Plugin prevents users from reusing previous passwords, with a retention policy controlled by the password_reuse_check_interval variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="password_reuse_check_interval.md" %}
+[password_reuse_check_interval.md](password_reuse_check_interval.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This system variable defines the retention period in days for the password history used by the Password Reuse Check Plugin to prevent reuse.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="simple-password-check-plugin.md" %}
+[simple-password-check-plugin.md](simple-password-check-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Simple Password Check Plugin enforces basic password complexity rules, such as minimum length and required numbers of digits, letters, and special characters.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/control-flow-functions/README.md
+++ b/server/reference/sql-functions/control-flow-functions/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # Control Flow Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="case-operator.md" %}
+[case-operator.md](case-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Implement conditional logic in SQL queries. This operator evaluates conditions and returns a specific value when the first true condition is met.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="decode_oracle.md" %}
+[decode_oracle.md](decode_oracle.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compare a value against a list of conditions. This Oracle-compatible function returns a corresponding result when a match is found, or a default value otherwise.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="if-function.md" %}
+[if-function.md](if-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete IF() function reference: IF(expr1,expr2,expr3) conditional syntax, TRUE/NULL evaluation rules, return type context (numeric/string), and examples.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ifnull.md" %}
+[ifnull.md](ifnull.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Replace NULL values with a fallback. This function returns the first argument if it's not NULL; otherwise, it returns the specified replacement value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nullif.md" %}
+[nullif.md](nullif.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compare two expressions and return NULL if they are equal. If the expressions differ, the function returns the first expression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nvl.md" %}
+[nvl.md](nvl.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for IFNULL. This Oracle-compatible function returns the first argument if it is not NULL, or the second argument if the first is NULL.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nvl2.md" %}
+[nvl2.md](nvl2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return values based on NULL status. This function returns the second argument if the first is not NULL, and the third argument if the first is NULL.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/date-time-functions/README.md
+++ b/server/reference/sql-functions/date-time-functions/README.md
@@ -7,3 +7,806 @@ description: >-
 
 # Date & Time Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="date-and-time-units.md" %}
+[date-and-time-units.md](date-and-time-units.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference keywords for date arithmetic. These units, such as DAY, HOUR, and MINUTE, specify the interval type used in functions like DATE_ADD and EXTRACT.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="add_months.md" %}
+[add_months.md](add_months.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add a specific number of months to a date. This Oracle-compatible function simplifies date calculations involving monthly intervals.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="adddate.md" %}
+[adddate.md](adddate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add a time interval to a date. This function performs date arithmetic, adding a specified value like days or hours to a starting date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="addtime.md" %}
+[addtime.md](addtime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add a time value to a date or time expression. This function sums two time arguments, returning a new time or datetime result.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="convert_tz.md" %}
+[convert_tz.md](convert_tz.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a datetime value between time zones. This function shifts a timestamp from a source time zone to a target time zone.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="curdate.md" %}
+[curdate.md](curdate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the current date. This function outputs today's date as a value in 'YYYY-MM-DD' or YYYYMMDD format, depending on the context.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="current_date.md" %}
+[current_date.md](current_date.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for CURDATE(). Returns the current date as a value in 'YYYY-MM-DD' or YYYYMMDD format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="current_time.md" %}
+[current_time.md](current_time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for CURTIME(). Returns the current time as a value in 'HH:MM:SS' or HHMMSS format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="current_timestamp.md" %}
+[current_timestamp.md](current_timestamp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for NOW(). Returns the current date and time as a value in 'YYYY-MM-DD HH:MM:SS' or YYYYMMDDHHMMSS format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="curtime.md" %}
+[curtime.md](curtime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the current time. This function outputs the current time of day as a value in 'HH:MM:SS' or HHMMSS format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date-function.md" %}
+[date-function.md](date-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the date part from a datetime expression. This function returns the year, month, and day portions, discarding the time component.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date_add.md" %}
+[date_add.md](date_add.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DATE_ADD() reference: DATE_ADD(date, INTERVAL expr unit) syntax, negative interval support, unit keywords (DAY/MONTH/YEAR), and return types.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date_format.md" %}
+[date_format.md](date_format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DATE_FORMAT reference for MariaDB. Complete function guide with syntax, parameters, return values, and usage examples with comprehensive examples.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date_sub.md" %}
+[date_sub.md](date_sub.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Subtract a time interval from a date. This function calculates a past date by subtracting a specified unit, such as days, from a starting value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="datediff.md" %}
+[datediff.md](datediff.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DATEDIFF() reference: DATEDIFF(expr1,expr2) syntax, date vs datetime expression handling, time component ignore, and positive/negative results.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="day.md" %}
+[day.md](day.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DAYOFMONTH(). Returns the day of the month (1-31) for a given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dayname.md" %}
+[dayname.md](dayname.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the name of the weekday. This function returns the full name of the day, such as 'Monday' or 'Sunday', for a given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dayofmonth.md" %}
+[dayofmonth.md](dayofmonth.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the day of the month. This function extracts the day portion of a date, returning a number from 1 to 31.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dayofweek.md" %}
+[dayofweek.md](dayofweek.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the weekday index. This function returns a number from 1 (Sunday) to 7 (Saturday) representing the day of the week.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dayofyear.md" %}
+[dayofyear.md](dayofyear.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the day of the year. This function returns a number from 1 to 366 indicating the day's position within the year.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="extract.md" %}
+[extract.md](extract.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract a specific part of a date. This function retrieves components like YEAR, MONTH, DAY, or HOUR from a date or datetime expression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="format_pico_time.md" %}
+[format_pico_time.md](format_pico_time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Format a time in picoseconds. This function converts a numeric picosecond value into a human-readable string with units like ps, ns, us, ms, s, m, h, or d.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="from_days.md" %}
+[from_days.md](from_days.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a day number to a date. This function returns a DATE value corresponding to the number of days since year 0.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="from_unixtime.md" %}
+[from_unixtime.md](from_unixtime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a Unix timestamp to a datetime. This function formats a Unix timestamp as a date string or number in the current time zone.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="get_format.md" %}
+[get_format.md](get_format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return a format string. This function provides standard format strings for DATE_FORMAT and STR_TO_DATE based on regions like 'USA' or 'EUR'.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hour.md" %}
+[hour.md](hour.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the hour. This function returns the hour portion of a time or datetime value as a number from 0 to 23.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="last_day.md" %}
+[last_day.md](last_day.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the last day of the month. This function calculates the date of the final day for the month containing the given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="localtime.md" %}
+[localtime.md](localtime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for NOW(). Returns the current date and time in the session time zone.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="localtimestamp.md" %}
+[localtimestamp.md](localtimestamp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for NOW(). Returns the current date and time in the session time zone as a datetime value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="makedate.md" %}
+[makedate.md](makedate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create a date from a year and day of year. This function constructs a DATE value given a year and the day number within that year.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="maketime.md" %}
+[maketime.md](maketime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create a time from hour, minute, and second. This function constructs a TIME value from three numeric arguments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="microsecond.md" %}
+[microsecond.md](microsecond.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract microseconds. This function returns the microsecond part of a time or datetime expression as a number from 0 to 999999.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="microseconds-in-mariadb.md" %}
+[microseconds-in-mariadb.md](microseconds-in-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand microsecond precision. This concept page explains how MariaDB stores and handles fractional seconds in time data types.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="minute.md" %}
+[minute.md](minute.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the minute. This function returns the minute portion of a time or datetime value as a number from 0 to 59.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="month.md" %}
+[month.md](month.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the month. This function returns the month portion of a date as a number from 1 (January) to 12 (December).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="monthname.md" %}
+[monthname.md](monthname.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the name of the month. This function returns the full name of the month, such as 'January' or 'December', for a given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="months_between.md" %}
+[months_between.md](months_between.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate the difference between two months.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="now.md" %}
+[now.md](now.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete NOW() function reference: NOW([precision]) and CURRENT_TIMESTAMP synonyms, TIMESTAMP vs DATETIME types, timezone/DST handling, and fractional seconds.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="period_add.md" %}
+[period_add.md](period_add.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add months to a period. This function adds a specified number of months to a period formatted as YYMM or YYYYMM.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="period_diff.md" %}
+[period_diff.md](period_diff.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate the difference between periods. This function returns the number of months between two periods formatted as YYMM or YYYYMM.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="quarter.md" %}
+[quarter.md](quarter.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the quarter of the year. This function returns a number from 1 to 4 indicating the quarter for a given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sec_to_time.md" %}
+[sec_to_time.md](sec_to_time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert seconds to time. This function returns a TIME value corresponding to the number of seconds elapsed from the start of the day.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="second.md" %}
+[second.md](second.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the second. This function returns the second portion of a time or datetime value as a number from 0 to 59.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="str_to_date.md" %}
+[str_to_date.md](str_to_date.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete STR_TO_DATE() reference: parse strings to DATE/TIME/DATETIME, format specifiers (%Y %m %d %H %i %s), invalid input handling, and SQL_MODE errors.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="subdate.md" %}
+[subdate.md](subdate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Subtract a time interval from a date. This synonym for DATE_SUB calculates a past date by subtracting a specified unit from a starting value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="subtime.md" %}
+[subtime.md](subtime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Subtract a time value. This function subtracts one time or datetime expression from another and returns the result.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sysdate.md" %}
+[sysdate.md](sysdate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the time of execution. Unlike NOW(), which returns the start time of the statement, SYSDATE() returns the time it executes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="time-function.md" %}
+[time-function.md](time-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the time portion. This function returns the time part of a time or datetime expression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="time_format.md" %}
+[time_format.md](time_format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Format a time. This function formats a time value according to a format string, similar to DATE_FORMAT but for time values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="time_to_sec.md" %}
+[time_to_sec.md](time_to_sec.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+TIME_TO_SEC() converts a time value to the number of seconds, returning a DOUBLE that preserves microseconds.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="timediff.md" %}
+[timediff.md](timediff.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Subtract two time values. This function calculates the difference between two time or datetime expressions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="timestamp-function.md" %}
+[timestamp-function.md](timestamp-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert to datetime or add time. With one argument, it returns a datetime; with two, it adds a time expression to a date or datetime.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="timestampadd.md" %}
+[timestampadd.md](timestampadd.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add an interval to a timestamp. This function adds a specified integer number of units (like MONTH or SECOND) to a datetime expression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="timestampdiff.md" %}
+[timestampdiff.md](timestampdiff.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate the difference between timestamps. This function returns the difference between two datetime expressions in the specified unit.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_date.md" %}
+[to_date.md](to_date.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+TO_DATE() converts a string to a date using a specified format, with optional handling for conversion errors.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_days.md" %}
+[to_days.md](to_days.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a date to a day number. This function returns the number of days between year 0 and the given date.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_seconds.md" %}
+[to_seconds.md](to_seconds.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a date to seconds. This function returns the number of seconds from year 0 to the given date or datetime.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="trunc.md" %}
+[trunc.md](trunc.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Truncate a date. In Oracle mode, this function truncates a date value to a specified unit of measure.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="unix_timestamp.md" %}
+[unix_timestamp.md](unix_timestamp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return a Unix timestamp. This function returns the number of seconds since the Unix Epoch ('1970-01-01 00:00:00' UTC).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="utc_date.md" %}
+[utc_date.md](utc_date.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the current UTC date. This function returns the current Coordinated Universal Time date in 'YYYY-MM-DD' or YYYYMMDD format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="utc_time.md" %}
+[utc_time.md](utc_time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the current UTC time. This function returns the current Coordinated Universal Time in 'HH:MM:SS' or HHMMSS format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="utc_timestamp.md" %}
+[utc_timestamp.md](utc_timestamp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the current UTC timestamp. This function returns the current Coordinated Universal Time date and time.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="week.md" %}
+[week.md](week.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the week number. This function returns the week number for a date, with an optional mode to define the start of the week.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="weekday.md" %}
+[weekday.md](weekday.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the weekday index. This function returns the index of the day of the week (0=Monday, 6=Sunday).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="weekofyear.md" %}
+[weekofyear.md](weekofyear.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the calendar week. This function returns the week number of the date (1-53), equivalent to WEEK(date, 3).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="year.md" %}
+[year.md](year.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract the year. This function returns the year portion of a date as a number from 1000 to 9999.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="yearweek.md" %}
+[yearweek.md](yearweek.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the year and week. This function returns the year and week number for a date, useful for grouping results by week.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/date-time-functions/time_to_sec.md
+++ b/server/reference/sql-functions/date-time-functions/time_to_sec.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  TIME_TO_SEC() converts a time value to the number of seconds, returning a
+  DOUBLE that preserves microseconds.
+---
+
 # TIME\_TO\_SEC
 
 ## Syntax

--- a/server/reference/sql-functions/date-time-functions/time_to_sec.md
+++ b/server/reference/sql-functions/date-time-functions/time_to_sec.md
@@ -16,7 +16,7 @@ TIME_TO_SEC(time)
 
 Returns the time argument, converted to seconds.
 
-The value returned by `TIME_TO_SEC` is of type [DOUBLE](../../../../data-types/data-types-numeric-data-types/double.md). The returned value preserves microseconds of the argument. See also [Microseconds in MariaDB](microseconds-in-mariadb.md).
+The value returned by `TIME_TO_SEC` is of type [DOUBLE](../../data-types/numeric-data-types/double.md). The returned value preserves microseconds of the argument. See also [Microseconds in MariaDB](microseconds-in-mariadb.md).
 
 ## Examples
 

--- a/server/reference/sql-functions/date-time-functions/to_date.md
+++ b/server/reference/sql-functions/date-time-functions/to_date.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  TO_DATE() converts a string to a date using a specified format, with
+  optional handling for conversion errors.
+---
+
 # TO\_DATE
 
 {% hint style="info" %}

--- a/server/reference/sql-functions/numeric-functions/README.md
+++ b/server/reference/sql-functions/numeric-functions/README.md
@@ -7,3 +7,410 @@ description: >-
 
 # Numeric Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="abs.md" %}
+[abs.md](abs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate absolute value. This function returns the non-negative value of a number, removing any negative sign.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="acos.md" %}
+[acos.md](acos.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate arc cosine. This function returns the angle in radians whose cosine is the given number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="asin.md" %}
+[asin.md](asin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate arc cosine. This function returns the angle in radians whose cosine is the given number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="atan.md" %}
+[atan.md](atan.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate arc tangent. This function returns the angle in radians whose tangent is the given number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="atan2.md" %}
+[atan2.md](atan2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate arc tangent of two variables. This function returns the angle in radians between the positive x-axis and the point (X, Y).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ceil.md" %}
+[ceil.md](ceil.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for CEILING(). Rounds a number up to the nearest integer.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ceiling.md" %}
+[ceiling.md](ceiling.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Round up to the nearest integer. This function returns the smallest integer value that is greater than or equal to the argument.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="conv.md" %}
+[conv.md](conv.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert numbers between bases. This function transforms a number from one numeric base system to another.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cos.md" %}
+[cos.md](cos.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate cosine. This function returns the cosine of an angle given in radians.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cot.md" %}
+[cot.md](cot.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate cotangent. This function returns the cotangent of an angle given in radians.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="crc32.md" %}
+[crc32.md](crc32.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compute cyclic redundancy check. This function returns a 32-bit unsigned integer representing the CRC32 checksum of a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="crc32c.md" %}
+[crc32c.md](crc32c.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compute CRC32C checksum. This function calculates a cyclic redundancy check value using the Castagnoli polynomial.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="degrees.md" %}
+[degrees.md](degrees.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert radians to degrees. This function transforms an angle measured in radians to its equivalent in degrees.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="div.md" %}
+[div.md](div.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform integer division. This operator divides one number by another and returns the integer result, discarding any remainder.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="exp.md" %}
+[exp.md](exp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate exponential value. This function returns the value of e (the base of natural logarithms) raised to the power of the argument.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="floor.md" %}
+[floor.md](floor.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Round down to the nearest integer. This function returns the largest integer value that is less than or equal to the argument.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ln.md" %}
+[ln.md](ln.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate natural logarithm. This function returns the logarithm of a number to the base e.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="log.md" %}
+[log.md](log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate logarithm. This function returns the natural logarithm of a number, or the logarithm to a specified base if two arguments are provided.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="log10.md" %}
+[log10.md](log10.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate base-10 logarithm. This function returns the logarithm of a number to the base 10.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="log2.md" %}
+[log2.md](log2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate base-2 logarithm. This function returns the logarithm of a number to the base 2.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mod.md" %}
+[mod.md](mod.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate modulo. This function returns the remainder of a number divided by another number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="oct.md" %}
+[oct.md](oct.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert to octal. This function returns the octal string representation of a numeric argument.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="pi.md" %}
+[pi.md](pi.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the value of pi. This function returns the mathematical constant π (approximately 3.141593).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="pow.md" %}
+[pow.md](pow.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for POWER(). Returns the value of a number raised to the power of another number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="power.md" %}
+[power.md](power.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate power. This function returns the value of a number raised to the specified exponent.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="radians.md" %}
+[radians.md](radians.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert degrees to radians. This function transforms an angle measured in degrees to its equivalent in radians.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rand.md" %}
+[rand.md](rand.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Generate a random number. This function returns a random floating-point value between 0 and 1.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="round.md" %}
+[round.md](round.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Round a number. This function rounds a number to a specified number of decimal places.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sign.md" %}
+[sign.md](sign.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the sign of a number. This function returns -1, 0, or 1 depending on whether the argument is negative, zero, or positive.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sin.md" %}
+[sin.md](sin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate sine. This function returns the sine of an angle given in radians.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sqrt.md" %}
+[sqrt.md](sqrt.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate square root. This function returns the non-negative square root of a number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="tan.md" %}
+[tan.md](tan.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate tangent. This function returns the tangent of an angle given in radians.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_number.md" %}
+[to_number.md](to_number.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a string to a number. This Oracle-compatible function parses a string using a specified format and returns a numeric value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="truncate.md" %}
+[truncate.md](truncate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Truncate a number. This function truncates a number to a specified number of decimal places.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/pseudo-columns/README.md
+++ b/server/reference/sql-functions/pseudo-columns/README.md
@@ -4,3 +4,14 @@ description: MariaDB has pseudo columns that can be used for different purposes.
 
 # Pseudo Columns
 
+{% columns %}
+{% column %}
+{% content-ref url="_rowid.md" %}
+[_rowid.md](_rowid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Access the unique row identifier. This pseudo column often aliases the primary key, allowing direct row access even if the primary key column name is unknown.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/secondary-functions/README.md
+++ b/server/reference/sql-functions/secondary-functions/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Secondary Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="bit-functions-and-operators/" %}
+[bit-functions-and-operators](bit-functions-and-operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform bitwise logic and manipulation. This section covers operators like AND, OR, XOR, and functions for shifting bits or counting set bits in binary data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="encryption-hashing-and-compression-functions/" %}
+[encryption-hashing-and-compression-functions](encryption-hashing-and-compression-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about encryption, hashing, and compression functions. This section details SQL functions for securing data, generating hashes, and compressing/decompressing information within your database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="information-functions/" %}
+[information-functions](information-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Retrieve system and session metadata. This section details functions to access database names, user details, version info, and query statistics like row counts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="miscellaneous-functions/" %}
+[miscellaneous-functions](miscellaneous-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore specialized utilities. This category includes functions for benchmarking, managing UUIDs, converting IP addresses, and handling binary data formats.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/special-functions/README.md
+++ b/server/reference/sql-functions/special-functions/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Special Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="dynamic-columns-functions/" %}
+[dynamic-columns-functions](dynamic-columns-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage schema-less data within relational tables. These functions, such as COLUMN_CREATE and COLUMN_GET, allow you to store and retrieve variable sets of columns in a single BLOB field.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="galera-functions/" %}
+[galera-functions](galera-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Interact with the Galera Cluster plugin. These functions provide internal status information and control mechanisms specific to synchronous multi-master replication nodes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="geographic-functions.md" %}
+[geographic-functions.md](geographic-functions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Process geospatial data. This collection of functions allows you to create, analyze, and manipulate geometric shapes like points, lines, and polygons within your database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="json-functions/" %}
+[json-functions](json-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete JSON Functions reference: JSON_EXTRACT(), JSON_SET(), JSON_REPLACE(), JSON_SEARCH() syntax for path queries, document updates, and value retrieval.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="window-functions/" %}
+[window-functions](window-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore window functions in MariaDB Server. This section details SQL functions that perform calculations across a set of table rows related to the current row, enabling advanced analytical queries.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/string-functions/README.md
+++ b/server/reference/sql-functions/string-functions/README.md
@@ -7,3 +7,806 @@ description: >-
 
 # String Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="ascii.md" %}
+[ascii.md](ascii.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the ASCII value of the first character. This function returns the numeric ASCII code for the leftmost character of the input string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bin.md" %}
+[bin.md](bin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the binary representation of a number. This function converts a number to its binary string equivalent.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary-operator.md" %}
+[binary-operator.md](binary-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Cast a string to a binary string. This operator converts a character string to a binary string, often used for case-sensitive comparisons.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bit_length.md" %}
+[bit_length.md](bit_length.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the length of a string in bits. This function calculates the size of the string in bits (length in bytes multiplied by 8).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cast.md" %}
+[cast.md](cast.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CAST reference for MariaDB. Complete function guide with syntax, parameters, return values, and usage examples with comprehensive examples and best.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="char-function.md" %}
+[char-function.md](char-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the character for each integer passed. This function interprets arguments as integer ASCII values and returns a string of those characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="char_length.md" %}
+[char_length.md](char_length.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the length of a string in characters. This function counts the number of characters in the string, treating multi-byte characters as single units.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="character_length.md" %}
+[character_length.md](character_length.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for CHAR_LENGTH(). Returns the number of characters in the string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="chr.md" %}
+[chr.md](chr.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the character for a specific ASCII value. This function is similar to CHAR() but accepts a single integer argument.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="concat.md" %}
+[concat.md](concat.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CONCAT reference for MariaDB. Complete function guide with syntax, parameters, return values, and usage examples with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="concat_ws.md" %}
+[concat_ws.md](concat_ws.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Concatenate with separator. This function joins strings with a specified separator. It skips NULL values during concatenation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="convert.md" %}
+[convert.md](convert.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CONVERT() reference: CONVERT(expr,type) and CONVERT(expr USING charset) syntax, SIGNED/UNSIGNED/BINARY/CHAR types, and CAST() differences.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="elt.md" %}
+[elt.md](elt.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the string at a specific index. This function returns the N-th string from a list of arguments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="export_set.md" %}
+[export_set.md](export_set.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return a string representation of bits. This function generates a string based on the bits set in a number, using specified 'on' and 'off' strings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="extractvalue.md" %}
+[extractvalue.md](extractvalue.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extract a value from XML. This function returns the text content of an XML fragment matching a given XPath expression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="field.md" %}
+[field.md](field.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the index of a string in a list. This function returns the position of the first argument within the subsequent list of arguments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="find_in_set.md" %}
+[find_in_set.md](find_in_set.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the index of a string in a comma-separated list. This function finds the position of a string within a list of strings separated by commas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="format.md" %}
+[format.md](format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Format a number. This function formats a number to a format like '#,###,###.##', rounded to a specified number of decimal places.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="from_base64.md" %}
+[from_base64.md](from_base64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Decode a base-64 encoded string. This function takes a base-64 string and returns the decoded binary result.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hex.md" %}
+[hex.md](hex.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the hexadecimal representation. This function converts a number or string to its hexadecimal string equivalent.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-function.md" %}
+[insert-function.md](insert-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Insert a substring into a string. This function inserts a string within another string at a specified position and length, replacing existing characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="instr.md" %}
+[instr.md](instr.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the position of the first occurrence of a substring. This function locates a substring within a string and returns its index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lcase.md" %}
+[lcase.md](lcase.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for LOWER(). Converts a string to lowercase characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="left.md" %}
+[left.md](left.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the leftmost characters. This function returns the specified number of characters from the beginning (left) of a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="length.md" %}
+[length.md](length.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the length of a string in bytes. This function counts the number of bytes in the string, which may differ from character count for multi-byte strings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lengthb.md" %}
+[lengthb.md](lengthb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the length of a string in bytes. This function is a synonym for LENGTH() in default mode, returning the byte count.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="like.md" %}
+[like.md](like.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete LIKE operator reference: LIKE/NOT LIKE pattern matching syntax, % and _ wildcards, ESCAPE clause, NULL behavior, and collation case-sensitivity.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="load_file.md" %}
+[load_file.md](load_file.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Read a file from the server. This function reads the content of a file located on the server host and returns it as a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="locate.md" %}
+[locate.md](locate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the position of the first occurrence of a substring. This function finds the starting position of a substring within a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lower.md" %}
+[lower.md](lower.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a string to lowercase. This function returns the string with all characters converted to lowercase.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lpad.md" %}
+[lpad.md](lpad.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Left-pad a string. This function pads a string on the left side with a specified string until it reaches a certain length.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ltrim.md" %}
+[ltrim.md](ltrim.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove leading spaces. This function returns the string with any leading whitespace characters removed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="make_set.md" %}
+[make_set.md](make_set.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return a set of comma-separated strings. This function returns a string consisting of substrings corresponding to the set bits in a given number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="match-against.md" %}
+[match-against.md](match-against.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform a full-text search. This construct searches for a text query against a set of columns indexed with a FULLTEXT index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mid.md" %}
+[mid.md](mid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for SUBSTRING(). Returns a substring starting at a specified position for a given length.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="natural_sort_key.md" %}
+[natural_sort_key.md](natural_sort_key.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Generate a sort key for natural ordering. This function produces a key that allows strings containing numbers to be sorted in a human-readable order.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="not-like.md" %}
+[not-like.md](not-like.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Negated pattern matching. This operator tests whether a string does NOT match a specified SQL pattern.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="not-regexp.md" %}
+[not-regexp.md](not-regexp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Negated regular expression matching. This operator tests whether a string does NOT match a specified regular expression pattern.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="octet_length.md" %}
+[octet_length.md](octet_length.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the length of a string in bytes. This function is a synonym for LENGTH() and returns the number of bytes in the string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ord.md" %}
+[ord.md](ord.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the numeric value of the first character. This function returns the code for the leftmost character, supporting multi-byte characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="position.md" %}
+[position.md](position.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for LOCATE(). Returns the position of the first occurrence of a substring within a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="quote.md" %}
+[quote.md](quote.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Quote a string for SQL usage. This function produces a string ready for use as a data value in an SQL statement, escaping special characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="repeat-function.md" %}
+[repeat-function.md](repeat-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Repeat a string. This function returns a string consisting of the input string repeated a specified number of times.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replace-function.md" %}
+[replace-function.md](replace-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete REPLACE Function reference for MariaDB. Complete function guide with syntax, parameters, return values, and usage examples for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="reverse.md" %}
+[reverse.md](reverse.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reverse a string. This function returns the string with the order of its characters reversed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="right.md" %}
+[right.md](right.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the rightmost characters. This function returns the specified number of characters from the end (right) of a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rpad.md" %}
+[rpad.md](rpad.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Right-pad a string. This function pads a string on the right side with a specified string until it reaches a certain length.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rtrim.md" %}
+[rtrim.md](rtrim.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove trailing spaces. This function returns the string with any trailing whitespace characters removed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sformat.md" %}
+[sformat.md](sformat.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Format strings with arbitrary patterns. This function allows complex string formatting using a pattern string and arguments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="soundex.md" %}
+[soundex.md](soundex.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the Soundex string. This function calculates the Soundex key for a string, allowing comparison of words that sound similar.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sounds-like.md" %}
+[sounds-like.md](sounds-like.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compare strings by sound. This operator tests if two strings have the same Soundex value, useful for fuzzy matching.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="space.md" %}
+[space.md](space.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return a string of spaces. This function returns a string consisting of a specified number of space characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="strcmp.md" %}
+[strcmp.md](strcmp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compare two strings. This function returns 0 if strings are equal, -1 if the first is smaller, and 1 if the first is larger.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="substr.md" %}
+[substr.md](substr.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+SUBSTR() is a synonym for SUBSTRING(), returning a substring from a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="substring.md" %}
+[substring.md](substring.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete SUBSTRING() reference: syntax forms (pos,len, FROM/FOR), negative position from end, NULL handling, and Oracle sql_mode position 0 behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="substring_index.md" %}
+[substring_index.md](substring_index.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete SUBSTRING_INDEX() reference: SUBSTRING_INDEX(str,delim,count) syntax, positive/negative count, case-sensitive delimiter, NULL rules.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_base64.md" %}
+[to_base64.md](to_base64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Encode a string to base-64. This function converts a string argument to its base-64 encoded form.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="to_char.md" %}
+[to_char.md](to_char.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert to string. This function converts a value (often date/time) to a string, potentially using a format mask.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="trim.md" %}
+[trim.md](trim.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove spaces from both ends. This function removes leading and trailing whitespace (or other specified characters) from a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="trim_oracle.md" %}
+[trim_oracle.md](trim_oracle.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Oracle-compatible TRIM function. This version of TRIM provides compatibility with Oracle's syntax for removing characters from a string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="type-conversion.md" %}
+[type-conversion.md](type-conversion.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand Type Conversion in MariaDB. Learn the rules for implicit conversion during comparisons and arithmetic, and how to use CAST for predictable results.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ucase.md" %}
+[ucase.md](ucase.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for UPPER(). Converts a string to uppercase characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="unhex.md" %}
+[unhex.md](unhex.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert hexadecimal to string. This function interprets pairs of hexadecimal digits as numbers and converts them to the characters they represent.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="updatexml.md" %}
+[updatexml.md](updatexml.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Replace a portion of XML. This function replaces a section of XML markup matching an XPath expression with a new XML fragment.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upper.md" %}
+[upper.md](upper.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert a string to uppercase. This function returns the string with all characters converted to uppercase.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="weight_string.md" %}
+[weight_string.md](weight_string.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the weight string. This function returns the binary string that represents the sorting and comparison value of the input string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="regular-expressions-functions/" %}
+[regular-expressions-functions](regular-expressions-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about regular expression functions in MariaDB Server. This section details SQL functions for powerful pattern matching and manipulation of string data using regular expressions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-functions/string-functions/substr.md
+++ b/server/reference/sql-functions/string-functions/substr.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  SUBSTR() is a synonym for SUBSTRING(), returning a substring from a string.
+---
+
 
 # SUBSTR
 

--- a/server/reference/sql-functions/vector-functions/README.md
+++ b/server/reference/sql-functions/vector-functions/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Vector Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="vector-functions-vec_distance.md" %}
+[vector-functions-vec_distance.md](vector-functions-vec_distance.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate distance between vectors. This function computes the distance between two vectors using either Euclidean or Cosine metric, depending on the index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vec_distance_cosine.md" %}
+[vec_distance_cosine.md](vec_distance_cosine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate Cosine distance. This function computes the Cosine distance between two vectors, measuring the cosine of the angle between them.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vec_distance_euclidean.md" %}
+[vec_distance_euclidean.md](vec_distance_euclidean.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Calculate Euclidean distance. This function computes the Euclidean (L2) distance between two vectors, representing the straight-line distance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vec_fromtext.md" %}
+[vec_fromtext.md](vec_fromtext.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert text to vector. This function parses a JSON array string representation of a vector and converts it into the binary VECTOR data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vec_totext.md" %}
+[vec_totext.md](vec_totext.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Convert vector to text. This function takes a binary VECTOR data type and returns its JSON array string representation.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/account-management-sql-statements/README.md
+++ b/server/reference/sql-statements/account-management-sql-statements/README.md
@@ -7,3 +7,146 @@ description: >-
 
 # Account Management
 
+{% columns %}
+{% column %}
+{% content-ref url="alter-user.md" %}
+[alter-user.md](alter-user.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete ALTER USER guide for MariaDB. Complete syntax for modifying authentication, passwords, and account security settings with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-role.md" %}
+[create-role.md](create-role.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create new roles to simplify privilege management. Learn how to define a role that can be assigned to multiple users or other roles.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-user.md" %}
+[create-user.md](create-user.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to creating MariaDB user accounts. Complete CREATE USER syntax for authentication methods and password policies with comprehensive examples.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-role.md" %}
+[drop-role.md](drop-role.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a role from the system. Learn the syntax to delete defined roles and revoke them from any users or roles that currently hold them.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-user.md" %}
+[drop-user.md](drop-user.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DROP statement reference for MariaDB. Complete guide for safely removing database objects with CASCADE options with comprehensive examples and best.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="grant.md" %}
+[grant.md](grant.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete privilege management guide for MariaDB. Complete GRANT syntax for database, table, and column permissions with roles with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rename-user.md" %}
+[rename-user.md](rename-user.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Rename existing database accounts. This guide explains how to change a user's name while preserving their current privileges and properties.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="revoke.md" %}
+[revoke.md](revoke.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove privileges or roles. Learn how to withdraw previously granted permissions from users or roles to restrict access and secure the database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-default-role.md" %}
+[set-default-role.md](set-default-role.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Define the default role for a user. Learn how to configure which role is automatically active when a user connects to the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-password.md" %}
+[set-password.md](set-password.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete reference for SET PASSWORD in MariaDB. Complete syntax guide with all options, clauses, and practical examples with comprehensive examples and best.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../set-session-authorization.md" %}
+[set-session-authorization.md](../../../set-session-authorization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Impersonate another user for the current session. Learn how to assume the identity and privileges of another account for testing or administration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-role.md" %}
+[set-role.md](set-role.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Sets the current role for the session. Learn how to enable none, or a specific role to change your current privileges dynamically.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/administrative-sql-statements/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/README.md
@@ -7,3 +7,182 @@ description: >-
 
 # Administrative Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="binlog.md" %}
+[binlog.md](binlog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Executes binary log events directly using base64-encoded data. Primarily used by the mariadb-binlog utility to re-apply events to the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cache-index.md" %}
+[cache-index.md](cache-index.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assigns specific table indices to a named key cache. Optimizes server performance by preloading or dedicating memory to frequently accessed keys.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="describe.md" %}
+[describe.md](describe.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides information about a table's columns. Acts as a shortcut for SHOW COLUMNS, displaying field names, types, and other attributes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="help-command.md" %}
+[help-command.md](help-command.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Displays help information from the server's help tables. Useful for looking up SQL syntax and command descriptions directly from the client.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="kill.md" %}
+[kill.md](kill.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Terminates a specific connection or query. Allows administrators to stop runaway threads or disconnect users to free up server resources.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="purge-binary-logs.md" %}
+[purge-binary-logs.md](purge-binary-logs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Official PURGE BINARY LOGS syntax: delete binlogs using TO 'log_name' or BEFORE datetime_expr, replica read constraints, and SHOW BINARY LOGS commands.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="reset.md" %}
+[reset.md](reset.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Clears internal server buffers, caches, and status variables. Resets state information like the query cache or replication status without a restart.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="shutdown.md" %}
+[shutdown.md](shutdown.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Stops the MariaDB server process. Allows a client with the SHUTDOWN privilege to cleanly power down the database instance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="analyze-and-explain-statements/" %}
+[analyze-and-explain-statements](analyze-and-explain-statements/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn commands for query analysis. This section covers ANALYZE TABLE and EXPLAIN, used to view execution plans and optimize query performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-commands/" %}
+[backup-commands](backup-commands/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about backup statements for MariaDB Server. This section details SQL statements and utilities for creating consistent database backups, essential for disaster recovery and data protection.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="flush-commands/" %}
+[flush-commands](flush-commands/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore commands to clear internal caches. Learn to use FLUSH to reload privileges, clear the query cache, or close open tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="plugin-sql-statements/" %}
+[plugin-sql-statements](plugin-sql-statements/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage server plugins. This section covers INSTALL PLUGIN, UNINSTALL PLUGIN, and SHOW PLUGINS for extending server functionality.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replication-statements/" %}
+[replication-statements](replication-statements/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control replication topologies. Learn statements like CHANGE MASTER TO and START SLAVE to configure primaries and replicas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-commands/" %}
+[set-commands](set-commands/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign values to system variables. Learn to use the SET statement to configure GLOBAL and SESSION variables for tuning server behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="show/" %}
+[show](show/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+View server metadata and status. This section lists SHOW statements for inspecting databases, tables, variables, and performance metrics.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-definition/README.md
+++ b/server/reference/sql-statements/data-definition/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # Data Definition (DDL)
 
+{% columns %}
+{% column %}
+{% content-ref url="atomic-ddl.md" %}
+[atomic-ddl.md](atomic-ddl.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about crash-safe DDL operations in MariaDB. This feature ensures data definition statements are either fully committed or completely rolled back, preventing metadata inconsistency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="constraint.md" %}
+[constraint.md](constraint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete constraints reference: PRIMARY KEY, FOREIGN KEY, UNIQUE, and CHECK syntax in CREATE/ALTER TABLE, ON DELETE/UPDATE actions, TABLE_CONSTRAINTS table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rename-table.md" %}
+[rename-table.md](rename-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Change the name of one or more tables atomically. This command moves tables within or between databases while preserving their data and structure.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="renaming-databases.md" %}
+[renaming-databases.md](renaming-databases.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn the supported methods for renaming a database. Since RENAME DATABASE is not available, this guide outlines safe workarounds like dumping and reloading or moving tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter/" %}
+[alter](alter/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Access the reference for ALTER statements. This section lists commands to modify existing database objects, including tables, databases, users, and servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create/" %}
+[create](create/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the CREATE statements used to define new database objects. This guide covers syntax for creating databases, tables, indexes, views, and stored routines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop/" %}
+[drop](drop/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Find statements to remove database objects. This section details the syntax for deleting databases, tables, users, and other entities when they are no longer needed.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/README.md
+++ b/server/reference/sql-statements/data-manipulation/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Data Manipulation (DML)
 
+{% columns %}
+{% column %}
+{% content-ref url="changing-deleting-data/" %}
+[changing-deleting-data](changing-deleting-data/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn to change and delete data in MariaDB Server. This section covers UPDATE and DELETE SQL statements, enabling you to modify existing records and remove unwanted information efficiently.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="inserting-loading-data/" %}
+[inserting-loading-data](inserting-loading-data/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn to insert and load data into MariaDB Server. This section covers INSERT and LOAD DATA SQL statements, enabling you to efficiently add new records to your databases.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="selecting-data/" %}
+[selecting-data](selecting-data/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn to select data in MariaDB Server using SQL. This section covers various SELECT statement clauses, including WHERE, GROUP BY, and ORDER BY, to retrieve and filter your data effectively.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/geometry-constructors/README.md
+++ b/server/reference/sql-statements/geometry-constructors/README.md
@@ -7,3 +7,122 @@ description: >-
 
 # Geometry Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="geometry-constructors/" %}
+[geometry-constructors](geometry-constructors/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about geometry constructors in MariaDB Server. This section details SQL functions for creating spatial data types like points, lines, and polygons, enabling geospatial data management.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="geometry-properties/" %}
+[geometry-properties](geometry-properties/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about geometry properties. This section details SQL functions for retrieving attributes of spatial objects, such as area, length, and bounding box, essential for geospatial analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="geometry-relations/" %}
+[geometry-relations](geometry-relations/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about geometry relations in MariaDB Server. This section details SQL functions for determining spatial relationships between geometric objects, such as ST_Intersects and ST_Contains.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linestring-properties/" %}
+[linestring-properties](linestring-properties/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about LINESTRING properties in MariaDB Server. This section details SQL functions for retrieving attributes of linear spatial objects, such as length, number of points, and start/end points.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbr-minimum-bounding-rectangle/" %}
+[mbr-minimum-bounding-rectangle](mbr-minimum-bounding-rectangle/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about Minimum Bounding Rectangles (MBR) in MariaDB Server. This section details how to calculate and use MBRs for spatial indexing and efficient querying of geometric data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="miscellaneous-gis-functions/" %}
+[miscellaneous-gis-functions](miscellaneous-gis-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore miscellaneous GIS functions in MariaDB Server. This section details various SQL functions that support geographic information system operations and spatial data analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="point-properties/" %}
+[point-properties](point-properties/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about POINT properties in MariaDB Server. This section details SQL functions for retrieving attributes of point spatial objects, such as their X and Y coordinates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="polygon-properties/" %}
+[polygon-properties](polygon-properties/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about POLYGON properties in MariaDB Server. This section details SQL functions for retrieving attributes of polygonal spatial objects, such as area, perimeter, and the number of rings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="wkb/" %}
+[wkb](wkb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about Well-Known Binary (WKB) in MariaDB Server. This section details how to represent and store geometric data in a binary format, essential for efficient spatial data exchange and storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="wkt/" %}
+[wkt](wkt/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about Well-Known Text (WKT) in MariaDB Server. This section details how to represent and store geometric data in a text format, essential for human-readable spatial data exchange.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/prepared-statements/README.md
+++ b/server/reference/sql-statements/prepared-statements/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Prepared Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="deallocate-drop-prepare.md" %}
+[deallocate-drop-prepare.md](deallocate-drop-prepare.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Release a prepared statement to free resources. This command removes the statement definition and its name from the current session.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="execute-statement.md" %}
+[execute-statement.md](execute-statement.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Run a previously prepared statement. This command executes the statement using the specified name, optionally supplying input parameters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="execute-immediate.md" %}
+[execute-immediate.md](execute-immediate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Prepare and run a dynamic SQL statement in one step. This command simplifies the process by combining the PREPARE and EXECUTE operations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="prepare-statement.md" %}
+[prepare-statement.md](prepare-statement.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Parse and optimize a SQL statement for later use. This command assigns a name to the statement, enabling efficient execution with parameters.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/programmatic-compound-statements/README.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/README.md
@@ -7,3 +7,266 @@ description: >-
 
 # Programmatic & Compound Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="begin-end.md" %}
+[begin-end.md](begin-end.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Group multiple SQL statements into a logical block. This construct defines a compound statement, creating a new scope for variables and exception handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="case-statement.md" %}
+[case-statement.md](case-statement.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete reference for CASE Statement in MariaDB. Complete syntax guide with all options, clauses, and practical examples with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="declare-condition.md" %}
+[declare-condition.md](declare-condition.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Define named error conditions. This statement associates a name with a specific SQLSTATE or MariaDB error code for easier handling in stored programs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="declare-handler.md" %}
+[declare-handler.md](declare-handler.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Specify actions for error conditions. This statement defines handler routines (CONTINUE or EXIT) to manage exceptions or warnings within a block.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="declare-type.md" %}
+[declare-type.md](declare-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Define data types for Oracle compatibility. This statement allows declaring PL/SQL-style record types and associative arrays, and REF CURSOR types within stored procedures.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="declare-variable.md" %}
+[declare-variable.md](declare-variable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Initialize local variables within a stored program. This statement defines variables with a specific data type and optional default value.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="for.md" %}
+[for.md](for.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Loop through a range or cursor result set. This control flow statement repeatedly executes a block of code for each item in a specified range or query.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="goto.md" %}
+[goto.md](goto.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Jump to a labeled point in the code. This Oracle-compatible statement transfers execution control to a specific label within the stored program.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="if.md" %}
+[if.md](if.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Execute code based on conditions. This control flow statement runs different blocks of SQL statements depending on whether a specified condition is true.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="iterate.md" %}
+[iterate.md](iterate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Restart the current loop. This statement jumps back to the beginning of a LOOP, REPEAT, or WHILE block, skipping any remaining statements in the current iteration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="labels.md" %}
+[labels.md](labels.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Identify blocks and loops for flow control. Labels provide names for BEGIN...END blocks or loops, allowing them to be targeted by LEAVE, ITERATE, or GOTO statements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="leave.md" %}
+[leave.md](leave.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Exit a labeled block or loop immediately. This statement terminates the execution of the current loop or compound statement and continues after the block.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="loop.md" %}
+[loop.md](loop.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create a simple loop construct. This statement repeatedly executes a block of code until explicitly terminated by a LEAVE statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="repeat-loop.md" %}
+[repeat-loop.md](repeat-loop.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Execute a block until a condition is met. This loop construct runs at least once and continues repeating as long as the UNTIL condition remains false.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="resignal.md" %}
+[resignal.md](resignal.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Propagate error conditions. This statement allows a handler to pass an error condition back to the caller or modify the error information before passing it on.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="return.md" %}
+[return.md](return.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Exit a stored function and return a value. This statement terminates function execution and sends the specified result back to the caller.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="selectinto.md" %}
+[selectinto.md](selectinto.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign query results to variables. This statement retrieves column values from a single row and stores them in local variables or user-defined variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="signal.md" %}
+[signal.md](signal.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Raise a custom error condition. This statement allows stored programs to generate specific error messages and SQLSTATEs to handle application logic exceptions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="while.md" %}
+[while.md](while.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Execute a block while a condition is true. This loop construct checks a condition before each iteration and repeats the block as long as the condition holds.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-compound-statements-outside-of-stored-programs.md" %}
+[using-compound-statements-outside-of-stored-programs.md](using-compound-statements-outside-of-stored-programs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Use compound statements such as IF and BEGIN...END outside of stored programs, with the delimiter set appropriately.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="programmatic-compound-statements-cursors/" %}
+[programmatic-compound-statements-cursors](programmatic-compound-statements-cursors/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about cursors in MariaDB Server's programmatic compound statements. This section details how to iterate over result sets row-by-row within stored procedures and functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="programmatic-compound-statements-diagnostics/" %}
+[programmatic-compound-statements-diagnostics](programmatic-compound-statements-diagnostics/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about diagnostics in programmatic compound statements. This section covers error handling and information retrieval within stored procedures and functions for effective debugging.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/programmatic-compound-statements/using-compound-statements-outside-of-stored-programs.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/using-compound-statements-outside-of-stored-programs.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Use compound statements such as IF and BEGIN...END outside of stored
+  programs, with the delimiter set appropriately.
+---
+
 # Using Compound Statements Outside of Stored Programs
 
 Compound statements can also be used outside of [stored programs](../../../server-usage/stored-routines/).

--- a/server/reference/sql-statements/transactions/README.md
+++ b/server/reference/sql-statements/transactions/README.md
@@ -7,3 +7,182 @@ description: >-
 
 # Transactions
 
+{% columns %}
+{% column %}
+{% content-ref url="commit.md" %}
+[commit.md](commit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Commit the current transaction. This statement permanently saves all changes made during the current transaction to the database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lock-tables.md" %}
+[lock-tables.md](lock-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete LOCK TABLES reference: READ/WRITE/WRITE CONCURRENT lock syntax, table aliases, WAIT n|NOWAIT timeouts, UNLOCK TABLES, and innodb_table_locks behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="metadata-locking.md" %}
+[metadata-locking.md](metadata-locking.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how MariaDB manages concurrency. Metadata locks protect the structure of database objects from being modified while they are in use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transactions-read-committed.md" %}
+[transactions-read-committed.md](transactions-read-committed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Set the transaction isolation level to READ COMMITTED. In this mode, each query within a transaction sees only data committed before the query began.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transactions-read-uncommitted.md" %}
+[transactions-read-uncommitted.md](transactions-read-uncommitted.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Set the transaction isolation level to READ UNCOMMITTED. This lowest isolation level allows dirty reads, where a transaction can see uncommitted changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transactions-repeatable-read.md" %}
+[transactions-repeatable-read.md](transactions-repeatable-read.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Set the transaction isolation level to REPEATABLE READ. This default InnoDB level ensures consistent results for repeated reads within the same transaction.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rollback.md" %}
+[rollback.md](rollback.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Undo changes in the current transaction. This statement reverts the database to its state before the transaction started or to a specific savepoint.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="savepoint.md" %}
+[savepoint.md](savepoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create a named marker within a transaction. Savepoints allow you to roll back part of a transaction without canceling the entire operation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transactions-serializable.md" %}
+[transactions-serializable.md](transactions-serializable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Set the transaction isolation level to SERIALIZABLE. This highest level ensures total isolation by converting plain SELECTs to locking reads.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sql-statements-that-cause-an-implicit-commit.md" %}
+[sql-statements-that-cause-an-implicit-commit.md](sql-statements-that-cause-an-implicit-commit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Identify statements that force a commit. Certain commands, like DDL statements, implicitly commit the current transaction before executing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="start-transaction.md" %}
+[start-transaction.md](start-transaction.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete START TRANSACTION reference: BEGIN/COMMIT/ROLLBACK syntax, WITH CONSISTENT SNAPSHOT option, READ ONLY/WRITE modes, AND [NO] CHAIN/RELEASE modifiers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transaction-timeouts.md" %}
+[transaction-timeouts.md](transaction-timeouts.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how timeouts affect transactions. This section explains system variables that control wait times for locks and transaction duration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="transactions-unlock-tables.md" %}
+[transactions-unlock-tables.md](transactions-unlock-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Release explicit table locks. This statement releases all locks acquired by the current session with LOCK TABLES.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="wait-and-nowait.md" %}
+[wait-and-nowait.md](wait-and-nowait.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control lock wait behavior. These clauses allow statements to wait for a specific timeout or fail immediately if a lock cannot be acquired.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xa-transactions.md" %}
+[xa-transactions.md](xa-transactions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage distributed transactions. This section covers XA statements for coordinating two-phase commits across multiple resources.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/system-tables/performance-schema/README.md
+++ b/server/reference/system-tables/performance-schema/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Performance Schema
 
+{% columns %}
+{% column %}
+{% content-ref url="performance-schema-digests.md" %}
+[performance-schema-digests.md](performance-schema-digests.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Statement digests aggregate statistics for similar queries by removing specific data values, allowing you to identify performance patterns across statement types.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="performance-schema-overview.md" %}
+[performance-schema-overview.md](performance-schema-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Performance Schema is a feature for monitoring server performance that inspects internal execution details at a low level with minimal overhead.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="performance-schema-status-variables.md" %}
+[performance-schema-status-variables.md](performance-schema-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page lists status variables that track the internal health of the Performance Schema, such as counters for lost events due to memory constraints.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="performance-schema-system-variables.md" %}
+[performance-schema-system-variables.md](performance-schema-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Configure the Performance Schema using these system variables to control buffer sizes, set instrumentation limits, and enable specific consumers at startup.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="performance-schema-tables/" %}
+[performance-schema-tables](performance-schema-tables/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the tables in the performance_schema database, which expose granular metrics on server events, locks, threads, and I/O for detailed performance analysis.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/system-tables/sys-schema/README.md
+++ b/server/reference/system-tables/sys-schema/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Sys Schema
 
+{% columns %}
+{% column %}
+{% content-ref url="sys-schema-sys_config-table.md" %}
+[sys-schema-sys_config-table.md](sys-schema-sys_config-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The sys_config table holds persistent configuration options for the Sys Schema, stored using the Aria storage engine to maintain settings across restarts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sys-schema-stored-functions/" %}
+[sys-schema-stored-functions](sys-schema-stored-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore sys_schema stored functions in MariaDB Server. These functions simplify querying performance and configuration data, offering a user-friendly interface for database diagnostics.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sys-schema-stored-procedures/" %}
+[sys-schema-stored-procedures](sys-schema-stored-procedures/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore sys_schema stored procedures in MariaDB Server. These procedures simplify complex administrative and diagnostic tasks, offering streamlined access to performance and configuration insights.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sys-schema-views/" %}
+[sys-schema-views](sys-schema-views/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore sys_schema views in MariaDB Server. These views offer simplified, aggregated insights into server performance, I/O, and memory usage, making diagnostics and monitoring easier.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/system-tables/the-mysql-database-tables/README.md
+++ b/server/reference/system-tables/the-mysql-database-tables/README.md
@@ -7,3 +7,410 @@ description: >-
 
 # The mysql Database Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="mysql-column_stats-table.md" %}
+[mysql-column_stats-table.md](mysql-column_stats-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.column_stats table stores engine-independent column statistics, such as histograms, used by the optimizer to improve query execution plans.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-columns_priv-table.md" %}
+[mysql-columns_priv-table.md](mysql-columns_priv-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.columns_priv table records column-level privileges granted to users, detailing specific access rights for individual columns.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-db-table.md" %}
+[mysql-db-table.md](mysql-db-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.db table stores database-level privileges, determining which users have access to specific databases and what actions they can perform.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-event-table.md" %}
+[mysql-event-table.md](mysql-event-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.event table contains the definitions and scheduling information for events created with the CREATE EVENT statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-func-table.md" %}
+[mysql-func-table.md](mysql-func-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.func table registers user-defined functions (UDFs), storing their names and the shared library files containing their code.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysqlgeneral_log-table.md" %}
+[mysqlgeneral_log-table.md](mysqlgeneral_log-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.general_log table captures a record of all SQL statements received by the server when general query logging is enabled and written to tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-global_priv-table.md" %}
+[mysql-global_priv-table.md](mysql-global_priv-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.global_priv table stores global privileges and account properties for all users, replacing the older mysql.user table structure.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysqlgtid_slave_pos-table.md" %}
+[mysqlgtid_slave_pos-table.md](mysqlgtid_slave_pos-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.gtid_slave_pos table tracks the Global Transaction ID (GTID) of the last applied transaction on a replica to ensure replication consistency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-help_category-table.md" %}
+[mysql-help_category-table.md](mysql-help_category-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.help_category table stores category information for the server-side help system, organizing help topics into a hierarchy.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-help_keyword-table.md" %}
+[mysql-help_keyword-table.md](mysql-help_keyword-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.help_keyword table maps keywords to help topics, facilitating keyword-based searches within the MariaDB help system.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-help_relation-table.md" %}
+[mysql-help_relation-table.md](mysql-help_relation-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.help_relation table links help keywords to help topics, defining the structure of the server-side help system.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-help_topic-table.md" %}
+[mysql-help_topic-table.md](mysql-help_topic-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.help_topic table stores the detailed content of help topics, including descriptions and examples displayed by the HELP command.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-index_stats-table.md" %}
+[mysql-index_stats-table.md](mysql-index_stats-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.index_stats table stores engine-independent index statistics, such as cardinality, used by the optimizer to plan query execution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-innodb_index_stats.md" %}
+[mysql-innodb_index_stats.md](mysql-innodb_index_stats.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.innodb_index_stats table stores persistent index statistics for InnoDB, allowing optimizer plans to remain stable across restarts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-innodb_table_stats.md" %}
+[mysql-innodb_table_stats.md](mysql-innodb_table_stats.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.innodb_table_stats table holds persistent table-level statistics for InnoDB, such as row counts, used for query optimization.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysqlpassword_reuse_check_history-table.md" %}
+[mysqlpassword_reuse_check_history-table.md](mysqlpassword_reuse_check_history-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table stores a history of password hashes to enforce security policies regarding password reuse when the relevant plugin is enabled.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-plugin-table.md" %}
+[mysql-plugin-table.md](mysql-plugin-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.plugin table records information about installed server plugins, ensuring they are reloaded automatically upon server startup.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-proc-table.md" %}
+[mysql-proc-table.md](mysql-proc-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.proc table stores the definitions, body, and metadata for stored procedures and functions created on the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-procs_priv-table.md" %}
+[mysql-procs_priv-table.md](mysql-procs_priv-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.procs_priv table records privileges granted to users specifically for executing or altering stored procedures and functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-proxies_priv-table.md" %}
+[mysql-proxies_priv-table.md](mysql-proxies_priv-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.proxies_priv table manages proxy user privileges, defining which accounts are authorized to proxy as other users.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-roles_mapping-table.md" %}
+[mysql-roles_mapping-table.md](mysql-roles_mapping-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.roles_mapping table manages role assignments, linking user accounts to the roles they have been granted.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-servers-table.md" %}
+[mysql-servers-table.md](mysql-servers-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.servers table stores connection information for remote servers, used by the FEDERATED and Spider storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-slow_log-table.md" %}
+[mysql-slow_log-table.md](mysql-slow_log-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.slow_log table records details of queries that exceed the long_query_time threshold when slow query logging to tables is enabled.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-table_stats-table.md" %}
+[mysql-table_stats-table.md](mysql-table_stats-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.table_stats table stores engine-independent statistics about tables, such as row counts, to assist the optimizer.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-tables_priv-table.md" %}
+[mysql-tables_priv-table.md](mysql-tables_priv-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.tables_priv table records table-level privileges granted to users, specifying which actions they can perform on specific tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-time_zone-table.md" %}
+[mysql-time_zone-table.md](mysql-time_zone-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.time_zone table assigns a unique ID to each time zone supported by the server, linking to other time zone system tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-time_zone_leap_second-table.md" %}
+[mysql-time_zone_leap_second-table.md](mysql-time_zone_leap_second-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.time_zone_leap_second table lists leap second corrections to be applied to specific time zones.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-time_zone_name-table.md" %}
+[mysql-time_zone_name-table.md](mysql-time_zone_name-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.time_zone_name table maps human-readable time zone names (e.g., "Europe/Berlin") to their internal time zone IDs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-time_zone_transition-table.md" %}
+[mysql-time_zone_transition-table.md](mysql-time_zone_transition-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.time_zone_transition table defines the exact times at which daylight saving time or other time zone transitions occur.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-time_zone_transition_type-table.md" %}
+[mysql-time_zone_transition_type-table.md](mysql-time_zone_transition_type-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.time_zone_transition_type table describes the properties of time zone transitions, such as the offset and abbreviation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-transaction_registry-table.md" %}
+[mysql-transaction_registry-table.md](mysql-transaction_registry-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.transaction_registry table is used by system-versioned tables to track transaction IDs and their commit timestamps.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-user-table.md" %}
+[mysql-user-table.md](mysql-user-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete mysql.user table reference: mysql.global_priv view, Host/User identifiers, plugin/authentication_string fields, and GRANT/CREATE USER integration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-mysql-database-tables/" %}
+[spider-mysql-database-tables](spider-mysql-database-tables/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore Spider-related tables within the mysql database. These system tables store crucial configuration and metadata for the Spider storage engine, essential for distributed deployments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="obsolete-mysql-database-tables/" %}
+[obsolete-mysql-database-tables](obsolete-mysql-database-tables/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore obsolete tables in the mysql database for MariaDB Server. This section provides information on deprecated system tables, useful for understanding historical contexts or migration planning.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, first depth-4 batch. Converts 24 auto-populated depth-4 landing pages under `server/reference/` into "optimal" ones (one `{% columns %}` block per child: a `content-ref` link + the child's description), modeled on `server/reference/product-development`.

## What changed

- **24 landing pages → columns**, in `server/SUMMARY.md` order: `reference/plugins/*` (5), `reference/sql-functions/*` (8, incl. date-time 67, string 67, numeric 34), `reference/sql-statements/*` (8), `reference/system-tables/*` (3). 358 columns total.
- **5 child descriptions authored** from page content: `caching_sha2_password` auth plugin, `TIME_TO_SEC`, `TO_DATE`, `SUBSTR`, and using-compound-statements-outside-of-stored-programs.

## Method

Child set/order from `SUMMARY.md`; descriptions from child frontmatter (5 authored where missing). Generator guards in force (curated/prose pages skipped, no currently-linked child dropped, cross-space links skipped) — 0 pages deferred in this batch.

## Verification

- ✅ GitBook block balance on all 24 pages (2 columns + 1 content-ref per block).
- ✅ All 358 card link targets exist.
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **111 of 349** Server landing pages; depths 1–3 complete, depth-4 underway. Remaining depth-4 (~82 pages) continues in batches 4b–4j.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ