### PR TITLE
DOCS-5973: Convert 17 depth-4 server-usage landing pages to columns (batch 4c)

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -7,3 +7,4 @@ characte
 clienta
 hax
 checkin
+searchd

--- a/server/server-usage/partitioning-tables/partitioning-types/README.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # Partitioning Types
 
+{% columns %}
+{% column %}
+{% content-ref url="partitioning-types-overview.md" %}
+[partitioning-types-overview.md](partitioning-types-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to the various partitioning strategies available in MariaDB, helping you choose the right method for your data distribution needs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hash-partitioning-type.md" %}
+[hash-partitioning-type.md](hash-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about HASH partitioning, which distributes data based on a user-defined expression to ensure an even spread of rows across partitions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="key-partitioning-type.md" %}
+[key-partitioning-type.md](key-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand KEY partitioning, similar to HASH but using MariaDB's internal hashing function on one or more columns to distribute data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linear-hash-partitioning-type.md" %}
+[linear-hash-partitioning-type.md](linear-hash-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore LINEAR HASH partitioning, a variation of HASH that uses a powers-of-two algorithm for faster partition management at the cost of distribution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linear-key-partitioning-type.md" %}
+[linear-key-partitioning-type.md](linear-key-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about LINEAR KEY partitioning, which combines the internal key hashing with a linear algorithm for efficient partition handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="list-partitioning-type.md" %}
+[list-partitioning-type.md](list-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand LIST partitioning, where rows are assigned to partitions based on whether a column value matches one in a defined list of values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="range-columns-and-list-columns-partitioning-types.md" %}
+[range-columns-and-list-columns-partitioning-types.md](range-columns-and-list-columns-partitioning-types.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover these variants that allow partitioning based on multiple columns and non-integer types, offering greater flexibility than standard RANGE/LIST.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="range-partitioning-type.md" %}
+[range-partitioning-type.md](range-partitioning-type.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The RANGE partitioning type assigns rows to partitions based on whether column values fall within contiguous, non-overlapping ranges.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/aria/README.md
+++ b/server/server-usage/storage-engines/aria/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # Aria
 
+{% columns %}
+{% column %}
+{% content-ref url="aria-storage-engine.md" %}
+[aria-storage-engine.md](aria-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of Aria, a storage engine designed as a crash-safe alternative to MyISAM, featuring transactional capabilities and improved caching.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-group-commit.md" %}
+[aria-group-commit.md](aria-group-commit.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about Aria's group commit functionality, which improves performance by batching commit operations to the transaction log.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-status-variables.md" %}
+[aria-status-variables.md](aria-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of status variables specific to the Aria engine, providing metrics on page cache usage, transaction log syncs, and other internal operations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-storage-formats.md" %}
+[aria-storage-formats.md](aria-storage-formats.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the different row formats supported by Aria, particularly the default PAGE format which enables crash safety and better concurrency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-system-variables.md" %}
+[aria-system-variables.md](aria-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A comprehensive list of system variables for configuring Aria, including buffer sizes, log settings, and recovery options.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-two-step-deadlock-detection.md" %}
+[aria-two-step-deadlock-detection.md](aria-two-step-deadlock-detection.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains Aria's deadlock detection mechanism, which uses a two-step process with configurable search depths and timeouts to resolve conflicts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-faq.md" %}
+[aria-faq.md](aria-faq.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Frequently asked questions about the Aria storage engine, covering its history, comparison with MyISAM, and key features like crash safety.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="the-aria-name.md" %}
+[the-aria-name.md](the-aria-name.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A brief history of the naming of the Aria storage engine, explaining its origins as "Maria" and the reasons for the eventual name change.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/csv/README.md
+++ b/server/server-usage/storage-engines/csv/README.md
@@ -6,3 +6,26 @@ description: >-
 
 # CSV
 
+{% columns %}
+{% column %}
+{% content-ref url="csv-overview.md" %}
+[csv-overview.md](csv-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CSV Storage Engine stores data in comma-separated values format text files, making it easy to exchange data with other applications.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="checking-and-repairing-csv-tables.md" %}
+[checking-and-repairing-csv-tables.md](checking-and-repairing-csv-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to use CHECK TABLE and REPAIR TABLE to identify and fix corruptions in CSV tables, discarding rows from the first error onwards.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/federatedx-storage-engine/README.md
+++ b/server/server-usage/storage-engines/federatedx-storage-engine/README.md
@@ -10,10 +10,26 @@ description: >-
 This storage engine has been deprecated.
 {% endhint %}
 
+{% columns %}
+{% column %}
 {% content-ref url="about-federatedx.md" %}
 [about-federatedx.md](about-federatedx.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+An introduction to the FederatedX storage engine, a fork of MySQL's Federated engine, allowing access to remote tables as if they were local. This storage engine has been deprecated.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="differences-between-federatedx-and-federated.md" %}
 [differences-between-federatedx-and-federated.md](differences-between-federatedx-and-federated.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page outlines the key enhancements in FederatedX over the original Federated engine, including support for transactions and a refactored codebase. This storage engine has been deprecated.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/README.md
+++ b/server/server-usage/storage-engines/innodb/README.md
@@ -7,3 +7,338 @@ description: >-
 
 # InnoDB
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-storage-engine-introduction.md" %}
+[innodb-storage-engine-introduction.md](innodb-storage-engine-introduction.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of the InnoDB storage engine, detailing its support for ACID transactions, row-level locking, and crash recovery.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-file-format.md" %}
+[innodb-file-format.md](innodb-file-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the different file formats supported by InnoDB, such as Antelope and Barracuda, and how they impact table features and storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-limitations.md" %}
+[innodb-limitations.md](innodb-limitations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of constraints and limits within the InnoDB engine, including maximum table size, column counts, and index key lengths.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="auto_increment-handling-in-innodb.md" %}
+[auto_increment-handling-in-innodb.md](auto_increment-handling-in-innodb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains how InnoDB manages AUTO_INCREMENT columns, including initialization behavior, gap handling, and potential restart effects.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary-log-group-commit-and-innodb-flushing-performance.md" %}
+[binary-log-group-commit-and-innodb-flushing-performance.md](binary-log-group-commit-and-innodb-flushing-performance.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how group commit works with InnoDB to improve performance by reducing the number of disk syncs required during transaction commits.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-asynchronous-io.md" %}
+[innodb-asynchronous-io.md](innodb-asynchronous-io.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore how InnoDB uses asynchronous I/O on various operating systems to handle multiple read and write requests concurrently without blocking.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-buffer-pool.md" %}
+[innodb-buffer-pool.md](innodb-buffer-pool.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete InnoDB Buffer Pool guide for MariaDB. Complete reference documentation for implementation, configuration, and usage with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-change-buffering.md" %}
+[innodb-change-buffering.md](innodb-change-buffering.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the change buffer, an optimization that delays secondary index writes to reduce I/O overhead for non-unique index modifications.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-data-scrubbing.md" %}
+[innodb-data-scrubbing.md](innodb-data-scrubbing.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This feature allows for the secure deletion of data by overwriting deleted records in tablespaces and logs to prevent data recovery.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-doublewrite-buffer.md" %}
+[innodb-doublewrite-buffer.md](innodb-doublewrite-buffer.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The doublewrite buffer is a storage area where InnoDB writes pages before writing them to the data file, preventing data corruption from partial page writes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-flush-method.md" %}
+[innodb-flush-method.md](innodb-flush-method.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Detailed description of the innodb_flush_method variable, its various settings, and effects.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-lock-modes.md" %}
+[innodb-lock-modes.md](innodb-lock-modes.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+InnoDB employs Row-Level Locking with Shared (S) and Exclusive (X) locks, along with Intention locks, to manage concurrent transaction access.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-log-archiving.md" %}
+[innodb-log-archiving.md](innodb-log-archiving.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Retain the full InnoDB write-ahead log history (from MariaDB 13.0) by archiving log files, enabling point-in-time recovery and incremental backups.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-monitors.md" %}
+[innodb-monitors.md](innodb-monitors.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+InnoDB Monitors, such as the Standard, Lock, and Tablespace monitors, provide detailed internal state information to the error log for diagnostics.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-page-compression.md" %}
+[innodb-page-compression.md](innodb-page-compression.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This feature enables transparent page-level compression for tables using algorithms like LZ4 or Zlib, reducing storage requirements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-page-flushing.md" %}
+[innodb-page-flushing.md](innodb-page-flushing.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the background processes that flush dirty pages from the buffer pool to disk, including adaptive flushing algorithms to optimize I/O.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-purge.md" %}
+[innodb-purge.md](innodb-purge.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The purge process is a garbage collection mechanism that removes old row versions from the undo log that are no longer required for MVCC.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-undo-log.md" %}
+[innodb-undo-log.md](innodb-undo-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The undo log stores the "before" image of data modified by active transactions, supporting rollbacks and consistent read views.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-redo-log.md" %}
+[innodb-redo-log.md](innodb-redo-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The redo log is a disk-based transaction log used during crash recovery to replay incomplete transactions and ensure data durability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-strict-mode.md" %}
+[innodb-strict-mode.md](innodb-strict-mode.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+InnoDB Strict Mode enforces stricter SQL compliance, returning errors instead of warnings for invalid CREATE TABLE options or potential data loss.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-system-variables.md" %}
+[innodb-system-variables.md](innodb-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to InnoDB system variables for MariaDB. Complete reference for buffer pool, I/O tuning, transaction settings, and optimization for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-versions.md" %}
+[innodb-versions.md](innodb-versions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page is outdated. It's left in place because release notes for old MariaDB versions refer to it (MariaDB < 10.3).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-architecture-for-mariadb-enterprise-server/" %}
+[innodb-architecture-for-mariadb-enterprise-server](innodb-architecture-for-mariadb-enterprise-server/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand InnoDB's architecture for MariaDB Enterprise Server. This section details its components and their interactions, focusing on performance, scalability, and reliability for enterprise workloa
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-online-ddl/" %}
+[innodb-online-ddl](innodb-online-ddl/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform online DDL operations with InnoDB in MariaDB Server. Learn how to alter tables without blocking read/write access, ensuring high availability for your applications.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-row-formats/" %}
+[innodb-row-formats](innodb-row-formats/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore InnoDB row formats in MariaDB Server. Understand different formats like Compact, Dynamic, and Compressed, and how they impact storage efficiency and performance for your data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-tablespaces/" %}
+[innodb-tablespaces](innodb-tablespaces/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Manage InnoDB tablespaces in MariaDB Server. Understand their role in data organization, performance, and recovery, including file-per-table and shared tablespaces.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-troubleshooting/" %}
+[innodb-troubleshooting](innodb-troubleshooting/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Troubleshoot InnoDB issues in MariaDB Server. Find solutions and best practices for common problems, ensuring your InnoDB-based applications run smoothly and efficiently.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-innodb-operations/" %}
+[mariadb-enterprise-server-innodb-operations](mariadb-enterprise-server-innodb-operations/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about InnoDB operations in MariaDB Enterprise Server. This section covers critical management tasks, including configuration, performance tuning, and troubleshooting for enterprise-grade deploym
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-log-archiving.md
+++ b/server/server-usage/storage-engines/innodb/innodb-log-archiving.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Retain the full InnoDB write-ahead log history (from MariaDB 13.0) by
+  archiving log files, enabling point-in-time recovery and incremental
+  backups.
+---
+
 # InnoDB Log Archiving
 
 {% hint style="info" %}

--- a/server/server-usage/storage-engines/legacy-storage-engines/README.md
+++ b/server/server-usage/storage-engines/legacy-storage-engines/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Legacy Storage Engines
 
+{% columns %}
+{% column %}
+{% content-ref url="federated-storage-engine.md" %}
+[federated-storage-engine.md](federated-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Legacy FEDERATED storage engine description.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cassandra/" %}
+[cassandra](cassandra/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Legacy Cassandra storage engine description. Cassandra was removed from MariaDB in MariaDB 10.6.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="tokudb/" %}
+[tokudb](tokudb/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The TokuDB storage engine has been removed from MariaDB.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/mroonga/README.md
+++ b/server/server-usage/storage-engines/mroonga/README.md
@@ -6,3 +6,62 @@ description: >-
 
 # Mroonga
 
+{% columns %}
+{% column %}
+{% content-ref url="mroonga-overview.md" %}
+[mroonga-overview.md](mroonga-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the Mroonga storage engine, which provides fast CJK-ready full-text searching using column-based storage and supports Groonga's features.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="about-mroonga.md" %}
+[about-mroonga.md](about-mroonga.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page provides version history, installation instructions, and limitations for the Mroonga storage engine, highlighting its full-text search capabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mroonga-status-variables.md" %}
+[mroonga-status-variables.md](mroonga-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of status variables specific to Mroonga, used to monitor internal operations like fast line counts and order-by-limit optimizations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mroonga-system-variables.md" %}
+[mroonga-system-variables.md](mroonga-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+System variables for the Mroonga storage engine, and how to set them.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mroonga-user-defined-functions/" %}
+[mroonga-user-defined-functions](mroonga-user-defined-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extend Mroonga's functionality in MariaDB Server with user-defined functions. Learn how to create custom functions to enhance full-text search and data processing capabilities.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/mroonga/mroonga-system-variables.md
+++ b/server/server-usage/storage-engines/mroonga/mroonga-system-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  System variables for the Mroonga storage engine, and how to set them.
+---
+
 # Mroonga System Variables
 
 This page documents system variables related to the [Mroonga storage engine](./). See [Server System Variables](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md) for instructions on setting them.

--- a/server/server-usage/storage-engines/myisam-storage-engine/README.md
+++ b/server/server-usage/storage-engines/myisam-storage-engine/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # MyISAM
 
+{% columns %}
+{% column %}
+{% content-ref url="myisam-overview.md" %}
+[myisam-overview.md](myisam-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A detailed overview of the MyISAM storage engine, including its file structure, features, and limitations compared to newer engines like Aria.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam-index-storage-space.md" %}
+[myisam-index-storage-space.md](myisam-index-storage-space.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains how MyISAM stores and compresses indexes, detailing space usage for different key types and compression strategies.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam-storage-formats.md" %}
+[myisam-storage-formats.md](myisam-storage-formats.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the three storage formats supported by MyISAM: FIXED (static), DYNAMIC (variable length), and COMPRESSED (read-only).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myisam-system-variables.md" %}
+[myisam-system-variables.md](myisam-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A reference for system variables that configure MyISAM behavior, such as key cache sizes, recovery modes, and concurrent insert settings.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/myrocks/README.md
+++ b/server/server-usage/storage-engines/myrocks/README.md
@@ -7,3 +7,218 @@ description: >-
 
 # MyRocks
 
+{% columns %}
+{% column %}
+{% content-ref url="about-myrocks-for-mariadb.md" %}
+[about-myrocks-for-mariadb.md](about-myrocks-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MyRocks is a storage engine based on RocksDB, optimized for high-write workloads and flash storage, offering superior compression and reduced write amplification.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="building-myrocks-in-mariadb.md" %}
+[building-myrocks-in-mariadb.md](building-myrocks-in-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to build the MyRocks storage engine from source within the MariaDB Server build process, including necessary dependencies and configuration options.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="differences-between-myrocks-variants.md" %}
+[differences-between-myrocks-variants.md](differences-between-myrocks-variants.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Differences between variants of the MyRocks storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="getting-started-with-myrocks.md" %}
+[getting-started-with-myrocks.md](getting-started-with-myrocks.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to installing and configuring MyRocks, including enabling the plugin, setting up basic tables, and understanding key configuration parameters.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="loading-data-into-myrocks.md" %}
+[loading-data-into-myrocks.md](loading-data-into-myrocks.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Best practices and methods for efficiently loading large datasets into MyRocks tables, including using bulk loading features to improve performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-bloom-filters.md" %}
+[myrocks-and-bloom-filters.md](myrocks-and-bloom-filters.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to configure and use Bloom filters in MyRocks to speed up point lookups by probabilistically determining if a key exists in a data file.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-check-table.md" %}
+[myrocks-and-check-table.md](myrocks-and-check-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details on using the CHECK TABLE statement with MyRocks to verify the integrity of tables and indexes, and how it differs from other engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-data-compression.md" %}
+[myrocks-and-data-compression.md](myrocks-and-data-compression.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore the data compression options available in MyRocks, including different algorithms (Zstd, LZ4, etc.) and how to configure them per column family.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-group-commit-with-binary-log.md" %}
+[myrocks-and-group-commit-with-binary-log.md](myrocks-and-group-commit-with-binary-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand how MyRocks implements group commit to coordinate with the binary log, ensuring data consistency and crash safety for replicated transactions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-index-only-scans.md" %}
+[myrocks-and-index-only-scans.md](myrocks-and-index-only-scans.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MyRocks storage engine scans that only use indexes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-replication.md" %}
+[myrocks-and-replication.md](myrocks-and-replication.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page details how MyRocks integrates with MariaDB replication, specifically addressing limitations with statement-based replication and lack of Gap Lock support.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-and-start-transaction-with-consistent-snapshot.md" %}
+[myrocks-and-start-transaction-with-consistent-snapshot.md](myrocks-and-start-transaction-with-consistent-snapshot.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MyRocks storage engine transactions with consistent snapshot.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-column-families.md" %}
+[myrocks-column-families.md](myrocks-column-families.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about MyRocks column families, a mechanism for grouping data similar to tablespaces, to optimize compression and Bloom filter settings per family.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-performance-troubleshooting.md" %}
+[myrocks-performance-troubleshooting.md](myrocks-performance-troubleshooting.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to diagnosing and resolving performance issues in MyRocks using status variables, `SHOW ENGINE ROCKSDB STATUS`, and RocksDB performance context.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer-statistics-in-myrocks.md" %}
+[optimizer-statistics-in-myrocks.md](optimizer-statistics-in-myrocks.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MyRocks storage engine statistics for the query optimizer.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-transactional-isolation.md" %}
+[myrocks-transactional-isolation.md](myrocks-transactional-isolation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MyRocks storage engine transactional isolatioin.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-status-variables.md" %}
+[myrocks-status-variables.md](myrocks-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of MyRocks-specific status variables providing metrics on cache hits, compaction statistics, block cache usage, and other internal operations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="myrocks-system-variables.md" %}
+[myrocks-system-variables.md](myrocks-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A comprehensive reference for MyRocks system variables, allowing fine-tuning of performance, memory usage, compaction, and other internal behaviors.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/oqgraph-storage-engine/README.md
+++ b/server/server-usage/storage-engines/oqgraph-storage-engine/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # OQGRAPH
 
+{% columns %}
+{% column %}
+{% content-ref url="oqgraph-overview.md" %}
+[oqgraph-overview.md](oqgraph-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of the OQGRAPH storage engine, which allows for handling hierarchies and graph structures using SQL.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-oqgraph.md" %}
+[installing-oqgraph.md](installing-oqgraph.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide provides instructions for installing the OQGRAPH storage engine from package repositories or enabling the plugin.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="compiling-oqgraph.md" %}
+[compiling-oqgraph.md](compiling-oqgraph.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the dependencies and build steps required to compile the OQGRAPH storage engine from source.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="building-oqgraph-under-windows.md" %}
+[building-oqgraph-under-windows.md](building-oqgraph-under-windows.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Specific instructions and prerequisites for building the OQGRAPH storage engine on Windows systems using Visual Studio.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="oqgraph-examples.md" %}
+[oqgraph-examples.md](oqgraph-examples.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Practical examples demonstrating how to create OQGRAPH tables and perform graph operations like finding shortest paths and leaf nodes.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/s3-storage-engine/README.md
+++ b/server/server-usage/storage-engines/s3-storage-engine/README.md
@@ -7,3 +7,74 @@ description: >-
 
 # S3 Storage Engine
 
+{% columns %}
+{% column %}
+{% content-ref url="using-the-s3-storage-engine.md" %}
+[using-the-s3-storage-engine.md](using-the-s3-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide covers typical use cases for the S3 engine, such as archiving inactive tables, and details supported operations like ALTER TABLE and SELECT.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="s3-storage-engine-status-variables.md" %}
+[s3-storage-engine-status-variables.md](s3-storage-engine-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of status variables for monitoring the S3 engine's interactions with the cloud service, although specific variables are not extensively documented here.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="s3-storage-engine-system-variables.md" %}
+[s3-storage-engine-system-variables.md](s3-storage-engine-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page lists system variables to configure the S3 engine, including AWS credentials, bucket names, page cache sizes, and connection protocols.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="s3-storage-engine-internals.md" %}
+[s3-storage-engine-internals.md](s3-storage-engine-internals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the internal architecture of the S3 engine, which inherits from Aria code but redirects reads to S3, using a dedicated page cache.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="testing-the-connections-to-s3.md" %}
+[testing-the-connections-to-s3.md](testing-the-connections-to-s3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on how to verify your S3 configuration using tools like `aria_s3_copy` and the `mysql-test-run` suite to ensure proper connectivity.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria_s3_copy.md" %}
+[aria_s3_copy.md](aria_s3_copy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A reference for the `aria_s3_copy` tool, which is used to manually copy Aria tables to and from S3 storage for testing and data migration.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/sphinx-storage-engine/README.md
+++ b/server/server-usage/storage-engines/sphinx-storage-engine/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # SphinxSE
 
+{% columns %}
+{% column %}
+{% content-ref url="about-sphinxse.md" %}
+[about-sphinxse.md](about-sphinxse.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+SphinxSE is a storage engine that connects MariaDB to the Sphinx search daemon, enabling advanced full-text search capabilities within MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-sphinx.md" %}
+[installing-sphinx.md](installing-sphinx.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for installing the standalone Sphinx search server on various operating systems, a prerequisite for using the SphinxSE storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-and-testing-sphinxse-with-mariadb.md" %}
+[installing-and-testing-sphinxse-with-mariadb.md](installing-and-testing-sphinxse-with-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to install the SphinxSE plugin in MariaDB and run tests to verify the connection between the database and the Sphinx daemon.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configuring-sphinx.md" %}
+[configuring-sphinx.md](configuring-sphinx.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to configuring the Sphinx daemon (`searchd`) to index data from MariaDB, including setting up `sphinx.conf` and creating necessary users.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/spider/README.md
+++ b/server/server-usage/storage-engines/spider/README.md
@@ -7,3 +7,182 @@ description: >-
 
 # Spider
 
+{% columns %}
+{% column %}
+{% content-ref url="spider-storage-engine-overview.md" %}
+[spider-storage-engine-overview.md](spider-storage-engine-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to the Spider storage engine, which provides built-in sharding by linking to tables on remote MariaDB servers, supporting partitioning and XA transactions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-storage-engine-introduction/" %}
+[spider-storage-engine-introduction](spider-storage-engine-introduction/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the architecture of Spider, where a "Spider node" processes queries and distributes them to one or more "Data nodes" that actually store the data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-differences-between-spiderformysql-and-mariadb.md" %}
+[spider-differences-between-spiderformysql-and-mariadb.md](spider-differences-between-spiderformysql-and-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page outlines the differences between the standalone SpiderForMySQL distribution and the version integrated into MariaDB Server, including version correspondence and feature availability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-feature-matrix.md" %}
+[spider-feature-matrix.md](spider-feature-matrix.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A matrix listing the features supported by Spider, including sharding, partitioning, XA transactions, and support for various SQL statements and functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-use-cases.md" %}
+[spider-use-cases.md](spider-use-cases.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes common use cases for Spider, such as horizontal sharding for scalability, consolidating data from multiple sources, and migrating data between servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-installation.md" %}
+[spider-installation.md](spider-installation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to installing the Spider storage engine on Debian/Ubuntu and other Linux distributions, including loading the plugin and configuring data nodes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-cluster-management.md" %}
+[spider-cluster-management.md](spider-cluster-management.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Covers advanced management topics like executing direct SQL on backends, copying tables between nodes, and monitoring the cluster using status variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-case-studies.md" %}
+[spider-case-studies.md](spider-case-studies.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of real-world companies and projects using Spider for high-volume data handling, gaming, and analytics, illustrating its scalability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-benchmarks.md" %}
+[spider-benchmarks.md](spider-benchmarks.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Performance benchmark results for Spider, demonstrating its throughput and latency characteristics under various workloads compared to other configurations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="information-schema-spider_wrapper_protocols-table.md" %}
+[information-schema-spider_wrapper_protocols-table.md](information-schema-spider_wrapper_protocols-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the SPIDER_WRAPPER_PROTOCOLS table, which lists the available foreign data wrappers (like `mysql`) that Spider can use to connect to remote servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-storage-engine-core-concepts.md" %}
+[spider-storage-engine-core-concepts.md](spider-storage-engine-core-concepts.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the fundamental concepts behind Spider, including its architecture as a proxy storage engine, sharding capabilities, and support for XA transactions across data nodes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-system-variables.md" %}
+[spider-system-variables.md](spider-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Comprehensive list of system variables to configure Spider globally or per session, affecting connection timeouts, buffering, and query pushdown strategies.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-table-parameters.md" %}
+[spider-table-parameters.md](spider-table-parameters.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A reference for table-level parameters in Spider, which can be set via the COMMENT or CONNECTION string to control connection settings, monitoring, and query behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-functions/" %}
+[spider-functions](spider-functions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore Spider functions in MariaDB Server. Learn about the specialized functions that enhance data access and manipulation across sharded and distributed databases using the Spider storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-faq.md" %}
+[spider-faq.md](spider-faq.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Frequently asked questions about Spider, covering troubleshooting common errors, configuration best practices, and architectural questions regarding HA and sharding.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/stored-routines/stored-functions/README.md
+++ b/server/server-usage/stored-routines/stored-functions/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Stored Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="stored-function-overview.md" %}
+[stored-function-overview.md](stored-function-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A Stored Function is a set of SQL statements that can be called by name, accepts parameters, and returns a single value, enhancing SQL with custom logic.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stored-aggregate-functions.md" %}
+[stored-aggregate-functions.md](stored-aggregate-functions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Stored Aggregate Functions allow users to create custom aggregate functions that process a sequence of rows and return a single summary result.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stored-routine-privileges.md" %}
+[stored-routine-privileges.md](stored-routine-privileges.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains the privileges required to create, alter, execute, and drop stored routines, including the automatic grants for creators.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-function.md" %}
+[drop-function.md](drop-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The DROP FUNCTION statement removes a stored function from the database, deleting its definition and associated privileges.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="stored-function-limitations.md" %}
+[stored-function-limitations.md](stored-function-limitations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page details the restrictions on stored functions, such as the inability to return result sets or use transaction control statements.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/stored-routines/stored-procedures/README.md
+++ b/server/server-usage/stored-routines/stored-procedures/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Stored Procedures
 
+{% columns %}
+{% column %}
+{% content-ref url="stored-procedure-overview.md" %}
+[stored-procedure-overview.md](stored-procedure-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Stored procedures are precompiled collections of SQL statements stored on the server, allowing for encapsulated logic, parameterized execution, and improved application performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-procedure.md" %}
+[create-procedure.md](create-procedure.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CREATE PROCEDURE guide for MariaDB. Complete reference documentation for implementation, configuration, and usage with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-procedure.md" %}
+[alter-procedure.md](alter-procedure.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The ALTER PROCEDURE statement modifies the characteristics of an existing stored procedure, such as its security context or comment, without changing its logic.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-procedure.md" %}
+[drop-procedure.md](drop-procedure.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The DROP PROCEDURE statement permanently removes a stored procedure and its associated privileges from the database.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/triggers-events/event-scheduler/README.md
+++ b/server/server-usage/triggers-events/event-scheduler/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Event Scheduler
 
+{% columns %}
+{% column %}
+{% content-ref url="events.md" %}
+[events.md](events.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to creating and managing scheduled events, which are named database objects containing SQL statements to be executed by the Event Scheduler.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-event.md" %}
+[alter-event.md](alter-event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to modify the characteristics of an existing event, such as its schedule, body, or enabled status, without dropping and recreating it.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="event-limitations.md" %}
+[event-limitations.md](event-limitations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A list of restrictions associated with the Event Scheduler, including the inability to return result sets and specific date range limitations.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/triggers-events/triggers/README.md
+++ b/server/server-usage/triggers-events/triggers/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Triggers
 
+{% columns %}
+{% column %}
+{% content-ref url="trigger-overview.md" %}
+[trigger-overview.md](trigger-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB triggers overview: BEFORE/AFTER INSERT/UPDATE/DELETE timing, CREATE TRIGGER syntax, FOLLOWS|PRECEDES ordering, and DROP/SHOW TRIGGERS.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-trigger.md" %}
+[create-trigger.md](create-trigger.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete CREATE TRIGGER reference: OR REPLACE, DEFINER, IF NOT EXISTS, FOLLOWS/PRECEDES options for BEFORE/AFTER INSERT, UPDATE, or DELETE triggers rules.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="trigger-limitations.md" %}
+[trigger-limitations.md](trigger-limitations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the constraints of triggers, such as the prohibition of statements that return result sets or explicitly start/commit transactions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="triggers-and-implicit-locks.md" %}
+[triggers-and-implicit-locks.md](triggers-and-implicit-locks.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how triggers can cause implicit locks on referenced tables during the execution of a statement, potentially affecting concurrency.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, depth-4 `server-usage/`. Converts 17 auto-populated depth-4 landing pages into columns (one `{% columns %}` block per child: `content-ref` link + description).

## What changed

- **17 landing pages → columns**, in `server/SUMMARY.md` order: `storage-engines/*` (13 — aria, csv, federatedx, innodb, myisam, myrocks, oqgraph, s3, sphinx, spider, mroonga, legacy-storage-engines, …), `stored-routines/*` (2), `triggers-events/*` (2), `partitioning-tables/partitioning-types`. 124 columns.
- **2 child descriptions authored** (InnoDB log archiving; Mroonga system variables).
- **`searchd`** added to `.codespellignore` — the Sphinx search-daemon name, appearing in a child description shown on the sphinx-storage-engine landing page.

## Method

Child set/order from `SUMMARY.md`; descriptions from child frontmatter. Generator guards in force — `storage-engines/connect` was deferred (curated prose; handled in a later hand-edited batch).

## Verification

- ✅ GitBook block balance on all 17 pages.
- ✅ All 124 card links resolve; body links in the 2 edited child pages checked (0 broken).
- ✅ codespell clean (with `.codespellignore`). lychee runs in CI.

## Scope note

Campaign progress: **139 of 349** Server landing pages. Depths 1–3 complete; depth-4 in progress (~54 pages remain across server-management, ha-and-performance, drop-links, heavy, and curated batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ