### PR TITLE
DOCS-5973: Surface orphaned children as columns on optimizer-hints and docker (batch 4j-3)

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/README.md
@@ -11,6 +11,66 @@ Optimizer hints are options available that affect the execution plan.
 
 [SELECT Modifiers](select-modifier-hints.md) have been in MariaDB for a long time, while [Expanded (New-Style) Optimizer Hints](expanded-optimizer-hints.md) were introduced in MariaDB 12.0 and 12.1.
 
+{% columns %}
+{% column %}
+{% content-ref url="select-modifier-hints.md" %}
+[select-modifier-hints.md](select-modifier-hints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+SELECT modifier hints such as HIGH_PRIORITY, SQL_CACHE, SQL_NO_CACHE, and SQL_BUFFER_RESULT that adjust how individual SELECT statements are executed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="expanded-optimizer-hints.md" %}
+[expanded-optimizer-hints.md](expanded-optimizer-hints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+New-style optimizer hints (MariaDB 12.0+) that give granular, per-query control over optimizer choices without changing server-wide variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="index-level-hints.md" %}
+[index-level-hints.md](index-level-hints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Index-level optimizer hints that tell the optimizer which indexes to use, ignore, or prefer for a given table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="query-block-naming.md" %}
+[query-block-naming.md](query-block-naming.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign names to query blocks with QB_NAME() so optimizer hints can target specific subqueries or statement blocks.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-level-hints.md" %}
+[table-level-hints.md](table-level-hints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Table-level optimizer hints that influence join order and per-table optimizer behavior, optionally scoped to a named query block.
+{% endcolumn %}
+{% endcolumns %}
+
 ## See Also
 
 * [Use optimizer\_switch to enable/disable specific optimizations](../query-optimizations/optimizer-switch.md)

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/expanded-optimizer-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/expanded-optimizer-hints.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  New-style optimizer hints (MariaDB 12.0+) that give granular, per-query
+  control over optimizer choices without changing server-wide variables.
+---
+
 # Expanded New-Style Optimizer Hints
 
 {% hint style="info" %}

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/index-level-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/index-level-hints.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Index-level optimizer hints that tell the optimizer which indexes to use,
+  ignore, or prefer for a given table.
+---
+
 # Index-Level Hints
 
 ## Overview

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/query-block-naming.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/query-block-naming.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Assign names to query blocks with QB_NAME() so optimizer hints can target
+  specific subqueries or statement blocks.
+---
+
 # Query Block Naming
 
 Optimizer hints can address certain named query blocks within the query. Query block is either a top-level `SELECT`/`UPDATE`/`DELETE` statement or a subquery within the statement.

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/select-modifier-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/select-modifier-hints.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  SELECT modifier hints such as HIGH_PRIORITY, SQL_CACHE, SQL_NO_CACHE, and
+  SQL_BUFFER_RESULT that adjust how individual SELECT statements are executed.
+---
+
 # SELECT Modifier Hints
 
 ## HIGH PRIORITY

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/table-level-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/table-level-hints.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Table-level optimizer hints that influence join order and per-table optimizer
+  behavior, optionally scoped to a named query block.
+---
+
 # Table-Level Hints
 
 Supported variants of syntax:

--- a/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/README.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/README.md
@@ -26,3 +26,207 @@ The MariaDB Server container images are available with a number of tags:
 Versions that aren't stable will be suffixed with **-rc**, or **-alpha** to clearly show their release status, and enables [Renovatebot](https://github.com/grooverdan/mariadb-docker/commit/a9a98d720ddc5afe5c62449bbe737f4780aee0fe) and other that follow [semantic versioning](https://docs.renovatebot.com/modules/versioning/#semantic-versioning) to follow updates.
 
 For a consistent application between testing an production environment using the SHA hash of the image is recommended like **docker.io/library/mariadb@sha256:29fe5062baf36bae8ec68f21a3dce4f0372dadc185e687624f1252fc49d91c67**. There is a list of mapping and history of tags to SHA hash on the [Docker Library repository](https://github.com/docker-library/repo-info/tree/master/repos/mariadb/remote).
+
+{% columns %}
+{% column %}
+{% content-ref url="adding-plugins-to-the-mariadb-docker-official-image.md" %}
+[adding-plugins-to-the-mariadb-docker-official-image.md](adding-plugins-to-the-mariadb-docker-official-image.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on how to extend the official MariaDB Docker image by installing additional plugins and dependencies using a custom Dockerfile.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="benefits-of-managing-mariadb-containers-with-orchestration-software.md" %}
+[benefits-of-managing-mariadb-containers-with-orchestration-software.md](benefits-of-managing-mariadb-containers-with-orchestration-software.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the advantages of using orchestration tools like Kubernetes or Docker Swarm for managing MariaDB containers, including automated failover, scaling, and rolling updates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="container-backup-and-restoration.md" %}
+[container-backup-and-restoration.md](container-backup-and-restoration.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete container backup guide: docker volume create, mariadb-dump --all-databases, mariadb-backup --backup/--prepare/--copy-back operations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="container-security-concerns.md" %}
+[container-security-concerns.md](container-security-concerns.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discusses security best practices for running MariaDB in containers, addressing topics like root user privileges, volume permissions, and network isolation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="creating-a-custom-container-image.md" %}
+[creating-a-custom-container-image.md](creating-a-custom-container-image.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide to building a custom MariaDB container image to include specific configuration files, scripts, or pre-loaded data.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="deploy-mariadb-enterprise-server-with-docker.md" %}
+[deploy-mariadb-enterprise-server-with-docker.md](deploy-mariadb-enterprise-server-with-docker.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for deploying MariaDB Enterprise Server using the official enterprise Docker images, including handling license keys and entitlements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-docker-registry-for-mariadb-enterprise-server.md" %}
+[mariadb-enterprise-docker-registry-for-mariadb-enterprise-server.md](mariadb-enterprise-docker-registry-for-mariadb-enterprise-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to authenticate with and pull images from the private MariaDB Enterprise Docker Registry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="docker-and-aws-ec2.md" %}
+[docker-and-aws-ec2.md](docker-and-aws-ec2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Specific considerations and steps for running MariaDB Docker containers on Amazon EC2 instances.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="docker-and-google-cloud.md" %}
+[docker-and-google-cloud.md](docker-and-google-cloud.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide for deploying MariaDB containers on Google Cloud Platform (GCP) compute resources.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="docker-and-microsoft-azure.md" %}
+[docker-and-microsoft-azure.md](docker-and-microsoft-azure.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for running MariaDB containers within the Microsoft Azure ecosystem.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="docker-official-image-frequently-asked-questions.md" %}
+[docker-official-image-frequently-asked-questions.md](docker-official-image-frequently-asked-questions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Answers to common questions regarding the official MariaDB image, covering versioning, tagging, and default configurations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-and-using-mariadb-via-docker.md" %}
+[installing-and-using-mariadb-via-docker.md](installing-and-using-mariadb-via-docker.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to MariaDB in Docker. Complete resource for container deployment, volume management, networking, and environment setup for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-container-cheat-sheet.md" %}
+[mariadb-container-cheat-sheet.md](mariadb-container-cheat-sheet.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A concise reference of common Docker commands and environment variables used with MariaDB containers.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-server-docker-official-image-environment-variables.md" %}
+[mariadb-server-docker-official-image-environment-variables.md](mariadb-server-docker-official-image-environment-variables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to MariaDB in Docker. Complete resource for container deployment, volume management, networking, and environment setup for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setting-up-a-lamp-stack-with-docker-compose.md" %}
+[setting-up-a-lamp-stack-with-docker-compose.md](setting-up-a-lamp-stack-with-docker-compose.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete LAMP stack Docker Compose: define docker-compose.yml services (web/mariadb), set volumes/env vars (${MARIADB_VERSION}), docker-compose up/down.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-healthcheck-sh.md" %}
+[using-healthcheck-sh.md](using-healthcheck-sh.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete healthcheck.sh Docker reference: --connect, --innodb_initialized, --replication_* checks, .my-healthcheck.cnf config, and environment variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-container-image-configuration-reference.md" %}
+[mariadb-enterprise-container-image-configuration-reference.md](mariadb-enterprise-container-image-configuration-reference.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Configuration reference for the official MariaDB Enterprise container images — environment variables, command-line flags, and sidecar patterns for production deployments.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/mariadb-enterprise-container-image-configuration-reference.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/mariadb-enterprise-container-image-configuration-reference.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Configuration reference for the official MariaDB Enterprise container images —
+  environment variables, command-line flags, and sidecar patterns for
+  production deployments.
+---
+
 # MariaDB Enterprise Container Image Configuration Reference
 
 Orchestrating a MariaDB Enterprise deployment within containerized environments involves more than just launching a database instance; it requires the precise alignment of server logic, intelligent traffic routing, and robust observability tools. This reference serves as the definitive technical roadmap for configuring the official images provided by the MariaDB Enterprise Docker Registry. It details the standardized environment variables, specialized sidecar patterns, and command-line flags required to transform raw images into a production-ready, cloud-native ecosystem.


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 4j-3 — final depth-4 misc, except a `download` follow-up).

Both pages had children that were not surfaced on the landing (orphaned from navigation). Columns are added, preserving each page's curated intro.

| Landing page | Columns | Notes |
|---|---|---|
| `ha-and-performance/optimization-and-tuning/optimizer-hints/README.md` | 5 | inserted before `## See Also`; intro + footer preserved (3 of 5 children were previously orphaned) |
| `server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/README.md` | 17 | appended; prose intro preserved (all 17 were orphaned) |

Frontmatter `description:` added to the 6 child pages that lacked one (5 optimizer-hints children + 1 docker child).

## Scope notes
- **`systemd`** left as-is — already has a complete, described "## In this Section" list of its two children.
- **`download`** deferred to a focused follow-up — it carries pre-existing cross-space `/broken/` link debt (space `WCInJQ9cmGjq1lsTG91E`) that needs proper alias resolution rather than a relative-link fix.

## Verification
- Columns balance 5/5, 17/17; all 22 content-ref targets resolve.
- optimizer-hints See Also + footer intact; all child relative links resolve.
- No `/broken/` or `docs-server` debt in touched files; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)