### PR TITLE
DOCS-5973: Columnize download landing + fix cross-space link debt (batch 4j-4)

### DIFF
--- a/server/clients-and-utilities/server-client-software/download/README.md
+++ b/server/clients-and-utilities/server-client-software/download/README.md
@@ -16,7 +16,7 @@ Instructions how to install the packages can be found [here](../../../server-man
 
 #### Pre-Release Binaries
 
-Binaries from our [Buildbot](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/YDeiIobaziVWZCxk4IlA) system at [buildbot.mariadb.org](https://buildbot.mariadb.org) are available as containers on quay.io/mariadb-foundation/mariadb-devel:{major version}. Tags available are listed [here](https://quay.io/repository/mariadb-foundation/mariadb-devel?tab=tags).
+Binaries from our [Buildbot](../../../reference/product-development/server-development/tools/buildbot/) system at [buildbot.mariadb.org](https://buildbot.mariadb.org) are available as containers on quay.io/mariadb-foundation/mariadb-devel:{major version}. Tags available are listed [here](https://quay.io/repository/mariadb-foundation/mariadb-devel?tab=tags).
 
 These haven't passed through a full release process; however changes there have been reviewed and are considered complete by the server developers. Its recommend to use these for testing.
 
@@ -24,14 +24,14 @@ These haven't passed through a full release process; however changes there have 
 
 The [mariadb.org/download](https://mariadb.org/download/) download page contains the source for all released binaries. You can find the latest source code at [server](https://github.com/MariaDB/server)
 
-To retrieve the code, the [Git](/broken/spaces/WCInJQ9cmGjq1lsTG91E/pages/xRCtl21mrR3GrhPpJgOM) source control software offers\
+To retrieve the code, the [Git](../../../reference/product-development/server-development/tools/using-git-with-mariadb/using-git.md) source control software offers\
 the path of least resistance. If you are unfamiliar with git, please refer to\
 the [git documentation](https://git-scm.com/doc) for an understanding\
 of version control with git.
 
 For instructions on creating a local branch of MariaDB, see the [Getting the MariaDB Source Code](getting-the-mariadb-source-code.md) page.
 
-See the [Generic Build Instructions](/broken/pages/bjatfkHoY1LmiorFXFKZ) page for\
+See the [Generic Build Instructions](../../../server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/) page for\
 general instructions on compiling MariaDB from the source.\
 The [source](../../../server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/) page has links to platform and distribution-specific\
 information, including information on how we build the release packages.
@@ -50,3 +50,51 @@ There are source and repositories there. To use repositories see the following l
 * [Debian/Ubuntu based distos](../../../server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/installing-mariadb-deb-files.md#pinning-the-mariadb-repository-to-a-specific-minor-release)
 
 It is also possible to access Docker Official Images of MariaDB back to 5.5.40 when it became an official image ([available tags](https://soaphub.org/imagehub/?q=mariadb\&n=library\&p=1)).
+
+{% columns %}
+{% column %}
+{% content-ref url="getting-the-mariadb-source-code.md" %}
+[getting-the-mariadb-source-code.md](getting-the-mariadb-source-code.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check out the MariaDB Server source code from GitHub with Git, including how to select a specific branch or release.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-rpm-packages.md" %}
+[mariadb-rpm-packages.md](mariadb-rpm-packages.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Where to find MariaDB RPM packages for Fedora and other distributions, plus the YUM repository configuration tool.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mirror-sites-for-mariadb.md" %}
+[mirror-sites-for-mariadb.md](mirror-sites-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How MariaDB is distributed through mirror sites, and how to volunteer your server as an official MariaDB mirror.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="where-to-download-mariadb.md" %}
+[where-to-download-mariadb.md](where-to-download-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Where to download MariaDB tarballs, binaries, and distribution packages, covering the latest releases and historical versions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/clients-and-utilities/server-client-software/download/mariadb-rpm-packages.md
+++ b/server/clients-and-utilities/server-client-software/download/mariadb-rpm-packages.md
@@ -1,4 +1,10 @@
 
+---
+description: >-
+  Where to find MariaDB RPM packages for Fedora and other distributions, plus
+  the YUM repository configuration tool.
+---
+
 # MariaDB RPM Packages
 
 Packages for Fedora Linux are included with our other packages available for download on [](https://mariadb.org/download/).

--- a/server/clients-and-utilities/server-client-software/download/mirror-sites-for-mariadb.md
+++ b/server/clients-and-utilities/server-client-software/download/mirror-sites-for-mariadb.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How MariaDB is distributed through mirror sites, and how to volunteer your
+  server as an official MariaDB mirror.
+---
+
 # Mirror Sites for MariaDB
 
 We rely on mirrors to distribute MariaDB to the world through the official download site at [download](https://mariadb.org/download). If you would like to volunteer to become a mirror, thank you! Getting you set up is easy.


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 4j-4). **Closes depth-4.**

The `download` landing page had 3 of its 4 children orphaned from navigation and carried pre-existing cross-space `/broken/` link debt. This surfaces the children as columns (preserving the curated download prose) and resolves the debt.

## Broken links fixed (10 occurrences, 4 unique targets)
Across `README.md` (3), `getting-the-mariadb-source-code.md` (3), and `where-to-download-mariadb.md` (4):

| Broken reference | Resolved to |
|---|---|
| Buildbot (`YDeiIobaziVWZCxk4IlA`) | `reference/product-development/server-development/tools/buildbot/` |
| Using git / Git (`xRCtl21mrR3GrhPpJgOM`) | `.../server-development/tools/using-git-with-mariadb/using-git.md` |
| Generic Build Instructions / Compiling MariaDB (`bjatfkHoY1LmiorFXFKZ`) | `.../installing-mariadb/compiling-mariadb-from-source/` (SUMMARY-canonical) |
| `community` (malformed docs-server URL) | `https://mariadb.com/kb/en/community/` |

The three page-ID references were stale `/broken/` markers claiming the **General Resources** space; the pages have since migrated into the **server** space, so the fixes use in-repo relative links (verified on disk), not `{general-resources}` aliases.

## Columns
4 columns appended; frontmatter `description:` added to the 4 child pages.

## Verification
- Columns balance 4/4; all content-ref targets resolve.
- All relative links in the 5 touched files resolve; no residual `/broken/` or `docs-server`.
- codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)