### PR TITLE
DOCS-5973: Columnize 5 administrative-sql-statements landings (batch 5f)

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/README.md
@@ -6,3 +6,98 @@ description: >-
 
 # ANALYZE and EXPLAIN Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="analyze-format-json.md" %}
+[analyze-format-json.md](analyze-format-json.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Gain deep insight into query execution with JSON-formatted analysis. This command combines optimizer estimates with actual runtime statistics for precise performance tuning.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="analyze-formatjson-examples.md" %}
+[analyze-formatjson-examples.md](analyze-formatjson-examples.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Review practical examples of ANALYZE FORMAT=JSON output. Learn to identify performance bottlenecks by comparing estimated costs against actual execution metrics.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="analyze-interpreting-rows-and-filtered-members.md" %}
+[analyze-interpreting-rows-and-filtered-members.md](analyze-interpreting-rows-and-filtered-members.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the r_rows and r_filtered fields in analysis output. Learn how these actual runtime counters compare to the optimizer's rows and filtered estimates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="analyze-statement.md" %}
+[analyze-statement.md](analyze-statement.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn to use the ANALYZE statement to execute a query and produce a performance report. This command reveals how close the optimizer's plan was to the actual execution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="explain-analyze.md" %}
+[explain-analyze.md](explain-analyze.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the historical context of EXPLAIN ANALYZE in MariaDB. Learn how this syntax maps to the modern ANALYZE statement for profiling query execution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="explain-format-json.md" %}
+[explain-format-json.md](explain-format-json.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Get comprehensive query plans in JSON format. This output provides detailed optimizer data, including costs and attached conditions, not found in the tabular view.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="explain.md" %}
+[explain.md](explain.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete EXPLAIN statement reference: SELECT/UPDATE/DELETE syntax, EXTENDED and PARTITIONS options, FORMAT=JSON output, EXPLAIN FOR CONNECTION usage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-buffer-update-algorithm.md" %}
+[using-buffer-update-algorithm.md](using-buffer-update-algorithm.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the 'Using buffer' strategy for UPDATE operations. Learn how MariaDB prevents infinite update loops when modifying indexed columns during a range scan.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/administrative-sql-statements/backup-commands/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/backup-commands/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # BACKUP Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="backup-lock.md" %}
+[backup-lock.md](backup-lock.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Protect table files during backups. This command blocks DDL operations like ALTER TABLE while allowing read/write activity, ensuring file consistency for backup tools.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="backup-stage.md" %}
+[backup-stage.md](backup-stage.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control backup phases for external tools. Learn how to cycle through stages like START, BLOCK_DDL, and BLOCK_COMMIT to perform consistent backups with minimal locking.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="storage-snapshots-and-backup-stage-commands.md" %}
+[storage-snapshots-and-backup-stage-commands.md](storage-snapshots-and-backup-stage-commands.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Combine database commands with storage-level snapshots. Learn the correct sequence of BACKUP STAGE commands to freeze writes safely while taking a disk snapshot.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/administrative-sql-statements/flush-commands/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/flush-commands/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # FLUSH Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="flush.md" %}
+[flush.md](flush.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete FLUSH statement reference: NO_WRITE_TO_BINLOG/LOCAL syntax, FLUSH TABLES WITH READ LOCK/FOR EXPORT, FLUSH STATUS, and SSL/TLS certificate reload.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="flush-query-cache.md" %}
+[flush-query-cache.md](flush-query-cache.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Defragment the query cache to optimize memory usage. This command reorganizes the cache to eliminate fragmentation without removing existing cached queries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="flush-tables-for-export.md" %}
+[flush-tables-for-export.md](flush-tables-for-export.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Prepare individual tables for binary backup. This command flushes changes to disk and locks tables, allowing safe copying of .ibd files while the server runs.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/administrative-sql-statements/plugin-sql-statements/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/plugin-sql-statements/README.md
@@ -17,3 +17,50 @@ description: >-
 
 # Plugin Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="install-plugin.md" %}
+[install-plugin.md](install-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Install a specific plugin from a shared library. This statement adds the plugin to the mysql.plugin table and loads its code into the server memory.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="install-soname.md" %}
+[install-soname.md](install-soname.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Load all plugins contained within a shared library file. This statement automatically discovers and installs every valid plugin found in the specified library.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="uninstall-plugin.md" %}
+[uninstall-plugin.md](uninstall-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a specific plugin from the server. This statement unloads the plugin code and deletes its entry from the mysql.plugin table to prevent reloading.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="uninstall-soname.md" %}
+[uninstall-soname.md](uninstall-soname.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Uninstall all plugins loaded from a specific library. This statement removes every plugin associated with the library file and unloads the library itself.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/administrative-sql-statements/set-commands/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/set-commands/README.md
@@ -6,42 +6,134 @@ description: >-
 
 # SET Statements
 
+{% columns %}
+{% column %}
 {% content-ref url="set.md" %}
 [set.md](set.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Assign values to different types of variables. Learn the syntax for setting user-defined variables, system variables, and stored program variables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../../data-types/string-data-types/character-sets/set-character-set.md" %}
 [set-character-set.md](../../../data-types/string-data-types/character-sets/set-character-set.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Map strings to a specific character set. This command updates the character set for the client, results, and connection to ensure correct data encoding.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../replication-statements/set-global-sql_slave_skip_counter.md" %}
-[set-global-sql\_slave\_skip\_counter.md](../replication-statements/set-global-sql_slave_skip_counter.md)
+[set-global-sql_slave_skip_counter.md](../replication-statements/set-global-sql_slave_skip_counter.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+SET GLOBAL sql_slave_skip_counter skips the next N events from the primary to recover from replication stops, and is valid only while the replica threads are stopped.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../../data-types/string-data-types/character-sets/set-names.md" %}
 [set-names.md](../../../data-types/string-data-types/character-sets/set-names.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Configure the character set and collation for the current connection. This ensures the server correctly interprets data sent by the client application.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../account-management-sql-statements/set-password.md" %}
 [set-password.md](../../account-management-sql-statements/set-password.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Complete reference for SET PASSWORD in MariaDB. Complete syntax guide with all options, clauses, and practical examples with comprehensive examples and best.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-path.md" %}
+[set-path.md](set-path.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+SET PATH sets the list of schemas MariaDB searches when invoking stored routines and packages, available from MariaDB 12.3 via the @@path system variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="set-sql_log_bin.md" %}
+[set-sql_log_bin.md](set-sql_log_bin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Enable or disable binary logging for the current session. This statement allows administrators to perform operations without replicating them to replicas.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../account-management-sql-statements/set-role.md" %}
 [set-role.md](../../account-management-sql-statements/set-role.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
-{% content-ref url="set-sql_log_bin.md" %}
-[set-sql\_log\_bin.md](set-sql_log_bin.md)
-{% endcontent-ref %}
+{% column %}
+Sets the current role for the session. Learn how to enable none, or a specific role to change your current privileges dynamically.
+{% endcolumn %}
+{% endcolumns %}
 
+{% columns %}
+{% column %}
 {% content-ref url="set-statement.md" %}
 [set-statement.md](set-statement.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Set a system variable for the duration of a single query. This statement allows temporary configuration changes that apply only to the immediate statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../transactions/set-transaction.md" %}
 [set-transaction.md](../../transactions/set-transaction.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Define isolation levels and access modes for transactions. Learn to configure the behavior of the next transaction or the entire session for data consistency.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="../../programmatic-compound-statements/set-variable.md" %}
 [set-variable.md](../../programmatic-compound-statements/set-variable.md)
 {% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign values to user-defined variables. This guide explains how to store data in session-specific variables for reuse in subsequent SQL statements.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5f — depth-5 authored columns, landings-only).

Small-page treatment: convert to `{% columns %}`. **27 descriptions reused verbatim** from the children's existing frontmatter (landing stays in sync with each child); **2 authored inline** (drafted from page content, version claims spot-verified against source). Child pages are not modified.

| Landing page | Columns |
|---|---|
| `.../administrative-sql-statements/analyze-and-explain-statements/README.md` | 8 |
| `.../administrative-sql-statements/backup-commands/README.md` | 3 |
| `.../administrative-sql-statements/flush-commands/README.md` | 3 |
| `.../administrative-sql-statements/plugin-sql-statements/README.md` | 4 |
| `.../administrative-sql-statements/set-commands/README.md` | 11 |

## Verification
- Columns balance 8/8, 3/3, 3/3, 4/4, 11/11; all 29 content-ref targets resolve (including `set-global-sql_slave_skip_counter`, cross-listed from `replication-statements/`).
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)