### PR TITLE
DOCS-5973: Convert 11 depth-4 server-management landing pages to columns (batch 4d)

### DIFF
--- a/server/server-management/automated-mariadb-deployment-and-administration/ansible-and-mariadb/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/ansible-and-mariadb/README.md
@@ -6,3 +6,86 @@ description: >-
 
 # Ansible and MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="ansible-overview-for-mariadb-users.md" %}
+[ansible-overview-for-mariadb-users.md](ansible-overview-for-mariadb-users.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to core Ansible concepts such as inventories, playbooks, and roles, with specific examples of how to structure them for MariaDB deployments like Galera Clusters and replicas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="deploying-docker-containers-with-ansible.md" %}
+[deploying-docker-containers-with-ansible.md](deploying-docker-containers-with-ansible.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use Ansible's Docker modules to automate the deployment and configuration of MariaDB containers, serving as an alternative to Docker Compose.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="deploying-to-remote-servers-with-ansible.md" %}
+[deploying-to-remote-servers-with-ansible.md](deploying-to-remote-servers-with-ansible.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to executing Ansible commands and playbooks on remote servers via SSH, covering basic connectivity tests (ping) and the application of roles to specific host groups.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="existing-ansible-modules-and-roles-for-mariadb.md" %}
+[existing-ansible-modules-and-roles-for-mariadb.md](existing-ansible-modules-and-roles-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Lists and describes the standard Ansible modules available for managing MariaDB, such as `mysql_db`, `mysql_user`, and `mysql_variables`, highlighting their idempotent nature.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-deb-files-with-ansible.md" %}
+[installing-mariadb-deb-files-with-ansible.md](installing-mariadb-deb-files-with-ansible.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Detailed instructions for automating the installation of MariaDB on Debian/Ubuntu systems, including tasks for adding repositories, importing GPG keys, and installing packages.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="managing-secrets-in-ansible.md" %}
+[managing-secrets-in-ansible.md](managing-secrets-in-ansible.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Best practices for handling sensitive information like database passwords and SSH keys within Ansible, recommending the use of `ansible-vault` to encrypt secrets.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="running-mariadb-tzinfo-to-sql-with-ansible.md" %}
+[running-mariadb-tzinfo-to-sql-with-ansible.md](running-mariadb-tzinfo-to-sql-with-ansible.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Demonstrates how to automate the loading of time zone data into MariaDB using the `mysql_tzinfo_to_sql` utility, with techniques to ensure the task is idempotent.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/automated-mariadb-deployment-and-administration/automated-mariadb-deployment-and-administration-puppet-and-mariadb/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/automated-mariadb-deployment-and-administration-puppet-and-mariadb/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Puppet and MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="puppet-overview-for-mariadb-users.md" %}
+[puppet-overview-for-mariadb-users.md](puppet-overview-for-mariadb-users.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to Puppet's architecture (agent-master vs. standalone), concepts like manifests and catalogs, and how it can be used for configuration management of MariaDB servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="deploying-docker-containers-with-puppet.md" %}
+[deploying-docker-containers-with-puppet.md](deploying-docker-containers-with-puppet.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to managing Docker container lifecycles using Puppet's `docker` resource type, covering image pulling, container execution, and upgrades for MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="existing-puppet-modules-for-mariadb.md" %}
+[existing-puppet-modules-for-mariadb.md](existing-puppet-modules-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Lists available Puppet modules for MariaDB from the Puppet Forge and GitHub, noting that while no official module exists, community and generic MySQL modules are often used.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="puppet-hiera-configuration-system.md" %}
+[puppet-hiera-configuration-system.md](puppet-hiera-configuration-system.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use Hiera, Puppet's hierarchical key/value lookup tool, to separate MariaDB configuration data from code and manage environment-specific settings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="bolt-examples.md" %}
+[bolt-examples.md](bolt-examples.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Demonstrates how to use Bolt, an orchestration tool in the Puppet ecosystem, to run ad-hoc commands, scripts, and tasks on remote MariaDB servers without a permanent agent.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/automated-mariadb-deployment-and-administration/kubernetes-and-mariadb/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/kubernetes-and-mariadb/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Kubernetes and MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="kubernetes-operators-for-mariadb.md" %}
+[kubernetes-operators-for-mariadb.md](kubernetes-operators-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Official Kubernetes Operators for MariaDB: Enterprise Operator for MariaDB Server+MaxScale, CRDs/controllers, HA topologies, and backup/restore automation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="kubernetes-overview-for-mariadb-users.md" %}
+[kubernetes-overview-for-mariadb-users.md](kubernetes-overview-for-mariadb-users.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to core Kubernetes concepts relevant to database administrators, such as StatefulSets, Persistent Volumes, and Services, and how they apply to MariaDB storage and networking.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/automated-mariadb-deployment-and-administration/vagrant-and-mariadb/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/vagrant-and-mariadb/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Vagrant and MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="creating-a-vagrantfile.md" %}
+[creating-a-vagrantfile.md](creating-a-vagrantfile.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide on creating and configuring a `Vagrantfile` to define the characteristics of a MariaDB virtual machine, including box selection and provisioning steps.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vagrant-overview-for-mariadb-users.md" %}
+[vagrant-overview-for-mariadb-users.md](vagrant-overview-for-mariadb-users.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to Vagrant's workflow and terminology for database administrators, explaining how it simplifies the creation of reproducible MariaDB development environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="vagrant-security-concerns.md" %}
+[vagrant-security-concerns.md](vagrant-security-concerns.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discusses security considerations when using Vagrant with MariaDB, such as default insecure keys, port forwarding risks, and ensuring production-grade settings are not used in dev boxes.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/README.md
@@ -23,3 +23,38 @@ layout:
 
 # Configuring MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="configuring-mariadb-with-option-files.md" %}
+[configuring-mariadb-with-option-files.md](configuring-mariadb-with-option-files.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to MariaDB option files. Complete my.cnf reference with configuration groups, parameter syntax, and file hierarchy for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-environment-variables.md" %}
+[mariadb-environment-variables.md](mariadb-environment-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB environment variables: MYSQL_HOME, LD_PRELOAD, my.cnf search path precedence, and interaction with option files/command-line options.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-performance-advanced-configurations/" %}
+[mariadb-performance-advanced-configurations](mariadb-performance-advanced-configurations/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Dive into advanced configurations for MariaDB Server performance. This section covers in-depth tuning parameters, optimization strategies, and best practices to maximize speed and efficiency.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/deployment-general-installing-and-upgrading-instructions/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/deployment-general-installing-and-upgrading-instructions/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # General Deployment Instructions
 
+{% columns %}
+{% column %}
+{% content-ref url="best-practices.md" %}
+[best-practices.md](best-practices.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide outlining essential recommendations for stable MariaDB deployments, covering backup strategies, change management, security controls, and pre-production testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="deployment-methods.md" %}
+[deployment-methods.md](deployment-methods.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of different deployment architectures (single-node, primary/replica) & methods, including manual installation via repositories or tarballs, and automated deployment with tools like Ansible.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-enterprise-server/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-enterprise-server/README.md
@@ -19,3 +19,62 @@ layout:
 
 # Installing Enterprise Server
 
+{% columns %}
+{% column %}
+{% content-ref url="token.md" %}
+[token.md](token.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on how to retrieve and use a Customer Download Token to access MariaDB Enterprise Server packages and binaries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../architecture/topologies/single-node-topologies/enterprise-server.md#installation" %}
+[enterprise-server.md#installation](../../../architecture/topologies/single-node-topologies/enterprise-server.md#installation)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to installing MariaDB Enterprise Server on various operating systems using package managers (YUM, APT, ZYpp) or binary tarballs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../architecture/topologies/primary-replica/" %}
+[primary-replica](../../../architecture/topologies/primary-replica/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains how to set up a standard Primary/Replica replication topology for MariaDB Enterprise Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/" %}
+[enterprise-server-with-columnstore-local-storage](../../../architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-local-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deployment instructions for a single-node MariaDB Enterprise Server instance with the ColumnStore engine using local storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/" %}
+[enterprise-server-with-columnstore-object-storage](../../../architecture/topologies/single-node-topologies/enterprise-server-with-columnstore-object-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Deployment instructions for a single-node MariaDB Enterprise Server instance with the ColumnStore engine using S3-compatible object storage.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/README.md
@@ -23,3 +23,62 @@ layout:
 
 # Installing Community Server
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-id-sign-up.md" %}
+[mariadb-id-sign-up.md](mariadb-id-sign-up.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on creating a free MariaDB ID account to access software downloads, including binary packages and repositories.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="binary-packages/" %}
+[binary-packages](binary-packages/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides details on using MariaDB binary packages (tarballs, RPMs, DEBs) for installation, including repository configuration scripts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-system-tables-mariadb-install-db/" %}
+[installing-system-tables-mariadb-install-db](installing-system-tables-mariadb-install-db/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the necessity of initializing system tables (using mariadb-install-db) after installation and troubleshooting startup issues related to missing tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="troubleshooting-installation-issues/" %}
+[troubleshooting-installation-issues](troubleshooting-installation-issues/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to diagnosing and resolving common installation and connection problems, such as socket errors, permission denied messages, and configuration conflicts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-on-ibm-cloud.md" %}
+[installing-mariadb-on-ibm-cloud.md](installing-mariadb-on-ibm-cloud.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Step-by-step instructions for deploying MariaDB on IBM Cloud Kubernetes Service, including provisioning clusters and configuring storage.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/README.md
@@ -22,3 +22,38 @@ layout:
 
 # Upgrading MariaDB
 
+{% columns %}
+{% column %}
+{% content-ref url="platform-specific-upgrade-guides/" %}
+[platform-specific-upgrade-guides](platform-specific-upgrade-guides/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides tailored instructions for upgrading MariaDB on different operating systems, including Linux and Windows, and within specific environments like Galera Cluster.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-community-server-upgrade-paths/" %}
+[mariadb-community-server-upgrade-paths](mariadb-community-server-upgrade-paths/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of supported upgrade paths for MariaDB Community Server, linking to specific guides for upgrading between major versions like 10.x and 11.x.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-paths/" %}
+[upgrade-paths](upgrade-paths/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides an overview of supported upgrade paths for MariaDB Enterprise Server, linking to specific guides for upgrading between major versions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/server-monitoring-logs/slow-query-log/README.md
+++ b/server/server-management/server-monitoring-logs/slow-query-log/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Slow Query Log
 
+{% columns %}
+{% column %}
+{% content-ref url="slow-query-log-overview.md" %}
+[slow-query-log-overview.md](slow-query-log-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Slow Query Log Overview guide for MariaDB. Complete reference documentation for implementation, configuration, and usage for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="explain-in-the-slow-query-log.md" %}
+[explain-in-the-slow-query-log.md](explain-in-the-slow-query-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes how to configure MariaDB to automatically write the `EXPLAIN` plan for slow queries to the log using the `log_slow_verbosity` system variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="log_slow_always_query_time-system-variable.md" %}
+[log_slow_always_query_time-system-variable.md](log_slow_always_query_time-system-variable.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the `log_slow_always_query_time` variable, which forces queries executed by a specific function or user to be logged regardless of their execution time.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/server-monitoring-logs/transaction-coordinator-log/README.md
+++ b/server/server-management/server-monitoring-logs/transaction-coordinator-log/README.md
@@ -23,3 +23,26 @@ layout:
 
 # Transaction Coordinator Log
 
+{% columns %}
+{% column %}
+{% content-ref url="transaction-coordinator-log-overview.md" %}
+[transaction-coordinator-log-overview.md](transaction-coordinator-log-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the purpose of the Transaction Coordinator (TC) log (`tc.log`), which maintains consistency for XA transactions that affect multiple storage engines, and how to configure it.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="heuristic-recovery-with-the-transaction-coordinator-log.md" %}
+[heuristic-recovery-with-the-transaction-coordinator-log.md](heuristic-recovery-with-the-transaction-coordinator-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the process of heuristic recovery using the TC log to resolve "in-doubt" transactions that may occur after a server crash during a 2-phase commit.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, depth-4 `server-management/`. Converts 11 auto-populated depth-4 landing pages into columns (one `{% columns %}` block per child: `content-ref` link + description).

## What changed

- **11 landing pages → columns**, in `server/SUMMARY.md` order: automated-deployment (ansible, puppet, kubernetes, vagrant), install-and-upgrade (configuring, deployment-instructions, installing-enterprise-server, installing-mariadb, upgrading), monitoring-logs (slow-query-log, transaction-coordinator-log). 40 columns.
- No new descriptions authored — all children already had frontmatter descriptions.

## Method

Child set/order from `SUMMARY.md`; descriptions from child frontmatter. Generator guards in force — `automated-.../docker-and-mariadb` and `starting-and-stopping-mariadb/systemd` were deferred (curated `##`/prose; handled in a later hand-edited batch).

## Verification

- ✅ GitBook block balance on all 11 pages.
- ✅ All 40 card links resolve (including one cross-tree link carrying a `#installation` anchor — target exists).
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **150 of 349** Server landing pages. Depths 1–3 complete; depth-4 in progress (~43 pages remain: ha-and-performance AUTO, drop-links, heavy, and curated batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ