### PR TITLE
DOCS-5973: Columnize 5 query-optimizations landings with authored descriptions (batch 5e)

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimization-strategies/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimization-strategies/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Optimization Strategies
 
+{% columns %}
+{% column %}
+{% content-ref url="duplicateweedout-strategy.md" %}
+[duplicateweedout-strategy.md](duplicateweedout-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+DuplicateWeedout is a semi-join execution strategy that runs the subquery as a regular inner join and removes duplicate record combinations using a temporary table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="firstmatch-strategy.md" %}
+[firstmatch-strategy.md](firstmatch-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+FirstMatch is a semi-join execution strategy that avoids duplicate results by short-cutting subquery execution as soon as the first matching record is found, improving performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="improvements-to-order-by.md" %}
+[improvements-to-order-by.md](improvements-to-order-by.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes MariaDB improvements to the ORDER BY optimizer, including cost- based index switching for ORDER BY with small LIMIT and multiple-equality handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="loosescan-strategy.md" %}
+[loosescan-strategy.md](loosescan-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LooseScan is a semi-join execution strategy that avoids duplicate record combinations by using an index on the subquery table to pick one row per group.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="semi-join-materialization-strategy.md" %}
+[semi-join-materialization-strategy.md](semi-join-materialization-strategy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Semi-join Materialization runs an uncorrelated IN-subquery into a temporary table, then joins it via the Materialization-scan or Materialization-lookup strategy.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimizations-for-derived-tables/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimizations-for-derived-tables/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Optimizations for Derived Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="condition-pushdown-into-derived-table-optimization.md" %}
+[condition-pushdown-into-derived-table-optimization.md](condition-pushdown-into-derived-table-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Condition Pushdown pushes a parent query's conditions into a derived table or view that cannot be merged, letting the optimizer build efficient access paths.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="derived-table-merge-optimization.md" %}
+[derived-table-merge-optimization.md](derived-table-merge-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Derived Table Merge folds a FROM-clause subquery or view into its parent SELECT when it has no grouping, aggregates, or ORDER BY ... LIMIT, avoiding a temporary table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="derived-table-with-key-optimization.md" %}
+[derived-table-with-key-optimization.md](derived-table-with-key-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Derived Table with Key lets a materialized derived table have one index that the optimizer uses for joins with other tables instead of a full table scan.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="lateral-derived-optimization.md" %}
+[lateral-derived-optimization.md](lateral-derived-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents Lateral Derived Optimization, also referred to as Split Grouping Optimization or Split Materialized Optimization.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="split-materialized-optimization.md" %}
+[split-materialized-optimization.md](split-materialized-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Split Materialized Optimization is another name for the Lateral Derived optimization.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Statistics for Optimizing Queries
 
+{% columns %}
+{% column %}
+{% content-ref url="engine-independent-table-statistics.md" %}
+[engine-independent-table-statistics.md](engine-independent-table-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Engine-independent table statistics store optimizer statistics in mysql database tables, collected via ANALYZE TABLE and controlled by the use_stat_tables variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="histogram-based-statistics.md" %}
+[histogram-based-statistics.md](histogram-based-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Histogram-based statistics give the optimizer value-distribution data for indexed and non-indexed columns, improving query plans through better selectivity estimates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-persistent-statistics.md" %}
+[innodb-persistent-statistics.md](innodb-persistent-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+InnoDB persistent statistics store index and table statistics on disk so they survive server restarts, controlled by innodb_stats_persistent and related variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="slow-query-log-extended-statistics.md" %}
+[slow-query-log-extended-statistics.md](slow-query-log-extended-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Extends the slow query log with query-plan, EXPLAIN, and storage-engine statistics, controlled by log_slow_verbosity, log_slow_filter, and log_slow_rate_limit.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="user-statistics.md" %}
+[user-statistics.md](user-statistics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The userstat plugin adds USER, CLIENT, INDEX, and TABLE statistics as INFORMATION_SCHEMA tables plus SHOW and FLUSH statements to track server activity and load.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # Subquery Optimizations
 
+{% columns %}
+{% column %}
+{% content-ref url="condition-pushdown-into-in-subqueries.md" %}
+[condition-pushdown-into-in-subqueries.md](condition-pushdown-into-in-subqueries.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes Condition Pushdown into IN subqueries, enabled through the condition_pushdown_for_subquery optimizer_switch flag.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="conversion-of-big-in-predicates-into-subqueries.md" %}
+[conversion-of-big-in-predicates-into-subqueries.md](conversion-of-big-in-predicates-into-subqueries.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Converts large IN predicates into IN subqueries once the list exceeds in_predicate_conversion_threshold elements, avoiding costly range analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="exists-to-in-optimization.md" %}
+[exists-to-in-optimization.md](exists-to-in-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+EXISTS-to-IN rewrites trivially correlated and semi-join EXISTS subqueries into IN subqueries so MariaDB's richer IN-subquery strategies can apply.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="non-semi-join-subquery-optimizations.md" %}
+[non-semi-join-subquery-optimizations.md](non-semi-join-subquery-optimizations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Covers strategies for IN-subqueries that cannot become semi-joins, chiefly materialization (with NULL-aware partial matching) and the IN-to-EXISTS transformation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizing-group-by.md" %}
+[optimizing-group-by.md](optimizing-group-by.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Automatically removes redundant DISTINCT and GROUP BY-without-HAVING clauses in IN/ALL/ANY/SOME/EXISTS subqueries, allowing more efficient query plans.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="semi-join-subquery-optimizations.md" %}
+[semi-join-subquery-optimizations.md](semi-join-subquery-optimizations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains semi-join IN-subqueries and MariaDB's five semi-join execution strategies: table pullout, FirstMatch, Materialization, LooseScan, and DuplicateWeedout.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="subquery-cache.md" %}
+[subquery-cache.md](subquery-cache.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The subquery cache speeds up correlated subqueries by caching results with their correlation parameters, avoiding re-execution when a result is already cached.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="subquery-optimizations-map.md" %}
+[subquery-optimizations-map.md](subquery-optimizations-map.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Presents a map of the subquery types allowed in SQL and the optimizer strategies MariaDB provides to handle each, with links to individual optimization pages.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-pullout-optimization.md" %}
+[table-pullout-optimization.md](table-pullout-optimization.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Table pullout rewrites a semi-join subquery as a join by pulling tables out into the parent SELECT based on UNIQUE or PRIMARY key definitions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/table-elimination/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/table-elimination/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Table Elimination
 
+{% columns %}
+{% column %}
+{% content-ref url="table-elimination-external-resources.md" %}
+[table-elimination-external-resources.md](table-elimination-external-resources.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Links to external resources demonstrating table elimination in MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-elimination-in-mariadb.md" %}
+[table-elimination-in-mariadb.md](table-elimination-in-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Shows how the MariaDB table elimination module merges a view and removes outer-joined tables that are guaranteed a single match and unused elsewhere in the query.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-elimination-in-other-databases.md" %}
+[table-elimination-in-other-databases.md](table-elimination-in-other-databases.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compares table elimination support in Microsoft SQL Server 2005/2008 and Oracle 11g, noting SQL Server's more advanced handling of subselect join conditions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table-elimination-user-interface.md" %}
+[table-elimination-user-interface.md](table-elimination-user-interface.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Shows how to confirm table elimination by inspecting EXPLAIN output for absent tables, and notes the debug-build table_elimination switch.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="what-is-table-elimination.md" %}
+[what-is-table-elimination.md](what-is-table-elimination.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduces table elimination, which resolves a query without accessing some referenced tables, using an Anchor Modeling actors example to show when it applies.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5e — first depth-5 authored-columns batch).

Small-page treatment (≤ ~12 children): convert to `{% columns %}` with authored descriptions written **inline in each column** (drafted from the child pages' content, spot-verified against source).

| Landing page | Columns |
|---|---|
| `.../query-optimizations/optimization-strategies/README.md` | 5 |
| `.../query-optimizations/optimizations-for-derived-tables/README.md` | 5 |
| `.../query-optimizations/statistics-for-optimizing-queries/README.md` | 5 |
| `.../query-optimizations/subquery-optimizations/README.md` | 9 |
| `.../query-optimizations/table-elimination/README.md` | 5 |

**Approach note:** descriptions live on the landing pages, not in child frontmatter. Adding frontmatter to the children pulled their **pre-existing external-link debt** (dead blogs, `bugs.mysql.com` 403s, cert-error sites) into lychee, which is unrelated to this campaign. Keeping edits to the landings avoids that entirely; the child pages' link debt is routed to DOCS-6308. This is the pattern I'll use for the remaining authored-columns batches.

## Verification
- Columns balance 5/5 (×4) and 9/9; all 29 content-ref targets resolve.
- Landings contain no external or `/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)