### PR TITLE
DOCS-5973: Convert 8 depth-4 ha-and-performance landing pages to columns (batch 4e)

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Buffers, Caches and Threads
 
+{% columns %}
+{% column %}
+{% content-ref url="query-cache.md" %}
+[query-cache.md](query-cache.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB performance optimization guide. Complete reference for query tuning, indexing strategies, and configuration improvements for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="thread-command-values.md" %}
+[thread-command-values.md](thread-command-values.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The COMMAND values a thread can show in SHOW PROCESSLIST, and what each one means.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="thread-pool/" %}
+[thread-pool](thread-pool/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Optimize MariaDB Server with the thread pool. This section explains how to manage connections and improve performance by efficiently handling concurrent client requests, reducing resource overhead.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="thread-states/" %}
+[thread-states](thread-states/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand MariaDB Server thread states. This section explains the different states a thread can be in, helping you monitor and troubleshoot query execution and server performance.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-command-values.md
+++ b/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/thread-command-values.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The COMMAND values a thread can show in SHOW PROCESSLIST, and what each one
+  means.
+---
+
 # Thread Command Values
 
 A thread can have any of the following `COMMAND` values (displayed by the `COMMAND` field listed by the [SHOW PROCESSLIST](../../../reference/sql-statements/administrative-sql-statements/show/show-processlist.md) statement or in the [Information Schema PROCESSLIST Table](../../../reference/system-tables/information-schema/information-schema-tables/information-schema-processlist-table.md), as well as the `PROCESSLIST_COMMAND` value listed in the [Performance Schema threads Table](../../../reference/system-tables/performance-schema/performance-schema-tables/performance-schema-threads-table.md)). These indicate the nature of the thread's activity.

--- a/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # MariaDB Internal Optimizations
 
+{% columns %}
+{% column %}
+{% content-ref url="fair-choice-between-range-and-index_merge-optimizations.md" %}
+[fair-choice-between-range-and-index_merge-optimizations.md](fair-choice-between-range-and-index_merge-optimizations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How the optimizer chooses fairly between the range and index_merge access methods.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="multi-range-read-optimization.md" %}
+[multi-range-read-optimization.md](multi-range-read-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Multi-Range Read (MRR) optimization, which improves performance for I/O-bound queries scanning many rows.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/fair-choice-between-range-and-index_merge-optimizations.md
+++ b/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/fair-choice-between-range-and-index_merge-optimizations.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How the optimizer chooses fairly between the range and index_merge access
+  methods.
+---
+
 # Fair Choice Between Range and Index\_merge Optimizations
 
 `index_merge` is a method used by the optimizer to retrieve rows from a single table using several index scans. The results of the scans are then merged.

--- a/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The Multi-Range Read (MRR) optimization, which improves performance for
+  I/O-bound queries scanning many rows.
+---
+
 # Multi Range Read Optimization
 
 Multi Range Read is an optimization aimed at improving performance for IO-bound queries that need to scan lots of rows.
@@ -5,7 +11,7 @@ Multi Range Read is an optimization aimed at improving performance for IO-bound 
 Multi Range Read can be used with
 
 * `range` access
-* `ref` and `eq_ref` access, when they are using [Batched Key Access](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/VWjZF4UcCaSJJtdMzBO2#batch-key-access-join)
+* `ref` and `eq_ref` access, when they are using [Batched Key Access](../query-optimizer/block-based-join-algorithms.md#batch-key-access-join)
 
 as shown in this diagram:
 

--- a/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Operating System Optimizations
 
+{% columns %}
+{% column %}
+{% content-ref url="filesystem-optimizations.md" %}
+[filesystem-optimizations.md](filesystem-optimizations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Filesystem choices and settings that affect MariaDB Server performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="storage-io-buffering-and-persistence.md" %}
+[storage-io-buffering-and-persistence.md](storage-io-buffering-and-persistence.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Defines the OS-agnostic terms MariaDB documentation uses for disk I/O — unbuffered I/O, write-through, persist — and shows how each one maps to Unix-like and Windows mechanisms.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/filesystem-optimizations.md
+++ b/server/ha-and-performance/optimization-and-tuning/operating-system-optimizations/filesystem-optimizations.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Filesystem choices and settings that affect MariaDB Server performance.
+---
+
 # Filesystem Optimizations
 
 ## Suitability of Filesystems

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # Optimization and Indexes
 
+{% columns %}
+{% column %}
+{% content-ref url="building-the-best-index-for-a-given-select.md" %}
+[building-the-best-index-for-a-given-select.md](building-the-best-index-for-a-given-select.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A cookbook for designing the best index for a given SELECT query.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="compound-composite-indexes.md" %}
+[compound-composite-indexes.md](compound-composite-indexes.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How compound (composite) indexes work in MariaDB and how to design them effectively.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="foreign-keys.md" %}
+[foreign-keys.md](foreign-keys.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB performance optimization guide. Complete reference for query tuning, indexing strategies, and configuration improvements for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ignored-indexes.md" %}
+[ignored-indexes.md](ignored-indexes.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Ignored indexes allow indexes to be visible and maintained without being used by the optimizer. This feature is comparable to MySQL 8’s "invisible indexes."
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="index-statistics.md" %}
+[index-statistics.md](index-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Index statistics provide crucial insights to the MariaDB query optimizer, guiding it in executing queries efficiently. Up-to-date index statistics ensure optimized query performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="latitudelongitude-indexing.md" %}
+[latitudelongitude-indexing.md](latitudelongitude-indexing.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Techniques for indexing latitude/longitude data to speed up nearest-location queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="primary-keys-with-nullable-columns.md" %}
+[primary-keys-with-nullable-columns.md](primary-keys-with-nullable-columns.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How MariaDB handles primary keys over nullable columns, following the SQL standard.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="storage-engine-index-types.md" %}
+[storage-engine-index-types.md](storage-engine-index-types.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The index types available when creating an index: BTREE, HASH, and RTREE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="full-text-indexes/" %}
+[full-text-indexes](full-text-indexes/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Implement full-text indexes in MariaDB Server for efficient text search. This section guides you through creating and utilizing these indexes to optimize queries on large text datasets.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/building-the-best-index-for-a-given-select.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  A cookbook for designing the best index for a given SELECT query.
+---
+
 # Building the best INDEX for a given SELECT
 
 ## The problem

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How compound (composite) indexes work in MariaDB and how to design them
+  effectively.
+---
+
 # Compound (Composite) Indexes
 
 ## A mini-lesson in "compound indexes" ("composite indexes")

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/latitudelongitude-indexing.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/latitudelongitude-indexing.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Techniques for indexing latitude/longitude data to speed up nearest-location
+  queries.
+---
+
 # Latitude/Longitude Indexing
 
 ## The problem

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/primary-keys-with-nullable-columns.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/primary-keys-with-nullable-columns.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How MariaDB handles primary keys over nullable columns, following the SQL
+  standard.
+---
+
 # Primary Keys with Nullable Columns
 
 MariaDB deals with primary keys over nullable columns according to the SQL standards.

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/storage-engine-index-types.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/storage-engine-index-types.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The index types available when creating an index: BTREE, HASH, and RTREE.
+---
+
 # Storage Engine Index Types
 
 This refers to the index\_type definition when creating an index, i.e. BTREE, HASH or RTREE.

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Compression
 
+{% columns %}
+{% column %}
+{% content-ref url="compression-plugins.md" %}
+[compression-plugins.md](compression-plugins.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compression provider plugins that supply compression algorithms to MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="storage-engine-independent-column-compression.md" %}
+[storage-engine-independent-column-compression.md](storage-engine-independent-column-compression.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Storage-engine-independent compression for BLOB and TEXT columns, independent of the storage engine.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/compression-plugins.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/compression-plugins.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Compression provider plugins that supply compression algorithms to MariaDB.
+---
+
 # Compression Plugins
 
 **MariaDB starting with** [**10.7.0**](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.7/10.7.0)

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/storage-engine-independent-column-compression.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-tuning-compression/storage-engine-independent-column-compression.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Storage-engine-independent compression for BLOB and TEXT columns,
+  independent of the storage engine.
+---
+
 # Storage-Engine Independent Column Compression
 
 Storage-engine independent column compression enables [TINYBLOB](../../../reference/data-types/string-data-types/tinyblob.md), [BLOB](../../../reference/data-types/string-data-types/blob.md), [MEDIUMBLOB](../../../reference/data-types/string-data-types/mediumblob.md), [LONGBLOB](../../../reference/data-types/string-data-types/longblob.md), [TINYTEXT](../../../reference/data-types/string-data-types/tinytext.md), [TEXT](../../../reference/data-types/string-data-types/text.md), [MEDIUMTEXT](../../../reference/data-types/string-data-types/mediumtext.md), [LONGTEXT](../../../reference/data-types/string-data-types/longtext.md), [VARCHAR](../../../reference/data-types/string-data-types/varchar.md) and [VARBINARY](../../../reference/data-types/string-data-types/varbinary.md) columns to be compressed.

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Optimizing Data Structure
 
+{% columns %}
+{% column %}
+{% content-ref url="numeric-vs-string-fields.md" %}
+[numeric-vs-string-fields.md](numeric-vs-string-fields.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Why choosing numeric over string columns, where possible, improves storage size and comparison speed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-memory-tables.md" %}
+[optimizing-memory-tables.md](optimizing-memory-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Optimizing MEMORY-engine tables, including choosing between B-tree and hash indexes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-string-and-character-fields.md" %}
+[optimizing-string-and-character-fields.md](optimizing-string-and-character-fields.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Optimizing string and character columns, including matching character sets and collations for faster comparisons.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/numeric-vs-string-fields.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/numeric-vs-string-fields.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Why choosing numeric over string columns, where possible, improves storage
+  size and comparison speed.
+---
+
 
 # Numeric vs String Fields
 

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/optimizing-memory-tables.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/optimizing-memory-tables.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Optimizing MEMORY-engine tables, including choosing between B-tree and hash
+  indexes.
+---
+
 # Optimizing MEMORY Tables
 
 [MEMORY tables](../../../server-usage/storage-engines/memory-storage-engine.md) are a good choice for data that needs to be accessed often, and is rarely updated. Being in memory, it's not suitable for critical data or for storage, but if data can be moved to memory for reading without needing to be regenerated often, if at all, it can provide a significant performance boost.

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/optimizing-string-and-character-fields.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-data-structure/optimizing-string-and-character-fields.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Optimizing string and character columns, including matching character sets
+  and collations for faster comparisons.
+---
+
 # Optimizing String and Character Fields
 
 ## Comparing String Columns

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Optimizing Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="optimize-table.md" %}
+[optimize-table.md](optimize-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB performance optimization guide. Complete reference for query tuning, indexing strategies, and configuration improvements for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="defragmenting-innodb-tablespaces.md" %}
+[defragmenting-innodb-tablespaces.md](defragmenting-innodb-tablespaces.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to reclaim free space and defragment InnoDB tablespaces after deleting rows.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="entity-attribute-value-implementation.md" %}
+[entity-attribute-value-implementation.md](entity-attribute-value-implementation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Implementing the entity-attribute-value (EAV) model in MariaDB, and its trade-offs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ip-range-table-performance.md" %}
+[ip-range-table-performance.md](ip-range-table-performance.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Efficiently storing and querying large sets of non-overlapping ranges, such as IP address ranges.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/defragmenting-innodb-tablespaces.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/defragmenting-innodb-tablespaces.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to reclaim free space and defragment InnoDB tablespaces after deleting
+  rows.
+---
+
 # Defragmenting InnoDB Tablespaces
 
 ## Overview

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/entity-attribute-value-implementation.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/entity-attribute-value-implementation.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Implementing the entity-attribute-value (EAV) model in MariaDB, and its
+  trade-offs.
+---
+
 # Entity-Attribute-Value Implementation
 
 ## The desires

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/ip-range-table-performance.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/ip-range-table-performance.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Efficiently storing and querying large sets of non-overlapping ranges, such
+  as IP address ranges.
+---
+
 # IP Range Table Performance
 
 ## The situation

--- a/server/ha-and-performance/standard-replication/obsolete-replication-information/README.md
+++ b/server/ha-and-performance/standard-replication/obsolete-replication-information/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Obsolete Replication Information
 
+{% columns %}
+{% column %}
+{% content-ref url="load-data-from-master-removed.md" %}
+[load-data-from-master-removed.md](load-data-from-master-removed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the removed LOAD DATA FROM MASTER statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="load-table-from-master-removed.md" %}
+[load-table-from-master-removed.md](load-table-from-master-removed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the removed LOAD TABLE ... FROM MASTER statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-52-replication-feature-preview.md" %}
+[mariadb-52-replication-feature-preview.md](mariadb-52-replication-feature-preview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An obsolete feature-preview page for early MariaDB replication features (historical).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xtradb-option-innodb-release-locks-early.md" %}
+[xtradb-option-innodb-release-locks-early.md](xtradb-option-innodb-release-locks-early.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the obsolete --innodb-release-locks-early XtraDB option.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/standard-replication/obsolete-replication-information/load-data-from-master-removed.md
+++ b/server/ha-and-performance/standard-replication/obsolete-replication-information/load-data-from-master-removed.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Documents the removed LOAD DATA FROM MASTER statement.
+---
+
 # LOAD DATA FROM MASTER (removed)
 
 ## Syntax
@@ -44,9 +49,9 @@ from the mysql database. This makes it easy to have different users and\
 privileges on the master and the slave.
 
 To use `LOAD DATA FROM MASTER`, the replication account that\
-is used to connect to the master must have the `RELOAD` and [SUPER](../../../../reference/sql-statements-and-structure/sql-statements/account-management-sql-commands/grant.md#global-privileges) privileges on the master and the`SELECT` privilege for all master tables you want to load.\
+is used to connect to the master must have the `RELOAD` and [SUPER](../../../reference/sql-statements/account-management-sql-statements/grant.md#global-privileges) privileges on the master and the`SELECT` privilege for all master tables you want to load.\
 All master tables for which the user does not have the`SELECT` privilege are ignored by`LOAD DATA FROM MASTER`. This is because the master hides\
-them from the user: `LOAD DATA FROM MASTER` calls`SHOW DATABASES` to know the master databases to load, but [SHOW DATABASES](../../../../reference/sql-statements-and-structure/sql-statements/administrative-sql-statements/show/show-databases.md) returns only databases\
+them from the user: `LOAD DATA FROM MASTER` calls`SHOW DATABASES` to know the master databases to load, but [SHOW DATABASES](../../../reference/sql-statements/administrative-sql-statements/show/show-databases.md) returns only databases\
 for which the user has some privilege. On the slave side, the user that\
 issues `LOAD DATA FROM MASTER` must have privileges for\
 dropping and creating the databases and tables that are copied.

--- a/server/ha-and-performance/standard-replication/obsolete-replication-information/load-table-from-master-removed.md
+++ b/server/ha-and-performance/standard-replication/obsolete-replication-information/load-table-from-master-removed.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Documents the removed LOAD TABLE ... FROM MASTER statement.
+---
+
 # LOAD TABLE FROM MASTER (removed)
 
 ## Syntax
@@ -26,7 +31,7 @@ works using `SELECT`.
 Transfers a copy of the table from the master to the slave. This statement is\
 implemented mainly debugging `LOAD DATA FROM MASTER`\
 operations. To use `LOAD TABLE`, the account used for\
-connecting to the master server must have the `RELOAD` and [SUPER](../../../../reference/sql-statements-and-structure/sql-statements/account-management-sql-commands/grant.md#global-privileges) privileges on the master and the`SELECT` privilege for the master table to load. On the slave\
+connecting to the master server must have the `RELOAD` and [SUPER](../../../reference/sql-statements/account-management-sql-statements/grant.md#global-privileges) privileges on the master and the`SELECT` privilege for the master table to load. On the slave\
 side, the user that issues `LOAD TABLE FROM MASTER` must have\
 privileges for dropping and creating the table.
 

--- a/server/ha-and-performance/standard-replication/obsolete-replication-information/mariadb-52-replication-feature-preview.md
+++ b/server/ha-and-performance/standard-replication/obsolete-replication-information/mariadb-52-replication-feature-preview.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  An obsolete feature-preview page for early MariaDB replication features
+  (historical).
+---
+
 # MariaDB 5.2 Replication Feature Preview
 
 **Note:** This page is obsolete. The information is old, outdated, or otherwise currently incorrect. We are keeping the page for historical reasons only. **Do not** rely on the information in this article.

--- a/server/ha-and-performance/standard-replication/obsolete-replication-information/xtradb-option-innodb-release-locks-early.md
+++ b/server/ha-and-performance/standard-replication/obsolete-replication-information/xtradb-option-innodb-release-locks-early.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Documents the obsolete --innodb-release-locks-early XtraDB option.
+---
+
 # XtraDB option --innodb-release-locks-early
 
 The --innodb-release-locks-early feature ([MWL#163](https://askmonty.org/worklog/?tid=163)) was included in the [5.2\


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, depth-4 `ha-and-performance/`. Converts 8 auto-populated depth-4 landing pages into columns (one `{% columns %}` block per child: `content-ref` link + description).

## What changed

- **8 landing pages → columns**, in `server/SUMMARY.md` order: `optimization-and-tuning/*` (optimization-and-indexes, optimizing-data-structure, optimizing-tables, mariadb-internal-optimizations, optimization-and-tuning-compression, buffers-caches-and-threads, operating-system-optimizations) and `standard-replication/obsolete-replication-information`. 30 columns.
- **21 child descriptions authored** from page content.
- **Fixed 4 pre-existing broken body links** (surfaced by the frontmatter edits): `multi-range-read-optimization` → `query-optimizer/block-based-join-algorithms.md#batch-key-access-join` (was a GitBook `/broken/` marker); three stale `sql-statements-and-structure/…` paths in `load-data-from-master-removed` / `load-table-from-master-removed` → current `sql-statements/…` paths.

## Method

Child set/order from `SUMMARY.md`. `optimization-and-tuning/optimizer-hints` was deferred (curated `##` grouping); the HEAVY pages (`query-optimizations`, `query-optimizer`, `system-variables`) are reserved for their own authored batches.

## Verification

- ✅ GitBook block balance on all 8 pages.
- ✅ All 30 card links resolve; **all body links in the 21 edited child pages now resolve** (0 broken).
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **158 of 349** Server landing pages. Depth-4 continues with 4e2 (clients + security AUTO), then drop-links, heavy, and curated batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ