### PR TITLE
DOCS-5973: Columnize the 3 product-development landing pages (batch 4j-1)

### DIFF
--- a/server/reference/product-development/mariadb-internals/README.md
+++ b/server/reference/product-development/mariadb-internals/README.md
@@ -11,14 +11,38 @@ description: >-
 This section contains background information, mostly aimed at engineers developing MariaDB features.
 {% endhint %}
 
+{% columns %}
+{% column %}
 {% content-ref url="mariadb-internals-documentation-merging-into-mariadb/" %}
 [mariadb-internals-documentation-merging-into-mariadb](mariadb-internals-documentation-merging-into-mariadb/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Serves as the primary category overview explaining the processes and strategies used to merge various source trees into the MariaDB codebase.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="mariadb-source-code-internals/" %}
 [mariadb-source-code-internals](mariadb-source-code-internals/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Serves as the main landing page for articles detailing the low-level source code architecture and internal logic of the MariaDB server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="using-mariadb-with-your-programs-api/" %}
 [using-mariadb-with-your-programs-api](using-mariadb-with-your-programs-api/)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This main page serves as a landing hub for developers looking to integrate MariaDB functionality into external applications using internal APIs.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/plugin-development/README.md
+++ b/server/reference/product-development/plugin-development/README.md
@@ -11,34 +11,98 @@ description: >-
 This section contains background information, mostly aimed at engineers developing MariaDB features.
 {% endhint %}
 
+{% columns %}
+{% column %}
 {% content-ref url="development-writing-plugins-for-mariadb.md" %}
 [development-writing-plugins-for-mariadb.md](development-writing-plugins-for-mariadb.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+A comprehensive guide on the basic structure and necessary components for creating a new plugin from scratch.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="encryption-plugin-api.md" %}
 [encryption-plugin-api.md](encryption-plugin-api.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Details the API used to develop encryption plugins for protecting data at rest, including key management and encryption schemes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="audit-plugin-development.md" %}
 [audit-plugin-development.md](audit-plugin-development.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Provides instructions for developing plugins that track and log server activity for security and compliance monitoring.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="authentication-plugin-development.md" %}
 [authentication-plugin-development.md](authentication-plugin-development.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Details how to implement custom authentication methods, allowing users to connect using external credentials or protocols.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="information-schema-plugins-show-and-flush-statements.md" %}
 [information-schema-plugins-show-and-flush-statements.md](information-schema-plugins-show-and-flush-statements.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Explains how to create plugins that expose internal server data through virtual tables in the Information Schema.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="replication-and-cluster-plugin-development.md" %}
 [replication-and-cluster-plugin-development.md](replication-and-cluster-plugin-development.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Focuses on building plugins that interact with the server's replication stream or manage cluster-level synchronization.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="password-validation-plugin-development.md" %}
 [password-validation-plugin-development.md](password-validation-plugin-development.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Implementation guide specifically for developers creating logic to intercept and validate password changes in the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="storage-engines-storage-engine-development/" %}
 [storage-engines-storage-engine-development](storage-engines-storage-engine-development/)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A dedicated resource for engineers to learn how to build or modify storage engines, detailing the pluggable API and data handling at the physical level.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/README.md
+++ b/server/reference/product-development/server-development/README.md
@@ -11,23 +11,62 @@ description: >-
 This section contains background information, mostly aimed at engineers developing MariaDB features.
 {% endhint %}
 
+{% columns %}
+{% column %}
 {% content-ref url="mariadb-server-roadmap.md" %}
 [mariadb-server-roadmap.md](mariadb-server-roadmap.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Provides a high-level view of upcoming features, version release schedules, and the strategic direction for MariaDB Server development.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="working-with-github.md" %}
 [working-with-github.md](working-with-github.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Outlines the workflow for contributing to MariaDB via GitHub, including branch management, pull requests, and coding standards for developers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="mariadb-fault-finding/" %}
 [mariadb-fault-finding](mariadb-fault-finding/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Offers deep-dive technical guides for diagnosing server issues, including trace file generation, debugger usage, and analyzing core dumps or memory usage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="quality/" %}
 [quality](quality/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Details the processes and methodologies used to ensure code quality, focusing on testing frameworks and bug verification during development.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="tools/" %}
 [tools](tools/)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+A guide to the essential software and utilities recommended for building, testing, and optimizing MariaDB Server code.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 4j-1).

In-place columnize of the product-development trio — the same pattern as the campaign's model page (`reference/product-development/README.md`):

| Page | Columns |
|---|---|
| `reference/product-development/mariadb-internals/README.md` | 3 |
| `reference/product-development/plugin-development/README.md` | 8 |
| `reference/product-development/server-development/README.md` | 5 |

Each existing content-ref is wrapped in `{% columns %}` and paired with the child page's frontmatter description. No child pages edited (all descriptions already present); intro hints preserved.

## Verification
- Columns balance 3/3, 8/8, 5/5; all 16 content-ref targets resolve.
- No `/broken/` or `docs-server` link debt in these files.
- codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)