### PR TITLE
DOCS-5973: Columnize 4 DDL/DML statement landings (batch 5g)

### DIFF
--- a/server/reference/sql-statements/data-definition/alter/README.md
+++ b/server/reference/sql-statements/data-definition/alter/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # ALTER
 
+{% columns %}
+{% column %}
+{% content-ref url="alter-database.md" %}
+[alter-database.md](alter-database.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Modify database characteristics. Learn how to change global properties like the default character set and collation for a specific database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-function.md" %}
+[alter-function.md](alter-function.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Change stored function characteristics. This statement allows modifying the security context or comments of a stored function without dropping it.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-logfile-group.md" %}
+[alter-logfile-group.md](alter-logfile-group.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the support status of this statement. Originally designed for NDB Cluster, it is not currently supported in MariaDB Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-server.md" %}
+[alter-server.md](alter-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Modify server definitions. Update connection information for external servers defined with CREATE SERVER, primarily used by the Federated engine.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-table/" %}
+[alter-table](alter-table/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete ALTER TABLE guide for MariaDB. Complete syntax for modifying columns, indexes, constraints, and table properties with comprehensive examples and.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="alter-tablespace.md" %}
+[alter-tablespace.md](alter-tablespace.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the status of tablespace management. This statement, originally for NDB, is not supported in MariaDB for InnoDB tablespaces.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../../server-usage/views/alter-view.md" %}
+[alter-view.md](../../../../server-usage/views/alter-view.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documentation for the ALTER VIEW statement, which is used to modify an existing view's definition without dropping and recreating it.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-definition/drop/README.md
+++ b/server/reference/sql-statements/data-definition/drop/README.md
@@ -7,3 +7,134 @@ description: >-
 
 # DROP
 
+{% columns %}
+{% column %}
+{% content-ref url="drop-database.md" %}
+[drop-database.md](drop-database.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to removing databases in MariaDB. Complete DROP DATABASE syntax with IF EXISTS, permissions, and recovery options for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-event.md" %}
+[drop-event.md](drop-event.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a scheduled event from the server. This command stops the event from executing and deletes its definition from the system tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-index.md" %}
+[drop-index.md](drop-index.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove an existing index from a table. This command deletes the index structure, potentially impacting query performance but freeing storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-logfile-group.md" %}
+[drop-logfile-group.md](drop-logfile-group.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a log file group. This statement, primarily for NDB Cluster, deletes the undo log files associated with the specified log file group.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-package-body.md" %}
+[drop-package-body.md](drop-package-body.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Delete the body of a stored package. This command removes the implementation logic while preserving the package specification and interface.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-package.md" %}
+[drop-package.md](drop-package.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a stored package completely. This command deletes both the package specification (interface) and its body (implementation) from the database.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-server.md" %}
+[drop-server.md](drop-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a server definition. This command deletes the connection details for a remote server used by the FEDERATED or SPIDER storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-table.md" %}
+[drop-table.md](drop-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete DROP TABLE syntax: TEMPORARY, IF EXISTS, WAIT/NOWAIT, RESTRICT/CASCADE options, metadata locks, atomic DROP, and replication behavior.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-tablespace.md" %}
+[drop-tablespace.md](drop-tablespace.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Delete a tablespace. This command removes the physical file container used for storing table data, applicable to engines like InnoDB or NDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="drop-trigger.md" %}
+[drop-trigger.md](drop-trigger.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Remove a trigger from a table. This command deletes the trigger definition, preventing it from firing on future INSERT, UPDATE, or DELETE events.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../../../server-usage/views/drop-view.md" %}
+[drop-view.md](../../../../server-usage/views/drop-view.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use the DROP VIEW statement to remove one or more views from the database, including required privileges.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/changing-deleting-data/README.md
+++ b/server/reference/sql-statements/data-manipulation/changing-deleting-data/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Changing & Deleting Data
 
+{% columns %}
+{% column %}
+{% content-ref url="delete.md" %}
+[delete.md](delete.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to deleting data in MariaDB. Complete DELETE syntax with WHERE filtering, JOIN operations, CTEs, and safety considerations for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="high_priority-and-low_priority.md" %}
+[high_priority-and-low_priority.md](high_priority-and-low_priority.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control locking priority for table access. These modifiers determine whether read or write operations take precedence when multiple threads access a table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replace.md" %}
+[replace.md](replace.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Insert or replace rows based on unique keys. This statement acts like INSERT, but if a duplicate key exists, it deletes the old row and inserts the new one.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="replacereturning.md" %}
+[replacereturning.md](replacereturning.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Replace rows and retrieve the results immediately. This extension returns the values of the replaced or inserted rows in the same operation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="update.md" %}
+[update.md](update.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete UPDATE statement guide for MariaDB. Complete syntax reference with WHERE conditions, JOIN operations, CTEs, and multi-table updates for production use.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/README.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/README.md
@@ -7,3 +7,122 @@ description: >-
 
 # Inserting & Loading Data
 
+{% columns %}
+{% column %}
+{% content-ref url="concurrent-inserts.md" %}
+[concurrent-inserts.md](concurrent-inserts.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand concurrent inserts in MyISAM. This feature allows SELECT statements to run simultaneously with INSERT operations, reducing lock contention and improving performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ignore.md" %}
+[ignore.md](ignore.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the IGNORE keyword. This modifier suppresses certain errors during statement execution, downgrading them to warnings to allow the operation to proceed.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert.md" %}
+[insert.md](insert.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to inserting data in MariaDB. Complete INSERT syntax for single rows, bulk operations, and ON DUPLICATE KEY handling for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-default-duplicate-values.md" %}
+[insert-default-duplicate-values.md](insert-default-duplicate-values.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Handle default and duplicate values during insertion. Learn how MariaDB manages missing columns and how to resolve duplicate key conflicts using various strategies.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-delayed.md" %}
+[insert-delayed.md](insert-delayed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Queue inserts for later execution. This MyISAM-specific extension returns control immediately to the client while the server inserts rows when the table is free.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-ignore.md" %}
+[insert-ignore.md](insert-ignore.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete INSERT IGNORE reference: ignore insert errors and warnings, duplicate key error handling, invalid value coercion, and SHOW WARNINGS compatibility.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-on-duplicate-key-update.md" %}
+[insert-on-duplicate-key-update.md](insert-on-duplicate-key-update.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete guide to inserting data in MariaDB. Complete INSERT syntax for single rows, bulk operations, and ON DUPLICATE KEY handling for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insert-select.md" %}
+[insert-select.md](insert-select.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Copy data between tables. This statement inserts the result set of a SELECT query directly into a target table, enabling efficient bulk data transfer.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="insertreturning.md" %}
+[insertreturning.md](insertreturning.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Insert rows and immediately retrieve the results. This extension returns the inserted values, including auto-increments and defaults, in the same round trip.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="load-data-into-tables-or-index/" %}
+[load-data-into-tables-or-index](load-data-into-tables-or-index/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Bulk load data efficiently. This section covers commands like LOAD DATA INFILE and LOAD XML for high-speed data import from text or XML files.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5g — depth-5 authored columns, landings-only).

Small-page treatment: convert to `{% columns %}`. All 33 child descriptions reused verbatim from existing child frontmatter (no authoring, no child edits).

| Landing page | Columns |
|---|---|
| `reference/sql-statements/data-definition/alter/README.md` | 7 |
| `reference/sql-statements/data-definition/drop/README.md` | 11 |
| `reference/sql-statements/data-manipulation/changing-deleting-data/README.md` | 5 |
| `reference/sql-statements/data-manipulation/inserting-loading-data/README.md` | 10 |

Nested sub-landings (`alter-table/`, `load-data-into-tables-or-index/`) correctly link to their directory.

## Verification
- Columns balance 7/7, 11/11, 5/5, 10/10; all 33 content-ref targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)