### PR TITLE
DOCS-5973: Finish sql-statements depth-5 landings (batch 5h)

### DIFF
--- a/server/reference/sql-statements/data-manipulation/selecting-data/README.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/README.md
@@ -7,3 +7,20 @@ description: >-
 
 # Selecting Data
 
+- [DUAL](dual.md)
+- [FOR UPDATE](for-update.md)
+- [GROUP BY](group-by.md)
+- [LIMIT](limit.md)
+- [LOCK IN SHARE MODE](lock-in-share-mode.md)
+- [Optimizer Hints](../../../../ha-and-performance/optimization-and-tuning/optimizer-hints/README.md)
+- [ORDER BY](order-by.md)
+- [PROCEDURE](procedure.md)
+- [SELECT](select.md)
+- [SELECT INTO DUMPFILE](select-into-dumpfile.md)
+- [SELECT INTO OUTFILE](select-into-outfile.md)
+- [SELECT ... OFFSET ... FETCH](select-offset-fetch.md)
+- [SELECT WITH ROLLUP](select-with-rollup.md)
+- [Common Table Expressions (CTE)](common-table-expressions/README.md)
+- [Joins](joins/README.md)
+- [Set Operations](set-operations/README.md)
+- [Subqueries](joins-subqueries/subqueries/README.md)

--- a/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/README.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Cursors
 
+{% columns %}
+{% column %}
+{% content-ref url="cursor-overview.md" %}
+[cursor-overview.md](cursor-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduces cursors in MariaDB stored programs, which are non-scrollable, read-only, and asensitive, and are declared, opened, fetched from, and closed to process result rows sequentially.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="close.md" %}
+[close.md](close.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+CLOSE closes a previously opened cursor, raising an error if it was not open; if not closed explicitly, a cursor closes at the end of its enclosing compound statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="declare-cursor.md" %}
+[declare-cursor.md](declare-cursor.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+DECLARE CURSOR declares a named cursor for a SELECT or, from MariaDB 12.3, a prepared statement name, optionally with parameters, for use within a stored program.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="fetch.md" %}
+[fetch.md](fetch.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+FETCH retrieves the next row from an open cursor into local variables and advances the cursor, raising a No Data condition (SQLSTATE 02000) when no more rows remain.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="open.md" %}
+[open.md](open.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+OPEN opens a previously declared cursor and executes its associated query, optionally binding variables or expressions, so that rows can be fetched.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-diagnostics/README.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-diagnostics/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Diagnostics
 
+{% columns %}
+{% column %}
+{% content-ref url="diagnostics-area.md" %}
+[diagnostics-area.md](diagnostics-area.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describes the diagnostics area that holds statement and condition information about errors, warnings, and notes produced by an SQL statement, including its properties and how it is populated and cleared.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="get-diagnostics.md" %}
+[get-diagnostics.md](get-diagnostics.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+GET DIAGNOSTICS copies statement and condition information from the diagnostics area into user or local variables, reading properties such as NUMBER, RETURNED_SQLSTATE, MYSQL_ERRNO, and MESSAGE_TEXT.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sqlstate.md" %}
+[sqlstate.md](sqlstate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains SQLSTATE, the five-character code identifying SQL error conditions by class and subclass, including the standard success, warning, and not-found classes and how they map to handler keywords.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/table-statements/obsolete-table-commands/README.md
+++ b/server/reference/sql-statements/table-statements/obsolete-table-commands/README.md
@@ -6,3 +6,26 @@ description: >-
 
 # Obsolete Table Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="backup-table-removed.md" %}
+[backup-table-removed.md](backup-table-removed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the removed BACKUP TABLE statement, which unreliably copied MyISAM tables to a backup directory, and points to mysqldump and MariaDB Backup as replacements.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="restore-table-removed.md" %}
+[restore-table-removed.md](restore-table-removed.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Documents the removed RESTORE TABLE statement, which unreliably restored MyISAM tables from a BACKUP TABLE backup directory, and points to mysqldump and other tools as replacements.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5h — depth-5, landings-only). Completes the sql-statements section for depth-5.

| Landing page | Treatment |
|---|---|
| `.../programmatic-compound-statements/programmatic-compound-statements-cursors/README.md` | 5 columns (authored) |
| `.../programmatic-compound-statements/programmatic-compound-statements-diagnostics/README.md` | 3 columns (authored) |
| `.../table-statements/obsolete-table-commands/README.md` | 2 columns (authored) |
| `.../data-manipulation/selecting-data/README.md` | 17 bullets (large-catalog treatment) |

10 descriptions authored inline (drafted from page content, spot-verified against source: DECLARE CURSOR 12.3 prepared-statement support, FETCH SQLSTATE 02000, BACKUP/RESTORE TABLE removed). No child pages modified.

## Verification
- Column balances 5/5, 3/3, 2/2; selecting-data 17 bullets; all content-ref and bullet targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)