### PR TITLE
DOCS-5973: Convert 11 depth-4 reference landing pages to columns (batch 4b)

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -6,3 +6,4 @@ numbe
 characte
 clienta
 hax
+checkin

--- a/server/reference/clientserver-protocol/1-connecting/README.md
+++ b/server/reference/clientserver-protocol/1-connecting/README.md
@@ -7,14 +7,38 @@ description: >-
 
 # 1 - Connecting
 
+{% columns %}
+{% column %}
 {% content-ref url="connection.md" %}
 [connection.md](connection.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
-{% content-ref url="caching_sha2_password-authentication-plugin.md" %}
-[caching\_sha2\_password-authentication-plugin.md](caching_sha2_password-authentication-plugin.md)
-{% endcontent-ref %}
+{% column %}
+The connection phase involves an initial handshake where the client and server exchange capabilities, default settings, and authentication data to establish a session.
+{% endcolumn %}
+{% endcolumns %}
 
+{% columns %}
+{% column %}
 {% content-ref url="sha256_password-plugin.md" %}
-[sha256\_password-plugin.md](sha256_password-plugin.md)
+[sha256_password-plugin.md](sha256_password-plugin.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The sha256_password plugin manages authentication using SHA-256 encryption, supporting both clear text passwords over SSL and RSA encrypted password exchange.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="caching_sha2_password-authentication-plugin.md" %}
+[caching_sha2_password-authentication-plugin.md](caching_sha2_password-authentication-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This plugin implements the caching_sha2_password authentication method, using an in-memory cache for fast authentication or RSA encryption for full verification.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/clientserver-protocol/2-text-protocol/README.md
+++ b/server/reference/clientserver-protocol/2-text-protocol/README.md
@@ -7,3 +7,194 @@ description: >-
 
 # 2 - Text Protocol
 
+{% columns %}
+{% column %}
+{% content-ref url="com_change_user.md" %}
+[com_change_user.md](com_change_user.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command allows a connected client to re-authenticate as a different user without closing and reopening the connection.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_create_db.md" %}
+[com_create_db.md](com_create_db.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command creates a new database on the server, functionally equivalent to the SQL statement CREATE DATABASE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_debug.md" %}
+[com_debug.md](com_debug.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command forces the server to dump debug information to the standard output or log, requiring the SUPER privilege.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_drop_db.md" %}
+[com_drop_db.md](com_drop_db.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command drops an existing database from the server, functionally equivalent to the SQL statement DROP DATABASE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_field_list.md" %}
+[com_field_list.md](com_field_list.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command retrieves a list of fields (columns) for a specified table, similar to the SHOW COLUMNS SQL statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_init_db.md" %}
+[com_init_db.md](com_init_db.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command selects the default database for the current connection, functionally equivalent to the USE statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_ping.md" %}
+[com_ping.md](com_ping.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command checks if the server is alive and reachable, the server responds with an OK packet if it is running.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_processlist.md" %}
+[com_processlist.md](com_processlist.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command retrieves a list of active threads and their current status, similar to the SHOW PROCESSLIST statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_process_kill.md" %}
+[com_process_kill.md](com_process_kill.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command asks the server to terminate a specific connection thread, functionally equivalent to the KILL statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_query.md" %}
+[com_query.md](com_query.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command sends an SQL statement to the server for execution immediately, without the prepare/execute steps.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_quit.md" %}
+[com_quit.md](com_quit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command instructs the server to close the connection and release associated resources.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_reset_connection.md" %}
+[com_reset_connection.md](com_reset_connection.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command resets the session state (variables, tables, etc.) to its initial values without closing the connection.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_set_option.md" %}
+[com_set_option.md](com_set_option.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command configures client-specific options for the current connection, such as enabling or disabling multi-statements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_shutdown.md" %}
+[com_shutdown.md](com_shutdown.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command requests the server to shut down, it requires the SHUTDOWN privilege to be executed successfully.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_sleep.md" %}
+[com_sleep.md](com_sleep.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This is an internal command used to represent a sleeping connection that is waiting for a new command from the client.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_statistics.md" %}
+[com_statistics.md](com_statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command retrieves a human-readable string containing internal server statistics like uptime and thread counts.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/clientserver-protocol/3-binary-protocol-prepared-statements/README.md
+++ b/server/reference/clientserver-protocol/3-binary-protocol-prepared-statements/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # 3 - Binary Protocol (Prepared Statements)
 
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_bulk_execute.md" %}
+[com_stmt_bulk_execute.md](com_stmt_bulk_execute.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command executes a bulk insert for a previously prepared statement, using a compact binary format for efficiency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="3-binary-protocol-prepared-statements-com_stmt_close.md" %}
+[3-binary-protocol-prepared-statements-com_stmt_close.md](3-binary-protocol-prepared-statements-com_stmt_close.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command deallocates a prepared statement on the server, freeing up associated resources.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_execute.md" %}
+[com_stmt_execute.md](com_stmt_execute.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command executes a prepared statement using parameter values provided in the binary protocol format.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_fetch.md" %}
+[com_stmt_fetch.md](com_stmt_fetch.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command fetches rows from an existing result set of a prepared statement that was executed with a cursor.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_prepare.md" %}
+[com_stmt_prepare.md](com_stmt_prepare.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command prepares an SQL statement on the server, returning a statement ID and metadata about parameters and columns.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_reset.md" %}
+[com_stmt_reset.md](com_stmt_reset.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command resets the data of a prepared statement on the server, clearing any buffers or previous parameter values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_stmt_send_long_data.md" %}
+[com_stmt_send_long_data.md](com_stmt_send_long_data.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command sends long data, such as BLOB or TEXT values, in chunks for a specific parameter of a prepared statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="server-response-packets-binary-protocol/" %}
+[server-response-packets-binary-protocol](server-response-packets-binary-protocol/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section details the structure of response packets sent by the server when using the binary protocol, particularly for result sets.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/clientserver-protocol/replication-protocol/README.md
+++ b/server/reference/clientserver-protocol/replication-protocol/README.md
@@ -7,3 +7,338 @@ description: >-
 
 # Replication Protocol
 
+{% columns %}
+{% column %}
+{% content-ref url="1-binlog-events.md" %}
+[1-binlog-events.md](1-binlog-events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section provides an overview of the various events recorded in the binary log, which are the core units of replication data transmission.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="2-binlog-event-header.md" %}
+[2-binlog-event-header.md](2-binlog-event-header.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Every binary log event starts with a standardized header containing metadata such as the timestamp, event type, server ID, and event size.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="3-binlog-network-stream.md" %}
+[3-binlog-network-stream.md](3-binlog-network-stream.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the continuous packet stream format used to transmit binary log events from the primary server to the replica over the network.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="4-semi-sync-replication.md" %}
+[4-semi-sync-replication.md](4-semi-sync-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the handshake and acknowledgement process for semi-synchronous replication, ensuring data is committed on at least one replica.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="5-replica-registration.md" %}
+[5-replica-registration.md](5-replica-registration.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the initialization phase where a replica connects to the primary, authenticates, sends capabilities, and registers for updates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="annotate_rows_event.md" %}
+[annotate_rows_event.md](annotate_rows_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event accompanies row-based events to provide the original SQL query text, which is useful for auditing and debugging replication.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="begin_load_query_event.md" %}
+[begin_load_query_event.md](begin_load_query_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Used during LOAD DATA INFILE operations, this event marks the beginning of the data load and contains the initial query information.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binlog_checkpoint_event.md" %}
+[binlog_checkpoint_event.md](binlog_checkpoint_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A marker event indicating a checkpoint in the binary log, used to ensure consistency and safe rotation of log files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_binlog_dump.md" %}
+[com_binlog_dump.md](com_binlog_dump.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command is sent by a replica to the primary server to request the start of the binary log event stream from a specific file and position.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="com_register_slave.md" %}
+[com_register_slave.md](com_register_slave.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This command is used by a replica to register its details, such as server ID, hostname, and port, with the primary server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="execute_load_query_event.md" %}
+[execute_load_query_event.md](execute_load_query_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event is used for LOAD DATA INFILE operations, managing the execution phase similar to a QUERY_EVENT but with extra static fields for file handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="fake-gtid_list-event.md" %}
+[fake-gtid_list-event.md](fake-gtid_list-event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A synthetic event sent by the master after the initial handshake to inform the replica of its current GTID state, it is not written to the binary log.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="fake-rotate_event.md" %}
+[fake-rotate_event.md](fake-rotate_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An artificial event sent to the replica to indicate the name of the binary log file on the master, ensuring the replica knows which file is being read.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="format_description_event.md" %}
+[format_description_event.md](format_description_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This descriptor event appears at the start of every binary log file, defining the server version, binlog version, and header lengths for all event types.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="gtid_event.md" %}
+[gtid_event.md](gtid_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The GTID_EVENT marks the start of a new transaction event group, associating it with a Global Transaction ID (GTID) and providing commit flags.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="gtid_list_event.md" %}
+[gtid_list_event.md](gtid_list_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Logged during binlog rotation or checkpoints, this event lists the GTIDs present in the binary log to help replicas determine their replication state.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="heartbeat_log_event.md" %}
+[heartbeat_log_event.md](heartbeat_log_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A heartbeat event sent over the network by the master when there are no binlog events, ensuring the replica knows the connection is still active.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="intvar_event.md" %}
+[intvar_event.md](intvar_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event records integer values for auto-increment columns or the LAST_INSERT_ID function, ensuring that these values are replicated deterministically.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="query_event.md" %}
+[query_event.md](query_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The QUERY_EVENT records text-based SQL statements for statement-based replication, capturing the query string and execution context like the default database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rand_event.md" %}
+[rand_event.md](rand_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The RAND_EVENT records the two seed values used for the random number generator, ensuring that calls to the RAND() function produce identical results on replicas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rotate_event.md" %}
+[rotate_event.md](rotate_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The ROTATE_EVENT indicates a log rotation, specifying the name of the next binary log file and the position where writing will continue.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rows_event_v1v2-rows_compressed_event_v1.md" %}
+[rows_event_v1v2-rows_compressed_event_v1.md](rows_event_v1v2-rows_compressed_event_v1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+These events record row-level changes (WRITE, UPDATE, DELETE) for replication, with versions supporting different column counts and compression.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="start_encryption_event.md" %}
+[start_encryption_event.md](start_encryption_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event marks the beginning of encrypted data in the binary log, defining the encryption scheme and key version for subsequent events.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stop_event.md" %}
+[stop_event.md](stop_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The STOP_EVENT is written to the binary log when the server shuts down, serving as a marker for a clean stop.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table_map_event.md" %}
+[table_map_event.md](table_map_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event provides a mapping between a table ID and its table definition, preceding row events to interpret the row data correctly.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user_var_event.md" %}
+[user_var_event.md](user_var_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The USER_VAR_EVENT logs the value of a user-defined variable, ensuring that statements using variables replicate consistently.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xa_prepare_log_event.md" %}
+[xa_prepare_log_event.md](xa_prepare_log_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This event records the preparation phase of an XA transaction, storing the XID to support two-phase commit and recovery.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xid_event.md" %}
+[xid_event.md](xid_event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The XID_EVENT signifies the commit of a transaction, containing the transaction ID (XID) to ensure atomicity across replication.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/data-types/date-and-time-data-types/README.md
+++ b/server/reference/data-types/date-and-time-data-types/README.md
@@ -6,3 +6,74 @@ description: >-
 
 # Date and Time Data Types
 
+{% columns %}
+{% column %}
+{% content-ref url="date.md" %}
+[date.md](date.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DATE type reference: YYYY-MM-DD format, YYMMDD input literals, date range 1000-01-01 to 9999-12-31, and zero-date SQL_MODE handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="datetime.md" %}
+[datetime.md](datetime.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DATETIME data type guide for MariaDB. Complete reference for syntax, valid values, storage requirements, and range limits for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sql_tsi_year.md" %}
+[sql_tsi_year.md](sql_tsi_year.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for YEAR. This keyword is an alias used for declaring a column to store year values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="time.md" %}
+[time.md](time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Store time values. This type handles time durations or time of day, ranging from '-838:59:59' to '838:59:59' with optional microsecond precision.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="timestamp.md" %}
+[timestamp.md](timestamp.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete TIMESTAMP data type guide for MariaDB. Complete reference for syntax, valid values, storage requirements, and range limits for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="year-data-type.md" %}
+[year-data-type.md](year-data-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Store year values. This type stores a year in 2-digit or 4-digit format, supporting values from 1901 to 2155, and 0000.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/data-types/numeric-data-types/README.md
+++ b/server/reference/data-types/numeric-data-types/README.md
@@ -7,3 +7,350 @@ description: >-
 
 # Numeric Data Types
 
+{% columns %}
+{% column %}
+{% content-ref url="numeric-data-type-overview.md" %}
+[numeric-data-type-overview.md](numeric-data-type-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+General introduction to numeric data types. This page summarizes the available integer, fixed-point, and floating-point types and their storage characteristics.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bigint.md" %}
+[bigint.md](bigint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Large integer type. A BIGINT uses 8 bytes and can store values from -9223372036854775808 to 9223372036854775807 (signed) or 0 to 18446744073709551615 (unsigned).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bit.md" %}
+[bit.md](bit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Bit-field data type. A BIT(M) column stores M bits per value, allowing storage of binary values from 1 to 64 bits in length.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bool.md" %}
+[bool.md](bool.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for TINYINT(1). This type is commonly used to represent boolean values, where 0 is considered false and non-zero values are true.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="boolean.md" %}
+[boolean.md](boolean.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete BOOLEAN type reference: TINYINT(1) synonym, TRUE/FALSE aliases, CREATE TABLE/SHOW CREATE TABLE output, and IF()/IS operator evaluation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dec-numeric-fixed.md" %}
+[dec-numeric-fixed.md](dec-numeric-fixed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonyms for DECIMAL. These keywords declare fixed-point numbers, which store exact numeric data with a defined precision and scale.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="numeric-data-types-dec.md" %}
+[numeric-data-types-dec.md](numeric-data-types-dec.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DECIMAL. This keyword creates a fixed-point column with exact precision, suitable for financial calculations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="decimal.md" %}
+[decimal.md](decimal.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DECIMAL type reference: DECIMAL(M,D) syntax, precision limits (M≤65, D≤38), SIGNED/UNSIGNED/ZEROFILL options, and rounding behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="double-precision.md" %}
+[double-precision.md](double-precision.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DOUBLE. This keyword declares a normal-size (8-byte) floating-point number with double precision.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="double.md" %}
+[double.md](double.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Double precision floating-point number. A DOUBLE column uses 8 bytes to store large or precise approximate values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="fixed.md" %}
+[fixed.md](fixed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DECIMAL. This keyword is used to define columns that require exact numeric precision, such as currency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="float.md" %}
+[float.md](float.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Single precision floating-point number. A FLOAT column uses 4 bytes and stores approximate values with less precision than DOUBLE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="float4.md" %}
+[float4.md](float4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for FLOAT. This keyword declares a single-precision floating-point column.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="float8.md" %}
+[float8.md](float8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DOUBLE. This keyword declares a double-precision floating-point column.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="floating-point-accuracy.md" %}
+[floating-point-accuracy.md](floating-point-accuracy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explanation of floating-point precision issues. This page details why FLOAT and DOUBLE types are approximate and how rounding errors occur.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int.md" %}
+[int.md](int.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete INT type reference: INT(M) syntax, signed (-2147483648 to 2147483647) vs unsigned (0 to 4294967295) ranges, and ZEROFILL padding guidelines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int1.md" %}
+[int1.md](int1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for TINYINT. This type uses 1 byte of storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int2.md" %}
+[int2.md](int2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for SMALLINT. This type uses 2 bytes of storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int3.md" %}
+[int3.md](int3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for MEDIUMINT. This type uses 3 bytes of storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int4.md" %}
+[int4.md](int4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for INT. This type uses 4 bytes of storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="int8.md" %}
+[int8.md](int8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for BIGINT. This type uses 8 bytes of storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="integer.md" %}
+[integer.md](integer.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for INT. This keyword declares a standard 4-byte integer column.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mediumint.md" %}
+[mediumint.md](mediumint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Medium-sized integer. A MEDIUMINT column uses 3 bytes and stores values from -8388608 to 8388607 (signed) or 0 to 16777215 (unsigned).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="middleint.md" %}
+[middleint.md](middleint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for MEDIUMINT. This keyword refers to the 3-byte integer type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="number.md" %}
+[number.md](number.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Oracle-compatible synonym for DECIMAL. This type is used for fixed-point arithmetic.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="numeric.md" %}
+[numeric.md](numeric.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DECIMAL. This type stores exact numeric data values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="real.md" %}
+[real.md](real.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for DOUBLE. In standard SQL mode, REAL is a double-precision floating-point number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="smallint.md" %}
+[smallint.md](smallint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Small integer type. A SMALLINT column uses 2 bytes and stores values from -32768 to 32767 (signed) or 0 to 65535 (unsigned).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="tinyint.md" %}
+[tinyint.md](tinyint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Very small integer type. A TINYINT column uses 1 byte and stores values from -128 to 127 (signed) or 0 to 255 (unsigned).
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/data-types/numeric-data-types/vector.md
+++ b/server/reference/data-types/numeric-data-types/vector.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The VECTOR data type, available from MariaDB 11.7.1, for storing fixed-
+  length numeric arrays used in vector search.
+---
+
 # VECTOR
 
 {% hint style="info" %}

--- a/server/reference/data-types/string-data-types/README.md
+++ b/server/reference/data-types/string-data-types/README.md
@@ -6,3 +6,542 @@ description: >-
 
 # String Data Types
 
+{% columns %}
+{% column %}
+{% content-ref url="blob-and-text-data-types.md" %}
+[blob-and-text-data-types.md](blob-and-text-data-types.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of large object types. This page compares BLOB (binary) and TEXT (character) types, explaining their storage and usage differences.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary.md" %}
+[binary.md](binary.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fixed-length binary string type. This type stores a fixed number of bytes, padding with zero bytes if the data is shorter.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="blob.md" %}
+[blob.md](blob.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Variable-length binary large object. BLOB columns can store binary data up to 65,535 bytes, suitable for images or other non-text files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="char.md" %}
+[char.md](char.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fixed-length character string type. CHAR columns store strings of a specified length (0 to 255), padding with spaces if necessary.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="character.md" %}
+[character.md](character.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fixed-length character string type. CHARACTER columns store strings of a specified length (0 to 255), padding with spaces if necessary.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="char-byte.md" %}
+[char-byte.md](char-byte.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fixed-length binary string type. This type stores a fixed number of bytes, padding with zero bytes if the data is shorter.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="char-varying.md" %}
+[char-varying.md](char-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+CHAR VARYING is a synonym for the VARCHAR string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="clob.md" %}
+[clob.md](clob.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+In Oracle mode, CLOB is an alias for the LONGTEXT data type used to store large text objects.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="enum.md" %}
+[enum.md](enum.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete ENUM type reference: ENUM('v1','v2') syntax, CHARACTER SET/COLLATE options, NULL/empty string defaults, and numeric index sorting guidelines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="inet4.md" %}
+[inet4.md](inet4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+IPv4 address data type. Stores IPv4 addresses as 4-byte binary strings for efficient storage and retrieval.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="inet6.md" %}
+[inet6.md](inet6.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+IPv6 address data type. Stores IPv6 addresses as 16-byte binary strings, also supporting IPv4 addresses via mapping.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="json.md" %}
+[json.md](json.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete JSON Data Type data type guide for MariaDB. Complete reference for syntax, valid values, storage requirements, and range limits for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-and-long-varchar.md" %}
+[long-and-long-varchar.md](long-and-long-varchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG and LONG VARCHAR are compatibility synonyms for the MEDIUMTEXT string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-char-varying.md" %}
+[long-char-varying.md](long-char-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG CHAR VARYING is a compatibility synonym for the MEDIUMTEXT string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-character-varying.md" %}
+[long-character-varying.md](long-character-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG CHARACTER VARYING is a compatibility synonym for the MEDIUMTEXT string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-varbinary.md" %}
+[long-varbinary.md](long-varbinary.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG VARBINARY is a compatibility synonym for the MEDIUMBLOB binary data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-varchar.md" %}
+[long-varchar.md](long-varchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG VARCHAR is a compatibility synonym for the MEDIUMTEXT string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="long-varcharacter.md" %}
+[long-varcharacter.md](long-varcharacter.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LONG VARCHARACTER is a compatibility synonym for the MEDIUMTEXT string data type.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="longblob.md" %}
+[longblob.md](longblob.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Very large binary object. A LONGBLOB column can store up to 4GB of binary data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="longtext.md" %}
+[longtext.md](longtext.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete LONGTEXT type reference: 4GB (2^32-1) storage limit, CHARACTER SET/COLLATE syntax, max_allowed_packet constraints, and JSON/CLOB aliases.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mediumblob.md" %}
+[mediumblob.md](mediumblob.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Medium-sized binary object. A MEDIUMBLOB column can store up to 16MB of binary data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mediumtext.md" %}
+[mediumtext.md](mediumtext.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Medium-sized character string. A MEDIUMTEXT column can store up to 16MB of text data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-char.md" %}
+[national-char.md](national-char.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL CHAR is a synonym for the CHAR data type that uses the predefined utf8mb3 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-char-varying.md" %}
+[national-char-varying.md](national-char-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL CHAR VARYING is a synonym for VARCHAR that uses the predefined utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-character-varying.md" %}
+[national-character-varying.md](national-character-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL CHARACTER VARYING is a synonym for VARCHAR using the predefined utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-character.md" %}
+[national-character.md](national-character.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL CHARACTER is a synonym for the CHAR data type using the predefined utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-varchar.md" %}
+[national-varchar.md](national-varchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL VARCHAR is a synonym for the VARCHAR data type using the predefined utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="national-varcharacter.md" %}
+[national-varcharacter.md](national-varcharacter.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NATIONAL VARCHARACTER is a synonym for VARCHAR using the predefined utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nchar.md" %}
+[nchar.md](nchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NCHAR is a synonym for the fixed-length CHAR string data type using the utf8mb3 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nchar-varchar.md" %}
+[nchar-varchar.md](nchar-varchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NCHAR VARCHAR is a synonym for the VARCHAR string data type using the utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nchar-varcharacter.md" %}
+[nchar-varcharacter.md](nchar-varcharacter.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NCHAR VARCHARACTER is a synonym for VARCHAR using the utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nchar-varying.md" %}
+[nchar-varying.md](nchar-varying.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NCHAR VARYING is a synonym for the VARCHAR string data type using the utf8 character set.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="raw.md" %}
+[raw.md](raw.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+In Oracle mode, RAW is a variable-length binary data type synonymous with VARBINARY.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="row.md" %}
+[row.md](row.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+ROW is a data type used in stored programs to store a complete row of data from a cursor or table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-data-type.md" %}
+[set-data-type.md](set-data-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+String object with zero or more values from a predefined list. A SET column can store multiple values selected from a list of permitted strings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="text.md" %}
+[text.md](text.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete TEXT type reference: TEXT(M) syntax, 65,535 byte maximum, 2-byte length prefix, DEFAULT value support, and indexing constraints rules.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="tinyblob.md" %}
+[tinyblob.md](tinyblob.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Very small binary object. A TINYBLOB column can store up to 255 bytes of binary data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="tinytext.md" %}
+[tinytext.md](tinytext.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Very small character string. A TINYTEXT column can store up to 255 characters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="uuid-data-type.md" %}
+[uuid-data-type.md](uuid-data-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Official UUID data type reference: 128-bit storage optimization, CAST from CHAR/VARCHAR/BINARY types, RFC4122 string format, and UUIDv6/v7 support.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="varbinary.md" %}
+[varbinary.md](varbinary.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Variable-length binary string type. VARBINARY columns store binary strings of variable length up to a specified maximum.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="varchar.md" %}
+[varchar.md](varchar.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete VARCHAR reference: VARCHAR(M) syntax, length limits (0-65532 per row), CHARACTER SET/COLLATE options, indexing rules, and trailing spaces.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="varchar2.md" %}
+[varchar2.md](varchar2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Variable-length character string type. VARCHAR2 columns store strings of variable length up to a specified maximum (up to 65,535).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="varcharacter.md" %}
+[varcharacter.md](varcharacter.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Variable-length character string type. VARCHARACTER columns store strings of variable length up to a specified maximum (up to 65,535).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xmltype.md" %}
+[xmltype.md](xmltype.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The XMLTYPE data type, available from MariaDB 12.3, for storing XML data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="character-sets/" %}
+[character-sets](character-sets/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about character sets in MariaDB Server. This section details how different character sets and collations impact string storage, comparison, and sorting within your database.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/data-types/string-data-types/char-varying.md
+++ b/server/reference/data-types/string-data-types/char-varying.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  CHAR VARYING is a synonym for the VARCHAR string data type.
+---
+
 # CHAR VARYING
 
 ## Overview

--- a/server/reference/data-types/string-data-types/xmltype.md
+++ b/server/reference/data-types/string-data-types/xmltype.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The XMLTYPE data type, available from MariaDB 12.3, for storing XML data.
+---
+
 # XMLTYPE
 
 ## Introduced

--- a/server/reference/sql-structure/geometry/README.md
+++ b/server/reference/sql-structure/geometry/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Geometry
 
+{% columns %}
+{% column %}
+{% content-ref url="geometry-hierarchy.md" %}
+[geometry-hierarchy.md](geometry-hierarchy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The geometry class hierarchy — the abstract Geometry base class and its instantiable point, line, and polygon subclasses.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="geometry-types.md" %}
+[geometry-types.md](geometry-types.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create spatial columns for geometry types in MariaDB, supported on MyISAM, InnoDB, and ARCHIVE tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="gis-features-in-533.md" %}
+[gis-features-in-533.md](gis-features-in-533.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of GIS support in MariaDB, based on the OpenGIS Simple Feature Access standard.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="gis-resources.md" %}
+[gis-resources.md](gis-resources.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+External resources and further reading on GIS and spatial data in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spatial-index.md" %}
+[spatial-index.md](spatial-index.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create SPATIAL (R-tree) indexes on geometry columns in MyISAM, Aria, and InnoDB tables.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/geometry/geometry-hierarchy.md
+++ b/server/reference/sql-structure/geometry/geometry-hierarchy.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The geometry class hierarchy — the abstract Geometry base class and its
+  instantiable point, line, and polygon subclasses.
+---
+
 # Geometry Hierarchy
 
 ## Description

--- a/server/reference/sql-structure/geometry/geometry-types.md
+++ b/server/reference/sql-structure/geometry/geometry-types.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Create spatial columns for geometry types in MariaDB, supported on MyISAM,
+  InnoDB, and ARCHIVE tables.
+---
+
 # Geometry Types
 
 ## Description

--- a/server/reference/sql-structure/geometry/gis-features-in-533.md
+++ b/server/reference/sql-structure/geometry/gis-features-in-533.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  An overview of GIS support in MariaDB, based on the OpenGIS Simple Feature
+  Access standard.
+---
+
 # GIS Features
 
 GIS stands for [Geographic Information System](https://en.wikipedia.org/wiki/Geographic_information_system).

--- a/server/reference/sql-structure/geometry/gis-resources.md
+++ b/server/reference/sql-structure/geometry/gis-resources.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  External resources and further reading on GIS and spatial data in MariaDB.
+---
+
 # GIS Resources
 
 GIS stands for [Geographic Information System](https://en.wikipedia.org/wiki/Geographic_information_system).

--- a/server/reference/sql-structure/geometry/spatial-index.md
+++ b/server/reference/sql-structure/geometry/spatial-index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Create SPATIAL (R-tree) indexes on geometry columns in MyISAM, Aria, and
+  InnoDB tables.
+---
+
 # SPATIAL INDEX
 
 ## Description

--- a/server/reference/sql-structure/operators/README.md
+++ b/server/reference/sql-structure/operators/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Operators
 
+{% columns %}
+{% column %}
+{% content-ref url="operator-precedence.md" %}
+[operator-precedence.md](operator-precedence.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand operator precedence in MariaDB Server SQL. This section details the order in which operators are evaluated within expressions, crucial for writing accurate and predictable queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="arithmetic-operators/" %}
+[arithmetic-operators](arithmetic-operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about arithmetic operators in MariaDB Server SQL. This section details how to perform mathematical calculations like addition, subtraction, multiplication, and division within your queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="assignment-operators/" %}
+[assignment-operators](assignment-operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about assignment operators in MariaDB Server SQL. This section details how to assign values to variables and columns, essential for data manipulation and programmatic logic.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="comparison-operators/" %}
+[comparison-operators](comparison-operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about comparison operators in MariaDB Server SQL. This section details operators like =, >, <, and LIKE used to compare values in conditions, essential for filtering and joining data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="logical-operators/" %}
+[logical-operators](logical-operators/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about logical operators in MariaDB Server SQL. This section details operators like AND, OR, and NOT used to combine or negate conditions, essential for complex filtering and data selection.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/temporal-tables/README.md
+++ b/server/reference/sql-structure/temporal-tables/README.md
@@ -7,14 +7,38 @@ description: >-
 
 # Temporal Tables
 
-{% content-ref url="system-versioned-tables.md" %}
-[system-versioned-tables.md](system-versioned-tables.md)
-{% endcontent-ref %}
-
+{% columns %}
+{% column %}
 {% content-ref url="application-time-periods.md" %}
 [application-time-periods.md](application-time-periods.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Application-time period tables define a time period between two temporal columns, for application-level data versioning.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="bitemporal-tables.md" %}
 [bitemporal-tables.md](bitemporal-tables.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Bitemporal tables combine system-versioning and application-time periods, versioning data at both levels.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="system-versioned-tables.md" %}
+[system-versioned-tables.md](system-versioned-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete system-versioned tables: WITH SYSTEM VERSIONING syntax, FOR SYSTEM_TIME AS OF/BETWEEN/ALL queries, and ROW_START/ROW_END columns.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/temporal-tables/application-time-periods.md
+++ b/server/reference/sql-structure/temporal-tables/application-time-periods.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Application-time period tables define a time period between two temporal
+  columns, for application-level data versioning.
+---
+
 # Application-Time Periods
 
 Extending [system-versioned tables](system-versioned-tables.md), MariaDB supports application-time period tables. Time periods are defined by a range between two temporal columns. The columns must be of the same [temporal data type](../../data-types/date-and-time-data-types/), i.e. [DATE](../../data-types/date-and-time-data-types/date.md), [TIMESTAMP](../../data-types/date-and-time-data-types/timestamp.md) or [DATETIME](../../data-types/date-and-time-data-types/datetime.md) ([TIME](../../data-types/date-and-time-data-types/time.md) and [YEAR](../../data-types/date-and-time-data-types/year-data-type.md) are not supported), and of the same width.

--- a/server/reference/sql-structure/temporal-tables/bitemporal-tables.md
+++ b/server/reference/sql-structure/temporal-tables/bitemporal-tables.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Bitemporal tables combine system-versioning and application-time periods,
+  versioning data at both levels.
+---
+
 # Bitemporal Tables
 
 Bitemporal tables are tables that use versioning both at the [system](system-versioned-tables.md) and [application-time period](application-time-periods.md) levels.

--- a/server/reference/sql-structure/vectors/README.md
+++ b/server/reference/sql-structure/vectors/README.md
@@ -7,26 +7,86 @@ description: >-
 
 # Vectors
 
+{% columns %}
+{% column %}
 {% content-ref url="vector-overview.md" %}
 [vector-overview.md](vector-overview.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Official MariaDB Vector reference: VECTOR(n) data type, VECTOR INDEX (M, DISTANCE=euclidean|cosine), VEC_FromText() inserts, VEC_DISTANCE() queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="create-table-with-vectors.md" %}
 [create-table-with-vectors.md](create-table-with-vectors.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Create tables optimized for vector storage. Learn to define columns with the VECTOR data type and configure vector indexes for similarity search.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="vector-system-variables.md" %}
 [vector-system-variables.md](vector-system-variables.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
-{% content-ref url="../../sql-functions/vector-functions/" %}
-[vector-functions](../../sql-functions/vector-functions/)
-{% endcontent-ref %}
+{% column %}
+System variables that control MariaDB's vector storage and similarity-search features.
+{% endcolumn %}
+{% endcolumns %}
 
-{% content-ref url="../../data-types/numeric-data-types/vector.md" %}
-[vector.md](../../data-types/numeric-data-types/vector.md)
-{% endcontent-ref %}
-
+{% columns %}
+{% column %}
 {% content-ref url="vector-framework-integrations.md" %}
 [vector-framework-integrations.md](vector-framework-integrations.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB Vector integrations with popular AI and application frameworks.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../sql-functions/vector-functions/" %}
+[vector-functions](../../sql-functions/vector-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore vector functions. This section details SQL functions for manipulating and querying vector data types, enabling efficient similarity search and AI/ML applications within your  database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../data-types/numeric-data-types/vector.md" %}
+[vector.md](../../data-types/numeric-data-types/vector.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The VECTOR data type, available from MariaDB 11.7.1, for storing fixed- length numeric arrays used in vector search.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf.md" %}
+[optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf.md](optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Combine full-text (keyword) and vector search using Reciprocal Rank Fusion (RRF) for higher-quality hybrid search results.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/vectors/optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf.md
+++ b/server/reference/sql-structure/vectors/optimizing-hybrid-search-query-with-reciprocal-rank-fusion-rrf.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Combine full-text (keyword) and vector search using Reciprocal Rank Fusion
+  (RRF) for higher-quality hybrid search results.
+---
+
 # Optimizing Hybrid Search Query with Reciprocal Rank Fusion (RRF)
 
 Hybrid search combines the keyword precision of full-text search with the conceptual understanding of vector search to produce a single, superior set of results.

--- a/server/reference/sql-structure/vectors/vector-framework-integrations.md
+++ b/server/reference/sql-structure/vectors/vector-framework-integrations.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  MariaDB Vector integrations with popular AI and application frameworks.
+---
+
 # Vector Framework Integrations
 
 {% include "https://app.gitbook.com/s/GxVnu02ec8KJuFSxmB93/~/reusable/pBQsCgBA6SJpi0m3pZuk/" %}

--- a/server/reference/sql-structure/vectors/vector-system-variables.md
+++ b/server/reference/sql-structure/vectors/vector-system-variables.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  System variables that control MariaDB's vector storage and similarity-search
+  features.
+---
+
 # Vector System Variables
 
 {% include "https://app.gitbook.com/s/GxVnu02ec8KJuFSxmB93/~/reusable/pBQsCgBA6SJpi0m3pZuk/" %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, second depth-4 batch. Converts 11 auto-populated depth-4 landing pages under `server/reference/` into columns (one `{% columns %}` block per child: `content-ref` link + description).

## What changed

- **11 landing pages → columns**, in `server/SUMMARY.md` order: `clientserver-protocol/*` (4), `data-types/*` (3: date-time, numeric, string), `sql-structure/*` (4: geometry, operators, temporal-tables, vectors). 155 columns.
- **13 child descriptions authored** from page content.

## Notes

- **`vectors`**: only *gains* links — the generator adds the missing `optimizing-hybrid-search…rrf` child that the page wasn't linking; no existing link is dropped.
- **`checkin`** added to `.codespellignore` — a column name in a temporal-table SQL example (`rooms(checkin, checkout)`), pre-existing content pulled into CI scope by a frontmatter edit.
- `sql-structure/nosql` and `sequences` were deferred (curated cross-links; handled in a later in-place batch).

## Verification

- ✅ GitBook block balance on all 11 pages.
- ✅ All 155 card links resolve; also checked body links in the 13 edited child pages (0 broken).
- ✅ codespell clean (with `.codespellignore`). lychee runs in CI.

## Scope note

Campaign progress: **122 of 349** Server landing pages. Depths 1–3 complete; depth-4 in progress. Remaining depth-4 (~71 pages) continues in later batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ