### PR TITLE
DOCS-5973: Columnize MariaDB Enterprise Spider topologies landing page (batch 4i)

### DIFF
--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/README.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/README.md
@@ -7,17 +7,41 @@ description: >-
 
 # MariaDB Enterprise Spider Topologies
 
+{% columns %}
+{% column %}
 {% content-ref url="federated-mariadb-enterprise-spider-topology.md" %}
 [federated-mariadb-enterprise-spider-topology.md](federated-mariadb-enterprise-spider-topology.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Query, join, or migrate tables on a remote MariaDB Enterprise Server node from a Spider Node using virtual Spider Tables and the MariaDB foreign data wrapper.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="odbc-mariadb-enterprise-spider-topology.md" %}
 [odbc-mariadb-enterprise-spider-topology.md](odbc-mariadb-enterprise-spider-topology.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Read from and write to external ODBC data sources from a Spider Node using virtual Spider Tables and the ODBC foreign data wrapper (Enterprise Server 10.5 and later).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="sharded-mariadb-enterprise-spider-topology.md" %}
 [sharded-mariadb-enterprise-spider-topology.md](sharded-mariadb-enterprise-spider-topology.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Partition a large table across multiple MariaDB Enterprise Server Data Nodes using virtual Spider Tables and standard partitioning syntax for horizontal scalability.
+{% endcolumn %}
+{% endcolumns %}
 
 ## See Also
 

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/federated-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/federated-mariadb-enterprise-spider-topology.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Query, join, or migrate tables on a remote MariaDB Enterprise Server node from
+  a Spider Node using virtual Spider Tables and the MariaDB foreign data wrapper.
+---
+
 # Federated MariaDB Enterprise Spider Topology
 
 ## Federated MariaDB Enterprise Spider Topology
@@ -144,7 +150,7 @@ COMMENT='server "hq_server", table "invoices"';
 
 ### Deployment
 
-* [Deploy MariaDB Enterprise Spider](/broken/spaces/aEnK0ZXmUbJzqQrTjFyb/pages/BbZ3TNWsYNwHXVyiSQ6z#spider-topologies)
+* [Deploy MariaDB Enterprise Spider](../topologies-overview.md#spider-topologies)
 
 ### Operations
 

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/odbc-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/odbc-mariadb-enterprise-spider-topology.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Read from and write to external ODBC data sources from a Spider Node using
+  virtual Spider Tables and the ODBC foreign data wrapper (Enterprise Server
+  10.5 and later).
+---
+
 # ODBC MariaDB Enterprise Spider Topology
 
 ## Overview

--- a/server/architecture/topologies/mariadb-enterprise-spider-topologies/sharded-mariadb-enterprise-spider-topology.md
+++ b/server/architecture/topologies/mariadb-enterprise-spider-topologies/sharded-mariadb-enterprise-spider-topology.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Partition a large table across multiple MariaDB Enterprise Server Data Nodes
+  using virtual Spider Tables and standard partitioning syntax for horizontal
+  scalability.
+---
+
 # Sharded MariaDB Enterprise Spider Topology
 
 ## Sharded MariaDB Enterprise Spider Topology
@@ -146,7 +153,7 @@ PARTITION BY LIST(branch_id) (
 
 ### Deployment
 
-* [Deploy MariaDB Enterprise Spider](/broken/spaces/aEnK0ZXmUbJzqQrTjFyb/pages/BbZ3TNWsYNwHXVyiSQ6z#spider-topologies)
+* [Deploy MariaDB Enterprise Spider](../topologies-overview.md#spider-topologies)
 
 ### Schema Design
 


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 4i — `architecture/topologies`).

## Scope decision
The `architecture/topologies` subtree is mostly **hand-curated ES deployment runbooks** (spec tables, `## Components`/`## Topology` prose, HTML "Procedure Steps" tables that already link every child). Those are left untouched. Only one page was a genuinely bare auto-populated content-ref list, so only it is converted here. The subtree is otherwise complete.

## Changes (4 files)
- `mariadb-enterprise-spider-topologies/README.md` — 3 bare content-refs → `{% columns %}` blocks with authored descriptions; `## See Also` + footer preserved.
- Added frontmatter `description:` to the 3 child pages (federated / odbc / sharded).
- Fixed **2 pre-existing `/broken/` GitBook dead-reference links** (federated + sharded) → `../topologies-overview.md#spider-topologies`. Surfaced by lychee once the child pages entered the changed set; same class of debt tracked by DOCS-6308.

## Verification
- Columns balance 3/3; all 4 content-ref targets resolve (incl. See Also).
- No residual `/broken/` or `docs-server` links in touched files.
- codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)