### PR TITLE
Fix escapes in string-literals.md

### DIFF
--- a/server/reference/sql-structure/sql-language-structure/string-literals.md
+++ b/server/reference/sql-structure/sql-language-structure/string-literals.md
@@ -74,17 +74,17 @@ There are other escape sequences:
 
 | Escape sequence | Character                                           |
 | --------------- | --------------------------------------------------- |
-| \0              | ASCII NUL (0x00).                                   |
-| '               | Single quote (“'”).                                 |
-| "               | Double quote (“"”).                                 |
-| \b              | Backspace.                                          |
-|                 | Newline, or linefeed,.                              |
-|                 | Carriage return.                                    |
-|                 | Tab.                                                |
-| \Z              | ASCII 26 (Control+Z). See note following the table. |
-| \\              | Backslash (“\”).                                    |
-| %               | “%” character. See note following the table.        |
-| \_              | A “\_” character. See note following the table.     |
+| \\0             | ASCII NUL (0x00).                                   |
+| \\'             | Single quote (“'”).                                 |
+| \\"             | Double quote (“"”).                                 |
+| \\b             | Backspace.                                          |
+| \\n             | Newline, or linefeed,.                              |
+| \\r             | Carriage return.                                    |
+| \\t             | Tab.                                                |
+| \\Z             | ASCII 26 (Control+Z). See note following the table. |
+| \\\\            | Backslash (“\”).                                    |
+| \\%             | “%” character. See note following the table.        |
+| \\_             | A “\_” character. See note following the table.     |
 
 Escaping the `%` and `_` characters can be necessary when using the [LIKE](../../sql-functions/string-functions/like.md) operator, which treats them as special characters.
 


### PR DESCRIPTION
Markdown also uses `\` for escaping.