### PR TITLE
DOCS-5973: Surface children as columns on catalogs, connect, xtrabackup landings (batch 4j-2)

### DIFF
--- a/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/README.md
+++ b/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/README.md
@@ -9,3 +9,27 @@ description: >-
 {% hint style="danger" %}
 Percona XtraBackup is **not supported** in MariaDB. [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/mariadb-backup-overview.md) is the recommended backup method to use instead of Percona XtraBackup. See [Percona XtraBackup Overview: Compatibility with MariaDB](percona-xtrabackup-overview.md#compatibility-with-mariadb) for more information.
 {% endhint %}
+
+{% columns %}
+{% column %}
+{% content-ref url="percona-xtrabackup-overview.md" %}
+[percona-xtrabackup-overview.md](percona-xtrabackup-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of Percona XtraBackup for hot backups of MariaDB — now unsupported in MariaDB; use mariadb-backup instead. Covers features, compatibility, and installation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="percona-xtrabackup-build-instructions.md" %}
+[percona-xtrabackup-build-instructions.md](percona-xtrabackup-build-instructions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Build instructions for compiling Percona XtraBackup from source, including platform-specific notes. Percona XtraBackup is unsupported in MariaDB; use mariadb-backup instead.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/percona-xtrabackup-build-instructions.md
+++ b/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/percona-xtrabackup-build-instructions.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Build instructions for compiling Percona XtraBackup from source, including
+  platform-specific notes. Percona XtraBackup is unsupported in MariaDB; use
+  mariadb-backup instead.
+---
+
 # Percona XtraBackup Build Instructions
 
 {% hint style="danger" %}

--- a/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/percona-xtrabackup-overview.md
+++ b/server/clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/percona-xtrabackup-overview.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Overview of Percona XtraBackup for hot backups of MariaDB — now unsupported in
+  MariaDB; use mariadb-backup instead. Covers features, compatibility, and
+  installation.
+---
+
 # Percona XtraBackup Overview
 
 {% hint style="danger" %}
@@ -173,7 +180,7 @@ This limitation is being tracked by Percona XtraBackup bug [PXB-1550](https://ji
 In [MariaDB 10.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/what-is-mariadb-102), [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/mariadb-backup-overview.md) is the recommended backup method to use instead of Percona XtraBackup.
 {% endhint %}
 
-In [MariaDB 10.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/what-is-mariadb-102), Percona XtraBackup 2.4 is supported in some cases if [InnoDB page compression](../../../server-usage/storage-engines/innodb/innodb-page-compression.md) is not used, and if [data at rest encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N) is not used, and if [innodb\_page\_size](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_page_size) is set to `16k`.
+In [MariaDB 10.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/what-is-mariadb-102), Percona XtraBackup 2.4 is supported in some cases if [InnoDB page compression](../../../server-usage/storage-engines/innodb/innodb-page-compression.md) is not used, and if [data at rest encryption](../../../security/encryption/data-at-rest-encryption/) is not used, and if [innodb\_page\_size](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_page_size) is set to `16k`.
 
 However, users should be aware that problems are likely due to the MySQL 5.7 undo log format incompatibility bug that was fixed in [MariaDB 10.2.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/10.2.2) in [MDEV-12289](https://jira.mariadb.org/browse/MDEV-12289). Due to this bug, backups prepared with Percona XtraBackup 2.4 may fail to recover some transactions. Only if you ran the server with the setting [innodb\_undo\_logs](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_undo_logs)=1 this would not be a problem. Percona XtraBackup 2.4 may also fail to work entirely with [MariaDB 10.2.19](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.2/10.2.19) and later if [innodb\_safe\_truncate=ON](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_safe_truncate) is set due to changes in the redo log format introduced by [MDEV-14717](https://jira.mariadb.org/browse/MDEV-14717). In that case, you may see the following error:
 
@@ -187,7 +194,7 @@ InnoDB: Unsupported redo log format. The redo log was created with MariaDB 10.2.
 In [MariaDB 10.1](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/changes-improvements-in-mariadb-10-1), [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/mariadb-backup-overview.md) is the recommended backup method to use instead of Percona XtraBackup.
 {% endhint %}
 
-In [MariaDB 10.1](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/changes-improvements-in-mariadb-10-1), Percona XtraBackup 2.3 is supported if [InnoDB page compression](../../../server-usage/storage-engines/innodb/innodb-page-compression.md) is not used, and if [data at rest encryption](/broken/pages/oH1AAxPLSc6Wq96yMJ2N) is not used, and if [innodb\_page\_size](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_page_size) is set to `16k`.
+In [MariaDB 10.1](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/changes-improvements-in-mariadb-10-1), Percona XtraBackup 2.3 is supported if [InnoDB page compression](../../../server-usage/storage-engines/innodb/innodb-page-compression.md) is not used, and if [data at rest encryption](../../../security/encryption/data-at-rest-encryption/) is not used, and if [innodb\_page\_size](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_page_size) is set to `16k`.
 
 ### Compatibility with [MariaDB 10.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.0/changes-improvements-in-mariadb-10-0) and Before
 

--- a/server/security/user-account-management/catalogs/README.md
+++ b/server/security/user-account-management/catalogs/README.md
@@ -25,3 +25,123 @@ layout:
 {% include "../../../.gitbook/includes/catalogs.md" %}
 
 Catalogs are a user account management feature. This section explains their role in organizing database objects and controlling access permissions.
+
+{% columns %}
+{% column %}
+{% content-ref url="catalogs-overview.md" %}
+[catalogs-overview.md](catalogs-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduces MariaDB catalogs, a multi-tenancy feature that lets a single server host multiple independent tenants, each with their own users, schemas, and logs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="starting-with-catalogs.md" %}
+[starting-with-catalogs.md](starting-with-catalogs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide to initializing a MariaDB server with catalog support using `mariadb-install-db --catalogs` and adding new catalogs to a running instance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="catalog-specific-functions-and-variables.md" %}
+[catalog-specific-functions-and-variables.md](catalog-specific-functions-and-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the catalog() function, which returns the current catalog name, and the @@catalogs system variable, which indicates if the server is configured for catalogs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="catalog-status-variables.md" %}
+[catalog-status-variables.md](catalog-status-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Covers status variables related to catalog operations and performance, useful for monitoring multi-tenant environments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connecting-to-a-server-configured-for-catalogs.md" %}
+[connecting-to-a-server-configured-for-catalogs.md](connecting-to-a-server-configured-for-catalogs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to connect to a specific catalog using the --catalog client option or the catalog_name.database_name syntax.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="create-catalog.md" %}
+[create-catalog.md](create-catalog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Define external catalogs for data integration. This statement configures connections to remote storage systems, allowing query access to external data sources.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="show-create-catalog.md" %}
+[show-create-catalog.md](show-create-catalog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for the SHOW CREATE CATALOG statement, which displays the SQL statement used to create a specific catalog.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="show-catalogs.md" %}
+[show-catalogs.md](show-catalogs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for the SHOW CATALOGS statement, which lists all available catalogs on the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="use-catalog.md" %}
+[use-catalog.md](use-catalog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for the USE CATALOG statement, allowing a user to switch their current session's context to a different catalog.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-catalog.md" %}
+[drop-catalog.md](drop-catalog.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Reference for the DROP CATALOG statement, used to remove a catalog and all its associated databases and users.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/user-account-management/catalogs/catalogs-overview.md
+++ b/server/security/user-account-management/catalogs/catalogs-overview.md
@@ -143,7 +143,7 @@ Client changes:
 * Add --catalog option to all standard MariaDB clients
 * Add support for looping over all existing catalogs to:
   * [mariadb-dump](../../../clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md)
-  * [mariadb-backup](../../../server-usage/backing-up-and-restoring-databases/mariadb-backup/)
+  * [mariadb-backup](../../../server-usage/backup-and-restore/mariadb-backup/)
   * [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md)
 
 Changes to [mariadb-install-db](../../../clients-and-utilities/deployment-tools/mariadb-install-db.md):

--- a/server/security/user-account-management/catalogs/catalogs-overview.md
+++ b/server/security/user-account-management/catalogs/catalogs-overview.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Introduces MariaDB catalogs, a multi-tenancy feature that lets a single server
+  host multiple independent tenants, each with their own users, schemas, and
+  logs.
+---
+
 # Catalogs Overview
 
 {% include "../../../.gitbook/includes/catalogs.md" %}

--- a/server/server-usage/storage-engines/connect/README.md
+++ b/server/server-usage/storage-engines/connect/README.md
@@ -29,3 +29,171 @@ The CONNECT storage engine enables MariaDB to access external local or remote da
 This storage engine supports table partitioning, MariaDB virtual columns and permits defining _special_ columns such as `ROWID`, `FILEID`, and `SERVID`.
 
 No precise definition of maturity exists. Because CONNECT handles many table types, each type has a different maturity depending on whether it is old and well-tested, less well-tested or newly implemented. This is indicated for all data types.
+
+{% columns %}
+{% column %}
+{% content-ref url="introduction-to-the-connect-engine.md" %}
+[introduction-to-the-connect-engine.md](introduction-to-the-connect-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-connect/" %}
+[using-connect](using-connect/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-the-connect-storage-engine.md" %}
+[installing-the-connect-storage-engine.md](installing-the-connect-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-create-table-options.md" %}
+[connect-create-table-options.md](connect-create-table-options.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-data-types.md" %}
+[connect-data-types.md](connect-data-types.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-table-types/" %}
+[connect-table-types](connect-table-types/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-security.md" %}
+[connect-security.md](connect-security.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-system-variables.md" %}
+[connect-system-variables.md](connect-system-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine has been deprecated.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-adding-the-rest-feature-as-a-library-called-by-an-oem-table.md" %}
+[connect-adding-the-rest-feature-as-a-library-called-by-an-oem-table.md](connect-adding-the-rest-feature-as-a-library-called-by-an-oem-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-compiling-json-udfs-in-a-separate-library.md" %}
+[connect-compiling-json-udfs-in-a-separate-library.md](connect-compiling-json-udfs-in-a-separate-library.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-making-the-getrest-library.md" %}
+[connect-making-the-getrest-library.md](connect-making-the-getrest-library.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="connect-oem-table-example.md" %}
+[connect-oem-table-example.md](connect-oem-table-example.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="current-status-of-the-connect-handler.md" %}
+[current-status-of-the-connect-handler.md](current-status-of-the-connect-handler.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="json-sample-files.md" %}
+[json-sample-files.md](json-sample-files.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The CONNECT storage engine.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 4j-2).

These three landing pages had curated intros but did not surface their child pages. Each page's curated intro (include / danger hint / PDF + version table + prose) is preserved, and `{% columns %}` blocks for the children are appended.

| Landing page | Columns added |
|---|---|
| `security/user-account-management/catalogs/README.md` | 10 |
| `server-usage/storage-engines/connect/README.md` | 14 |
| `clients-and-utilities/legacy-clients-and-utilities/backing-up-and-restoring-databases-percona-xtrabackup/README.md` | 2 |

Frontmatter `description:` added to 3 child pages that lacked one (`catalogs-overview`, `percona-xtrabackup-overview`, `percona-xtrabackup-build-instructions`).

## Pre-existing broken links fixed (2)
Two identical `/broken/pages/oH1AAxPLSc6Wq96yMJ2N` markers ("data at rest encryption") in `percona-xtrabackup-overview.md` → `../../../security/encryption/data-at-rest-encryption/`. Surfaced by lychee once the page entered the changed set; DOCS-6308 class.

## Verification
- Columns balance 10/10, 14/14, 2/2; all 26 content-ref targets resolve.
- No residual `/broken/` or `docs-server` links in touched files.
- codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)