### PR TITLE
DOCS-5973: Convert 3 depth-4 HEAVY landing pages to columns (batch 4h)

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/README.md
@@ -7,3 +7,134 @@ description: >-
 
 # Query Optimizer
 
+{% columns %}
+{% column %}
+{% content-ref url="block-based-join-algorithms.md" %}
+[block-based-join-algorithms.md](block-based-join-algorithms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Block-based join algorithms in MariaDB: Block Nested Loop, Block Hash Join, and Batch Key Access.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="condition-selectivity-computation-internals.md" %}
+[condition-selectivity-computation-internals.md](condition-selectivity-computation-internals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How the optimizer computes condition selectivities (internals).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="extended-keys.md" %}
+[extended-keys.md](extended-keys.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The Extended Keys optimization, which uses primary-key parts appended to secondary indexes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="minmax-optimization.md" %}
+[minmax-optimization.md](minmax-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The MIN/MAX optimization, which resolves MIN() and MAX() from an index without scanning rows.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="notes-when-an-index-cannot-be-used.md" %}
+[notes-when-an-index-cannot-be-used.md](notes-when-an-index-cannot-be-used.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Situations in which the optimizer cannot use an index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer-debugging-with-gdb.md" %}
+[optimizer-debugging-with-gdb.md](optimizer-debugging-with-gdb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Tips for debugging MariaDB optimizer code with GDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer-development.md" %}
+[optimizer-development.md](optimizer-development.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Notes on MariaDB optimizer development.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer_max_sel_arg_weight.md" %}
+[optimizer_max_sel_arg_weight.md](optimizer_max_sel_arg_weight.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The optimizer_max_sel_arg_weight setting, which caps the complexity of range analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="range-optimizer.md" %}
+[range-optimizer.md](range-optimizer.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The range optimizer, which builds range scans from WHERE conditions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="the-optimizer-cost-model-from-mariadb-11-0.md" %}
+[the-optimizer-cost-model-from-mariadb-11-0.md](the-optimizer-cost-model-from-mariadb-11-0.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The optimizer cost model introduced in MariaDB 11.0.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer-trace/" %}
+[optimizer-trace](optimizer-trace/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Optimizer trace, which records how the optimizer builds a query's execution plan.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/block-based-join-algorithms.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/block-based-join-algorithms.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Block-based join algorithms in MariaDB: Block Nested Loop, Block Hash Join,
+  and Batch Key Access.
+---
+
 # Block-Based Join Algorithms
 
 In the versions of MariaDB/MySQL before 5.3, only one block-based join algorithm was implemented: the Block Nested Loops (BNL) join algorithm, which could only be used for inner joins.

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/condition-selectivity-computation-internals.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/condition-selectivity-computation-internals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How the optimizer computes condition selectivities (internals).
+---
+
 # Condition Selectivity Computation Internals
 
 This page describes how the MariaDB optimizer computes condition selectivities.

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/extended-keys.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/extended-keys.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The Extended Keys optimization, which uses primary-key parts appended to
+  secondary indexes.
+---
+
 # Extended Keys
 
 ## Syntax

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/extended-keys.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/extended-keys.md
@@ -22,7 +22,7 @@ SET optimizer_switch='extended_keys=off';
 
 ## Description
 
-Extended Keys is an optimization set with the [optimizer\_switch](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#optimizer_switch) system variable, which makes use of existing components of InnoDB keys to generate more efficient execution plans. Using these components in many cases allows the server to generate execution plans which employ index-only look-ups. It is set by default.
+Extended Keys is an optimization set with the [optimizer\_switch](../system-variables/server-system-variables.md#optimizer_switch) system variable, which makes use of existing components of InnoDB keys to generate more efficient execution plans. Using these components in many cases allows the server to generate execution plans which employ index-only look-ups. It is set by default.
 
 Extended keys can be used with:
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/minmax-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/minmax-optimization.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Min/Max optimization without GROUP BY
 
-MariaDB and MySQL can optimize the [MIN()](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/sql-functions/aggregate-functions/min.md) and [MAX()](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/sql-functions/aggregate-functions/max.md) functions to be a single row lookup in the following cases:
+MariaDB and MySQL can optimize the [MIN()](../../../reference/sql-functions/aggregate-functions/min.md) and [MAX()](../../../reference/sql-functions/aggregate-functions/max.md) functions to be a single row lookup in the following cases:
 
 * There is only one table used in the `SELECT`.
 * You only have constants, `MIN()` and `MAX()` in the `SELECT` part.
@@ -66,8 +66,8 @@ SELECT a, b, MIN(c),MAX(c) FROM t1 GROUP BY a,b
 
 ## See also
 
-* [MIN()](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/sql-functions/aggregate-functions/min.md)
-* [MAX()](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/sql-functions/aggregate-functions/max.md)
+* [MIN()](../../../reference/sql-functions/aggregate-functions/min.md)
+* [MAX()](../../../reference/sql-functions/aggregate-functions/max.md)
 * [MySQL manual on loose index scans](https://dev.mysql.com/doc/refman/5.7/en/group-by-optimization.html)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/minmax-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/minmax-optimization.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The MIN/MAX optimization, which resolves MIN() and MAX() from an index
+  without scanning rows.
+---
+
 # MIN/MAX optimization
 
 ## Min/Max optimization without GROUP BY

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/notes-when-an-index-cannot-be-used.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/notes-when-an-index-cannot-be-used.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Situations in which the optimizer cannot use an index.
+---
+
 # Notes When an Index Cannot Be Used
 
 **MariaDB starting with** [**10.6.16**](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.6/10.6.16)

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/notes-when-an-index-cannot-be-used.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/notes-when-an-index-cannot-be-used.md
@@ -46,7 +46,7 @@ As a server variable:
 @@note_verbosity="all";
 ```
 
-[note\_verbosity](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#note_verbosity) describes with note categories one want to get notes for. Be aware that if the old [sql\_notes](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#sql_notes) variable is 0, one will not get any notes.
+[note\_verbosity](../system-variables/server-system-variables.md#note_verbosity) describes with note categories one want to get notes for. Be aware that if the old [sql\_notes](../system-variables/server-system-variables.md#sql_notes) variable is 0, one will not get any notes.
 
 It can have one or many of the following options:
 
@@ -72,7 +72,7 @@ As a server variable:
 
 ## See Also
 
-* [Type conversions](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/sql-functions/string-functions/type-conversion.md)
+* [Type conversions](../../../reference/sql-functions/string-functions/type-conversion.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-debugging-with-gdb.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-debugging-with-gdb.md
@@ -44,7 +44,7 @@ end
 
 ## Other Settings
 
-* May need to set [innodb\_fatal\_semaphore\_wait\_threshold](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/storage-engines/innodb/innodb-system-variables.md#innodb_fatal_semaphore_wait_threshold) to be high enough?
+* May need to set [innodb\_fatal\_semaphore\_wait\_threshold](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_fatal_semaphore_wait_threshold) to be high enough?
 
 ## Other development topics
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-debugging-with-gdb.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-debugging-with-gdb.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Tips for debugging MariaDB optimizer code with GDB.
+---
+
 # Optimizer Debugging With GDB
 
 Some useful things for debugging optimizer code.
@@ -64,7 +69,7 @@ git diff -U0 --no-color --relative HEAD^ | clang-format-diff -p1 -i
 
 ## See Also
 
-* [How to collect large optimizer traces](mariadb-internals-documentation-optimizer-trace/how-to-collect-large-optimizer-traces.md)
+* [How to collect large optimizer traces](optimizer-trace/how-to-collect-large-optimizer-traces.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-development.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-development.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Notes on MariaDB optimizer development.
+---
+
 # Optimizer Development
 
 Notes about Optimizer Development

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-trace/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer-trace/README.md
@@ -1,2 +1,8 @@
+---
+description: >-
+  Optimizer trace, which records how the optimizer builds a query's execution
+  plan.
+---
+
 # Optimizer Trace
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer_max_sel_arg_weight.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer_max_sel_arg_weight.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The optimizer_max_sel_arg_weight setting, which caps the complexity of range
+  analysis.
+---
+
 # optimizer\_max\_sel\_arg\_weight
 
 ## Basics

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer_max_sel_arg_weight.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/optimizer_max_sel_arg_weight.md
@@ -58,13 +58,13 @@ SELECT * FROM information_schema.optimizer_trace\G
                          ],
 ```
 
-This number is fine but if your IN-list are thousands then the number of ranges can in the millions which may cause excessive CPU or memory usage (Note: this however is avoided in some cases when [IN-predicate is converted into subquery](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/conversion-of-big-in-predicates-into-subqueries.md). But there are cases when that is not done)
+This number is fine but if your IN-list are thousands then the number of ranges can in the millions which may cause excessive CPU or memory usage (Note: this however is avoided in some cases when [IN-predicate is converted into subquery](../query-optimizations/subquery-optimizations/conversion-of-big-in-predicates-into-subqueries.md). But there are cases when that is not done)
 
 ## SEL\_ARG graph
 
 Internally, the Range Optimizer builds this kind of graph:
 
-![](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/.gitbook/assets/optimizer_max_sel_arg_weight/+image/sel-arg-graph1.png)
+![](../../../.gitbook/assets/sel-arg-graph1.png)
 
 Vertical black lines connect adjacent "intervals" on the same key part.\
 Red lines connect a key part to a subsequent key part.
@@ -84,7 +84,7 @@ Due to the way the graph is constructed, we cannot tell how many ranges it would
 we introduce a parameter "weight" which is easy to compute and is roughly proportional to the number of\
 ranges we estimate to produce.
 
-![](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/.gitbook/assets/optimizer_max_sel_arg_weight/+image/sel-arg-subgraphs.png)
+![](../../../.gitbook/assets/sel-arg-subgraphs.png)
 
 Here is how the weight is computed:
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/range-optimizer.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/range-optimizer.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The range optimizer, which builds range scans from WHERE conditions.
+---
+
 # Range Optimizer
 
 Range optimizer is a part of MariaDB (and MySQL) optimizer that takes as input

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/the-optimizer-cost-model-from-mariadb-11-0.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/the-optimizer-cost-model-from-mariadb-11-0.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The optimizer cost model introduced in MariaDB 11.0.
+---
+
 # The Optimizer Cost Model from MariaDB 11.0
 
 ## Background

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizer/the-optimizer-cost-model-from-mariadb-11-0.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizer/the-optimizer-cost-model-from-mariadb-11-0.md
@@ -65,10 +65,10 @@ OPTIMIZER_INDEX_BLOCK_COPY_COST: 0.035600
       OPTIMIZER_ROWID_COPY_COST: 0.002653
 ```
 
-The above costs are the default (base) for all engines and should be reasonable for engines that does not have a clustered index (like [MyISAM](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/storage-engines/myisam-storage-engine/README.md), [Aria](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/storage-engines/aria/README.md) etc). The default costs can be changed by specifying just the cost as an argument, like `mariadbd --optimizer-disk-read-cost=20` or from SQL: `set global optimizer_disk_read_cost=20`. An engine specific cost can be tuned by prefixing the cost with the engine name, like `set global innodb.optimizer_disk_read_cost=20`.
+The above costs are the default (base) for all engines and should be reasonable for engines that does not have a clustered index (like [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/README.md), [Aria](../../../server-usage/storage-engines/aria/README.md) etc). The default costs can be changed by specifying just the cost as an argument, like `mariadbd --optimizer-disk-read-cost=20` or from SQL: `set global optimizer_disk_read_cost=20`. An engine specific cost can be tuned by prefixing the cost with the engine name, like `set global innodb.optimizer_disk_read_cost=20`.
 
 An engine can tune some or all of the above cost in the storage engine interface.\
-Here follows the cost for the [InnoDB storage engine](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/community/storage-engines/innodb/README.md).
+Here follows the cost for the [InnoDB storage engine](../../../server-usage/storage-engines/innodb/README.md).
 
 ```sql
 SELECT * FROM information_schema.optimizer_costs WHERE engine="innodb"\G
@@ -130,7 +130,7 @@ things, except for `OPTIMIZER_DISK_READ_COST` as one should use published/tested
 | OPTIMIZER\_SCAN\_SETUP\_COST        | Session | Cost of starting a table or index scan. This has a low value to encourage the optimizer to use index lookup also tables with very few rows                                                                                                                                                   |
 | OPTIMIZER\_WHERE\_COST              | Session | Cost to execute the WHERE clause for every found row. Increasing this variable will encourage the optimizer to find plans which read fewer rows                                                                                                                                              |
 
-More information of the costs and how they were calculated can be found in the `Docs/optimizer_costs.txt` file in the [MariaDB Source distributions](https://github.com/mariadb-corporation/docs-server/blob/test/general-resources/clients-and-utilities/server-client-software/download/getting-the-mariadb-source-code.md).
+More information of the costs and how they were calculated can be found in the `Docs/optimizer_costs.txt` file in the [MariaDB Source distributions](../../../clients-and-utilities/server-client-software/download/getting-the-mariadb-source-code.md).
 
 ## Other Optimizer Cost Changes
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/README.md
@@ -7,3 +7,194 @@ description: >-
 
 # System Variables
 
+{% columns %}
+{% column %}
+{% content-ref url="big-query-settings.md" %}
+[big-query-settings.md](big-query-settings.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Settings and features aimed at big queries, several of which are disabled by default.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="handling-too-many-connections.md" %}
+[handling-too-many-connections.md](handling-too-many-connections.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to handle and avoid the 'too many connections' error on busy servers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-optimization-for-mysql-users.md" %}
+[mariadb-optimization-for-mysql-users.md](mariadb-optimization-for-mysql-users.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+MariaDB optimization options and defaults that differ from MySQL, for users migrating from MySQL.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-key_buffer_size.md" %}
+[optimizing-key_buffer_size.md](optimizing-key_buffer_size.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Tuning key_buffer_size for servers with mostly MyISAM tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-table_open_cache.md" %}
+[optimizing-table_open_cache.md](optimizing-table_open_cache.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Tuning table_open_cache to balance performance against open-file usage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="oqgraph-system-and-status-variables.md" %}
+[oqgraph-system-and-status-variables.md](oqgraph-system-and-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+System and status variables for the OQGRAPH storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sample-mycnf-files.md" %}
+[sample-mycnf-files.md](sample-mycnf-files.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Sample my.cnf configuration files for different memory sizes and storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="segmented-key-cache.md" %}
+[segmented-key-cache.md](segmented-key-cache.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Segmented key caches, which split the MyISAM key cache into structures to reduce contention.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="semisynchronous-replication-plugin-status-variables.md" %}
+[semisynchronous-replication-plugin-status-variables.md](semisynchronous-replication-plugin-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Status variables for the semisynchronous replication plugin.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-status-variables.md" %}
+[innodb-status-variables.md](innodb-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+InnoDB server status variables, viewable with SHOW STATUS.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setting-innodb-buffer-pool-size-dynamically.md" %}
+[setting-innodb-buffer-pool-size-dynamically.md](setting-innodb-buffer-pool-size-dynamically.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to resize the InnoDB buffer pool dynamically, in chunks.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sphinx-status-variables.md" %}
+[sphinx-status-variables.md](sphinx-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Status variables for the Sphinx storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="spider-status-variables.md" %}
+[spider-status-variables.md](spider-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Status variables for the Spider storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sql-error-log-system-variables-and-options.md" %}
+[sql-error-log-system-variables-and-options.md](sql-error-log-system-variables-and-options.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+System variables and options for the SQL Error Log plugin.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ssltls-status-variables.md" %}
+[ssltls-status-variables.md](ssltls-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Status variables related to TLS/SSL-encrypted connections.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="system-and-status-variables-added-by-major-release/" %}
+[system-and-status-variables-added-by-major-release](system-and-status-variables-added-by-major-release/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover system and status variables added by major MariaDB Server releases. This section helps you track new configuration options and monitoring metrics introduced in different versions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/big-query-settings.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/big-query-settings.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Settings and features aimed at big queries, several of which are disabled by
+  default.
+---
+
 # Big Query Settings
 
 MariaDB 5.3 and beyond have a number of features that are targeted at big queries and so are disabled by default.
@@ -32,7 +38,7 @@ Turn on [index\_merge/sort-intersection](../query-optimizations/index_merge-sort
 optimizer_switch='index_merge_sort_intersection=on'
 ```
 
-If your queries examine big fraction of the tables (somewhere more than \~ 30%), turn on [hash join](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/VWjZF4UcCaSJJtdMzBO2#block-hash-join):
+If your queries examine big fraction of the tables (somewhere more than \~ 30%), turn on [hash join](../query-optimizer/block-based-join-algorithms.md#block-hash-join):
 
 ```sql
 # Turn on both Hash Join and Batched Key Access

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/handling-too-many-connections.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/handling-too-many-connections.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How to handle and avoid the 'too many connections' error on busy servers.
+---
+
 
 # Handling Too Many Connections
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/innodb-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  InnoDB server status variables, viewable with SHOW STATUS.
+---
+
 # InnoDB Server Status Variables
 
 See [Server Status Variables](server-status-variables.md) for a complete list of status variables that can be viewed with [SHOW STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-status.md).
@@ -507,35 +512,35 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_encryption_rotation_estimated_iops`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
 
 #### `Innodb_encryption_rotation_pages_flushed`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
 
 #### `Innodb_encryption_rotation_pages_modified`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
 
 #### `Innodb_encryption_rotation_pages_read_from_cache`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
 
 #### `Innodb_encryption_rotation_pages_read_from_disk`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
@@ -928,13 +933,13 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_num_pages_decrypted`
 
-* Description: Number of pages page decrypted. See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: Number of pages page decrypted. See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 
 #### `Innodb_num_pages_encrypted`
 
-* Description: Number of pages page encrypted. See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: Number of pages page encrypted. See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 
@@ -958,7 +963,7 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_num_pages_page_encryption_error`
 
-* Description: Number of page encryption errors. See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: Number of page encryption errors. See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Introduced: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
@@ -1241,7 +1246,7 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_scrub_background_page_reorganizations`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Introduced: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
@@ -1249,7 +1254,7 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_scrub_background_page_split_failures_missing_index`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Introduced: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
@@ -1257,7 +1262,7 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_scrub_background_page_split_failures_out_of_filespace`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Introduced: [MariaDB 10.1.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.3)
@@ -1265,21 +1270,21 @@ See also the [Full list of MariaDB options, system and status variables](../../.
 
 #### `Innodb_scrub_background_page_split_failures_underflow`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.5.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.5/10.5.2)
 
 #### `Innodb_scrub_background_page_split_failures_unknown`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.5.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.5/10.5.2)
 
 #### `Innodb_scrub_background_page_splits`
 
-* Description: See [Table and Tablespace Encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N).
+* Description: See [Table and Tablespace Encryption](../../../security/encryption/data-at-rest-encryption/innodb-encryption/).
 * Scope: Global
 * Data Type: `numeric`
 * Removed: [MariaDB 10.5.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.5/10.5.2)

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/mariadb-optimization-for-mysql-users.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/mariadb-optimization-for-mysql-users.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  MariaDB optimization options and defaults that differ from MySQL, for users
+  migrating from MySQL.
+---
+
 # MariaDB Optimization for MySQL Users
 
 MariaDB contains many new options and optimizations which, for\
@@ -17,7 +23,7 @@ If you are using a log of on-disk temporary tables, increase the above to as muc
 key-cache-segments=8
 ```
 
-If you use/have a lot of MyISAM files, increase the above to 4 or 8. See [Segmented Key Cache](segmented-key-cache.md) and [Segmented Key Cache Performance](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/ySaANiCpRqROWwoll9yo) for more information.
+If you use/have a lot of MyISAM files, increase the above to 4 or 8. See [Segmented Key Cache](segmented-key-cache.md) and [Segmented Key Cache Performance](../../../reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/segmented-key-cache-performance.md) for more information.
 
 ```
 thread-handling=pool-of-threads

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/optimizing-key_buffer_size.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/optimizing-key_buffer_size.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Tuning key_buffer_size for servers with mostly MyISAM tables.
+---
+
 # Optimizing key\_buffer\_size
 
 [key\_buffer\_size](../../../server-usage/storage-engines/myisam-storage-engine/myisam-system-variables.md#key_buffer_size) is a [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/) variable which determines the size of the index buffers held in memory, which affects the speed of index reads. Note that Aria tables by default make use of an alternative setting, [aria-pagecache-buffer-size](../../../server-usage/storage-engines/aria/aria-system-variables.md).

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/optimizing-table_open_cache.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/optimizing-table_open_cache.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Tuning table_open_cache to balance performance against open-file usage.
+---
+
 # Optimizing table\_open\_cache
 
 [_table\_open\_cache_](server-system-variables.md#table_open_cache) can be a useful variable to adjust to improve performance.

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/oqgraph-system-and-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/oqgraph-system-and-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  System and status variables for the OQGRAPH storage engine.
+---
+
 # OQGRAPH System and Status Variables
 
 This page documents system and status variables related to the [OQGRAPH storage engine](../../../server-usage/storage-engines/oqgraph-storage-engine/). See [Server Status Variables](server-status-variables.md) and [Server System Variables](server-system-variables.md) for complete list of all system and status variables.

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/sample-mycnf-files.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/sample-mycnf-files.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Sample my.cnf configuration files for different memory sizes and storage
+  engines.
+---
+
 
 # Sample my.cnf Files
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/segmented-key-cache.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/segmented-key-cache.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Segmented key caches, which split the MyISAM key cache into structures to
+  reduce contention.
+---
+
 # Segmented Key Cache
 
 ## About Segmented Key Cache
@@ -12,7 +18,7 @@ page. Pages are evenly distributed among segments.
 
 The idea and the original code of the segmented key cache was provided by Fredrik Nylander from Stardoll.com. The code was extensively reworked, improved, and eventually merged into MariaDB by Igor Babaev from Monty Program (now MariaDB Corporation).
 
-You can find some benchmark results comparing various settings on the [Segmented Key Cache Performance](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/ySaANiCpRqROWwoll9yo) page.
+You can find some benchmark results comparing various settings on the [Segmented Key Cache Performance](../../../reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/segmented-key-cache-performance.md) page.
 
 ## Segmented Key Cache Syntax
 
@@ -43,7 +49,7 @@ Statistics about the key cache can be found by looking at the [KEY\_CACHES](../.
 
 ## See Also
 
-* [Segmented Key Cache Performance](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/ySaANiCpRqROWwoll9yo)
+* [Segmented Key Cache Performance](../../../reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/segmented-key-cache-performance.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/semisynchronous-replication-plugin-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/semisynchronous-replication-plugin-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Status variables for the semisynchronous replication plugin.
+---
+
 # Semisynchronous Replication Plugin Status Variables
 
 This page documents status variables related to the [Semisynchronous Replication Plugin](../../standard-replication/semisynchronous-replication.md) (which has been merged into the main server from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)). See [Server Status Variables](server-status-variables.md) for a complete list of status variables that can be viewed with [SHOW STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-status.md).

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/setting-innodb-buffer-pool-size-dynamically.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/setting-innodb-buffer-pool-size-dynamically.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How to resize the InnoDB buffer pool dynamically, in chunks.
+---
+
 # Setting Innodb Buffer Pool Size Dynamically
 
 Resizing the buffer pool is performed in chunks determined by the size of the [innodb\_buffer\_pool\_chunk\_size](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_buffer_pool_chunk_size) variable.

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/sphinx-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/sphinx-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Status variables for the Sphinx storage engine.
+---
+
 # Sphinx Status Variables
 
 This page documents status variables related to the [Sphinx storage engine](../../../server-usage/storage-engines/sphinx-storage-engine/). See [Server Status Variables](server-status-variables.md) for a complete list of status variables that can be viewed with [SHOW STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-status.md).

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/spider-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/spider-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Status variables for the Spider storage engine.
+---
+
 # Spider Status Variables
 
 The following status variables are associated with the [Spider storage engine](../../../server-usage/storage-engines/spider/). See [Server Status Variables](server-status-variables.md) for a complete list of status variables that can be viewed with [SHOW STATUS](../../../reference/sql-statements/administrative-sql-statements/show/show-status.md).

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/sql-error-log-system-variables-and-options.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/sql-error-log-system-variables-and-options.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  System variables and options for the SQL Error Log plugin.
+---
+
 # SQL Error Log System Variables and Options
 
 This page documents system variables and options related to the [SQL\_Error\_Log Plugin](../../../server-management/server-monitoring-logs/sql-error-log-plugin.md). See [Server System Variables](server-system-variables.md) for a complete list of system variables and instructions on setting them.

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/ssltls-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/ssltls-status-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Status variables related to TLS/SSL-encrypted connections.
+---
+
 # SSL/TLS Status Variables
 
 The status variables listed on this page relate to encrypting data during transfer with the Transport Layer Security (TLS) protocol. Often, the term Secure Socket Layer (SSL) is used interchangeably with TLS, although strictly speaking, the SSL protocol is a predecessor to TLS and is no longer considered secure.

--- a/server/reference/sql-structure/sql-language-structure/README.md
+++ b/server/reference/sql-structure/sql-language-structure/README.md
@@ -7,3 +7,170 @@ description: >-
 
 # SQL Language Structure
 
+{% columns %}
+{% column %}
+{% content-ref url="binary-literals.md" %}
+[binary-literals.md](binary-literals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Binary literal syntax in MariaDB: b'value', B'value', and 0bvalue.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="date-and-time-literals.md" %}
+[date-and-time-literals.md](date-and-time-literals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Syntax for DATE, TIME, DATETIME, and TIMESTAMP literals, including SQL- standard and ODBC forms.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hexadecimal-literals.md" %}
+[hexadecimal-literals.md](hexadecimal-literals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Hexadecimal literal syntax in MariaDB, such as x'value' and 0xvalue.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="identifier-case-sensitivity.md" %}
+[identifier-case-sensitivity.md](identifier-case-sensitivity.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How identifier case sensitivity depends on the object type and the operating system.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="identifier-names.md" %}
+[identifier-names.md](identifier-names.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Rules for naming identifiers such as databases, tables, columns, and other objects.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="identifier-qualifiers.md" %}
+[identifier-qualifiers.md](identifier-qualifiers.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Using qualifiers (such as db.table.column) to reference database objects in SQL.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="identifier-to-file-name-mapping.md" %}
+[identifier-to-file-name-mapping.md](identifier-to-file-name-mapping.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How MariaDB maps identifiers to file names on disk.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="numeric-iterals.md" %}
+[numeric-iterals.md](numeric-iterals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Numeric literal syntax for integers and decimals, including signs and exponents.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="reserved-words.md" %}
+[reserved-words.md](reserved-words.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The list of reserved words in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sql-language-structure-boolean-literals.md" %}
+[sql-language-structure-boolean-literals.md](sql-language-structure-boolean-literals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Boolean literals: TRUE and FALSE as synonyms for 1 and 0.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="schema-qualifiers.md" %}
+[schema-qualifiers.md](schema-qualifiers.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Schema qualifiers manage SQL mode dependent behavior for data types and functions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="string-literals.md" %}
+[string-literals.md](string-literals.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+String literal syntax, quoting, and escape sequences.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-value-constructors.md" %}
+[table-value-constructors.md](table-value-constructors.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The VALUES table value constructor, which produces a set of rows.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-defined-variables.md" %}
+[user-defined-variables.md](user-defined-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Session-scoped user-defined variables (@var), and how to set and use them.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/sql-language-structure/binary-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/binary-literals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Binary literal syntax in MariaDB: b'value', B'value', and 0bvalue.
+---
+
 # Binary Literals
 
 Binary literals can be written in one of the following formats: `b'value'`, `B'value'` or `0bvalue`, where `value` is a string composed by `0` and `1` digits.

--- a/server/reference/sql-structure/sql-language-structure/date-and-time-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/date-and-time-literals.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Syntax for DATE, TIME, DATETIME, and TIMESTAMP literals, including SQL-
+  standard and ODBC forms.
+---
+
 # Date and Time Literals
 
 ## Standard syntaxes

--- a/server/reference/sql-structure/sql-language-structure/hexadecimal-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/hexadecimal-literals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Hexadecimal literal syntax in MariaDB, such as x'value' and 0xvalue.
+---
+
 # Hexadecimal Literals
 
 Hexadecimal literals can be written using any of the following syntaxes:

--- a/server/reference/sql-structure/sql-language-structure/identifier-case-sensitivity.md
+++ b/server/reference/sql-structure/sql-language-structure/identifier-case-sensitivity.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How identifier case sensitivity depends on the object type and the operating
+  system.
+---
+
 # Identifier Case Sensitivity
 
 Whether objects are case sensitive or not is partly determined by the underlying operating system. Unix-based systems are case sensitive, Windows is not, while Mac OS X is usually case insensitive by default, but devices can be configured as case sensitive using Disk Utility.
@@ -9,7 +15,8 @@ Log file group names are case sensitive.
 {% hint style="info" %}
 In some cases, the table exists but that you are referring to it incorrectly:
 
-*  Because MariaDB uses directories and files to store databases and tables, database and table names are case-sensitive if they are located on a file system that has case-sensitive file names.
+*
+  Because MariaDB uses directories and files to store databases and tables, database and table names are case-sensitive if they are located on a file system that has case-sensitive file names.
 * Even for file systems that are not case-sensitive, such as on Windows, all references to a given table within a query must use the same lettercase. 
 {% endhint %}
 

--- a/server/reference/sql-structure/sql-language-structure/identifier-names.md
+++ b/server/reference/sql-structure/sql-language-structure/identifier-names.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Rules for naming identifiers such as databases, tables, columns, and other
+  objects.
+---
+
 # Identifier Names
 
 Databases, tables, indexes, columns, aliases, views, stored routines, triggers, events, variables, partitions, tablespaces, savepoints, labels, users, roles, are collectively known as identifiers, and have certain rules for naming.

--- a/server/reference/sql-structure/sql-language-structure/identifier-qualifiers.md
+++ b/server/reference/sql-structure/sql-language-structure/identifier-qualifiers.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Using qualifiers (such as db.table.column) to reference database objects in
+  SQL.
+---
+
 # Identifier Qualifiers
 
 Qualifiers are used within SQL statements to reference data structures, such as databases, tables, or columns. For example, typically a `SELECT` query contains references to some columns and at least one table.

--- a/server/reference/sql-structure/sql-language-structure/identifier-to-file-name-mapping.md
+++ b/server/reference/sql-structure/sql-language-structure/identifier-to-file-name-mapping.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How MariaDB maps identifiers to file names on disk.
+---
+
 # Identifier to File Name Mapping
 
 Some identifiers map to a file name on the filesystem. Databases each have their own directory, while, depending on the [storage engine](../../../server-usage/storage-engines/), table names and index names may map to a file name.

--- a/server/reference/sql-structure/sql-language-structure/numeric-iterals.md
+++ b/server/reference/sql-structure/sql-language-structure/numeric-iterals.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Numeric literal syntax for integers and decimals, including signs and
+  exponents.
+---
+
 
 # Numeric Literals
 
@@ -10,7 +16,7 @@ If the integer part is zero, it can be omitted, but the literal must begin with 
 The notation with exponent can be used. The exponent is preceded by an `E` or `e` character. The exponent can be preceded by a sign and must be an integer. A number `N` with an exponent part `X`, is calculated as `N * POW(10, X)`.
 
 
-In some cases, adding zeroes at the end of a decimal number can increment the precision of the expression where the number is used. For example, [PI()](../sql-statements/built-in-functions/numeric-functions/pi.md) by default returns a number with 6 decimal digits. But the `PI()+0.0000000000` expression (with 10 zeroes) returns a number with 10 decimal digits.
+In some cases, adding zeroes at the end of a decimal number can increment the precision of the expression where the number is used. For example, [PI()](../../sql-functions/numeric-functions/pi.md) by default returns a number with 6 decimal digits. But the `PI()+0.0000000000` expression (with 10 zeroes) returns a number with 10 decimal digits.
 
 
 [Hexadecimal literals](hexadecimal-literals.md) are interpreted as numbers when used in numeric contexts.

--- a/server/reference/sql-structure/sql-language-structure/reserved-words.md
+++ b/server/reference/sql-structure/sql-language-structure/reserved-words.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The list of reserved words in MariaDB.
+---
+
 # Reserved Words
 
 The following is a list of all reserved words in MariaDB.

--- a/server/reference/sql-structure/sql-language-structure/sql-language-structure-boolean-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/sql-language-structure-boolean-literals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Boolean literals: TRUE and FALSE as synonyms for 1 and 0.
+---
+
 # Boolean Literals
 
 In MariaDB, `FALSE` is a synonym of `0` and `TRUE` is a synonym of `1`. These constants are case insensitive, so `TRUE`, `True`, and `true` are equivalent.

--- a/server/reference/sql-structure/sql-language-structure/string-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/string-literals.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  String literal syntax, quoting, and escape sequences.
+---
+
 # String Literals
 
 Strings are sequences of characters and enclosed with quotes.

--- a/server/reference/sql-structure/sql-language-structure/table-value-constructors.md
+++ b/server/reference/sql-structure/sql-language-structure/table-value-constructors.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The VALUES table value constructor, which produces a set of rows.
+---
+
 # Table Value Constructors
 
 ## Syntax

--- a/server/reference/sql-structure/sql-language-structure/user-defined-variables.md
+++ b/server/reference/sql-structure/sql-language-structure/user-defined-variables.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Session-scoped user-defined variables (@var), and how to set and use them.
+---
+
 # User-Defined Variables
 
 User-defined variables are variables which can be created by the user and exist in the session. This means that no one can access user-defined variables that have been set by another user, and when the session is closed these variables expire. However, these variables can be shared between several queries and [stored programs](../../../server-usage/stored-routines/).


### PR DESCRIPTION
## What & why

[DOCS-5973](https://mariadbcorp.atlassian.net/browse/DOCS-5973) — landing-page columns campaign, the last HEAVY depth-4 batch. Converts 3 auto-populated depth-4 landing pages into columns, authoring the missing child descriptions.

## What changed

- **3 landing pages → columns** (41 total), in `server/SUMMARY.md` order: `optimization-and-tuning/system-variables` (16), `reference/sql-structure/sql-language-structure` (14 — literals, identifiers, reserved words), `optimization-and-tuning/query-optimizer` (11 — range optimizer, cost model, block-based joins, optimizer trace).
- **39 child descriptions authored** from page content.
- **Fixed 20 pre-existing broken links** (5 unique) surfaced by the frontmatter edits, all to verified in-repo targets:
  - `innodb-status-variables` ×14 ("Table and Tablespace Encryption") → the InnoDB Encryption section
  - `block-hash-join` → `query-optimizer/block-based-join-algorithms.md#block-hash-join`
  - "Segmented Key Cache Performance" (2 pages) → the benchmarks page
  - optimizer-trace stale directory name → `optimizer-trace/`
  - `pi.md` → `sql-functions/numeric-functions/pi.md` (post-rename path)

## Verification

- ✅ GitBook block balance (41 columns).
- ✅ All 41 card links resolve; **all 39 child-page body links resolve** (0 broken).
- ✅ codespell clean. lychee runs in CI.

## Scope note

Campaign progress: **169 of 349** Server landing pages. Depth-4 is down to the curated hand-edit batches (topologies; product-development / docker / connect / systemd / etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-5973]: https://mariadbcorp.atlassian.net/browse/DOCS-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ