### PR TITLE
DOCS-5973: Columnize 7 InnoDB sub-section landings (batch 5i)

### DIFF
--- a/server/server-usage/storage-engines/innodb/innodb-architecture-for-mariadb-enterprise-server/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-architecture-for-mariadb-enterprise-server/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # InnoDB Architecture for MariaDB Enterprise Server
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-innodb-background-thread-pool.md" %}
+[mariadb-enterprise-server-innodb-background-thread-pool.md](mariadb-enterprise-server-innodb-background-thread-pool.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page details the dedicated thread pool in MariaDB Enterprise Server that manages InnoDB background tasks, improving scalability and performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-innodb-io-threads.md" %}
+[mariadb-enterprise-server-innodb-io-threads.md](mariadb-enterprise-server-innodb-io-threads.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the specialized I/O threads in MariaDB Enterprise Server's InnoDB engine that handle asynchronous read and write operations efficiently.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-online-ddl/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-online-ddl/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # InnoDB Online DDL
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-online-ddl-overview.md" %}
+[innodb-online-ddl-overview.md](innodb-online-ddl-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An introduction to InnoDB's online DDL capabilities, detailing the ALGORITHM and LOCK clauses for controlling performance and concurrency during schema changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-online-ddl-operations-with-the-inplace-alter-algorithm.md" %}
+[innodb-online-ddl-operations-with-the-inplace-alter-algorithm.md](innodb-online-ddl-operations-with-the-inplace-alter-algorithm.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about operations supported by the INPLACE algorithm, which rebuilds the table but allows concurrent DML, offering a balance between performance and availability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-online-ddl-operations-with-the-instant-alter-algorithm.md" %}
+[innodb-online-ddl-operations-with-the-instant-alter-algorithm.md](innodb-online-ddl-operations-with-the-instant-alter-algorithm.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover the INSTANT algorithm, which modifies table metadata without rebuilding the table, enabling extremely fast schema changes like adding columns.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-online-ddl-operations-with-the-nocopy-alter-algorithm.md" %}
+[innodb-online-ddl-operations-with-the-nocopy-alter-algorithm.md](innodb-online-ddl-operations-with-the-nocopy-alter-algorithm.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the NOCOPY algorithm, which avoids rebuilding the clustered index for certain operations like adding secondary indexes, significantly reducing I/O.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="instant-add-column-for-innodb.md" %}
+[instant-add-column-for-innodb.md](instant-add-column-for-innodb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A focused guide on the Instant ADD COLUMN feature, explaining how it works by modifying metadata and its advantages over traditional table-rebuilding methods.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-row-formats/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-row-formats/README.md
@@ -7,3 +7,74 @@ description: >-
 
 # InnoDB Row Formats
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-row-formats-overview.md" %}
+[innodb-row-formats-overview.md](innodb-row-formats-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of the four InnoDB row formats (REDUNDANT, COMPACT, DYNAMIC, COMPRESSED), comparing their storage efficiency and feature support.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-compact-row-format.md" %}
+[innodb-compact-row-format.md](innodb-compact-row-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Detailed information on the COMPACT row format, which reduces storage space by roughly 20% compared to REDUNDANT, handling NULLs and variable-length columns efficiently.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-compressed-row-format.md" %}
+[innodb-compressed-row-format.md](innodb-compressed-row-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn about the COMPRESSED row format, which compresses data and index pages using algorithms like zlib to minimize storage footprint at the cost of CPU.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-dynamic-row-format.md" %}
+[innodb-dynamic-row-format.md](innodb-dynamic-row-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The DYNAMIC row format, default in modern MariaDB versions, optimizes storage for large BLOB/TEXT columns by storing them on separate overflow pages.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-redundant-row-format.md" %}
+[innodb-redundant-row-format.md](innodb-redundant-row-format.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on the legacy REDUNDANT row format, primarily maintained for backward compatibility with older MySQL versions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="troubleshooting-row-size-too-large-errors-with-innodb.md" %}
+[troubleshooting-row-size-too-large-errors-with-innodb.md](troubleshooting-row-size-too-large-errors-with-innodb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete InnoDB row size troubleshooting: innodb_strict_mode, ALTER TABLE ROW_FORMAT=DYNAMIC, VARCHAR/VARBINARY(256) overflow, and BLOB/TEXT solutions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-tablespaces/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-tablespaces/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # InnoDB Tablespaces
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-file-per-table-tablespaces.md" %}
+[innodb-file-per-table-tablespaces.md](innodb-file-per-table-tablespaces.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to configure InnoDB to store each table in its own .ibd file, enabling features like table compression and easier space reclamation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-system-tablespaces.md" %}
+[innodb-system-tablespaces.md](innodb-system-tablespaces.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains the InnoDB system tablespace (ibdata1), which stores the data dictionary, doublewrite buffer, and undo logs, and how to resize it.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-temporary-tablespaces.md" %}
+[innodb-temporary-tablespaces.md](innodb-temporary-tablespaces.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This page explains how InnoDB manages temporary tablespaces for non-compressed temporary tables, including configuration and sizing options.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-troubleshooting/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-troubleshooting/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # InnoDB Troubleshooting
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-troubleshooting-overview.md" %}
+[innodb-troubleshooting-overview.md](innodb-troubleshooting-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A starting point for diagnosing InnoDB issues, recommending checks on error logs, deadlocks, and table integrity using various tools.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-data-dictionary-troubleshooting.md" %}
+[innodb-data-dictionary-troubleshooting.md](innodb-data-dictionary-troubleshooting.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to resolve inconsistencies between the InnoDB internal data dictionary and the file system, such as orphan .frm or .ibd files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-recovery-modes.md" %}
+[innodb-recovery-modes.md](innodb-recovery-modes.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand the different `innodb_force_recovery` levels, which allow you to start the server in read-only modes to recover data after a crash.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/innodb-unmaintained/README.md
+++ b/server/server-usage/storage-engines/innodb/innodb-unmaintained/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # InnoDB - Unmaintained
 
+{% columns %}
+{% column %}
+{% content-ref url="about-xtradb.md" %}
+[about-xtradb.md](about-xtradb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information about the XtraDB storage engine that was used in old MariaDB versions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-innodb-instead-of-xtradb.md" %}
+[using-innodb-instead-of-xtradb.md](using-innodb-instead-of-xtradb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information about XtraDB, an storage engine used in old MariaDB versions.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/innodb/mariadb-enterprise-server-innodb-operations/README.md
+++ b/server/server-usage/storage-engines/innodb/mariadb-enterprise-server-innodb-operations/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # MariaDB Enterprise Server InnoDB Operations
 
+{% columns %}
+{% column %}
+{% content-ref url="configure-the-innodb-buffer-pool.md" %}
+[configure-the-innodb-buffer-pool.md](configure-the-innodb-buffer-pool.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to configuring the size and instances of the InnoDB Buffer Pool to optimize memory usage and cache performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configure-the-innodb-io-threads.md" %}
+[configure-the-innodb-io-threads.md](configure-the-innodb-io-threads.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on tuning the number of InnoDB read and write I/O threads to match your system's disk I/O capabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configure-the-innodb-purge-threads.md" %}
+[configure-the-innodb-purge-threads.md](configure-the-innodb-purge-threads.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to adjust the number of background purge threads to efficiently manage undo logs and prevent history list growth.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configure-the-innodb-redo-log.md" %}
+[configure-the-innodb-redo-log.md](configure-the-innodb-redo-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to configuring the size and number of InnoDB redo log files in MariaDB Enterprise Server to balance write performance and crash recovery time.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configure-the-innodb-undo-log.md" %}
+[configure-the-innodb-undo-log.md](configure-the-innodb-undo-log.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to manage InnoDB undo logs in MariaDB Enterprise Server, including moving them to separate tablespaces and enabling truncation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="schema-changes/" %}
+[schema-changes](schema-changes/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of supported online schema change operations in InnoDB, detailing which DDL statements can be performed without locking the table.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../innodb-unmaintained/" %}
+[innodb-unmaintained](../innodb-unmaintained/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section provides information about unmaintained or deprecated features related to InnoDB in MariaDB Server. It is advisable to review this content for compatibility and migration planning.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5i — depth-5 authored columns, landings-only).

Small-page treatment: convert to `{% columns %}`. All 28 child descriptions reused verbatim from existing child frontmatter (no authoring, no child edits).

| Landing page | Columns |
|---|---|
| `server-usage/storage-engines/innodb/innodb-architecture-for-mariadb-enterprise-server/README.md` | 2 |
| `.../innodb/innodb-online-ddl/README.md` | 5 |
| `.../innodb/innodb-row-formats/README.md` | 6 |
| `.../innodb/innodb-tablespaces/README.md` | 3 |
| `.../innodb/innodb-troubleshooting/README.md` | 3 |
| `.../innodb/innodb-unmaintained/README.md` | 2 |
| `.../innodb/mariadb-enterprise-server-innodb-operations/README.md` | 7 |

The innodb-operations landing correctly links its nested `schema-changes/` and the cross-listed sibling `../innodb-unmaintained/`.

## Verification
- Column balances all match (2/2, 5/5, 6/6, 3/3, 3/3, 2/2, 7/7); all 28 content-ref targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)