### PR TITLE
DOCS-5973: Columnize 6 operators/sequences/nosql landings (batch 5k)

### DIFF
--- a/server/reference/sql-structure/nosql/handler/README.md
+++ b/server/reference/sql-structure/nosql/handler/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # HANDLER
 
+{% columns %}
+{% column %}
+{% content-ref url="handler-commands.md" %}
+[handler-commands.md](handler-commands.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Access storage engine interfaces directly for key lookups and key or table scans with the HANDLER statement's OPEN, READ, and CLOSE commands.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="handler-for-memory-tables.md" %}
+[handler-for-memory-tables.md](handler-for-memory-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Use HANDLER commands efficiently with MEMORY/HEAP tables, including creating BTREE keys for range scans and the limitations of HASH keys, BTREE keys, and table scans.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/nosql/handlersocket/README.md
+++ b/server/reference/sql-structure/nosql/handlersocket/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # HandlerSocket
 
+{% columns %}
+{% column %}
+{% content-ref url="handlersocket-installation.md" %}
+[handlersocket-installation.md](handlersocket-installation.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Install and configure the HandlerSocket plugin with INSTALL PLUGIN and the required my.cnf address and port options, then restart MariaDB.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="handlersocket-client-libraries.md" %}
+[handlersocket-client-libraries.md](handlersocket-client-libraries.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+List the HandlerSocket client libraries available for C++, Perl, PHP, Java, Python, Ruby, JavaScript, Scala, and Haskell applications.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="handlersocket-configuration-options.md" %}
+[handlersocket-configuration-options.md](handlersocket-configuration-options.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Describe the HandlerSocket plugin configuration options for the my.cnf [mysqld] section, including addresses, ports, thread counts, buffers, and timeouts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="handlersocket-external-resources.md" %}
+[handlersocket-external-resources.md](handlersocket-external-resources.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Collect external resources and documentation about the HandlerSocket plugin, including its home repository, background articles, and presentations.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/operators/arithmetic-operators/README.md
+++ b/server/reference/sql-structure/operators/arithmetic-operators/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Arithmetic Operators
 
+{% columns %}
+{% column %}
+{% content-ref url="addition-operator.md" %}
+[addition-operator.md](addition-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Add two operands with the + operator, calculating integer results at BIGINT precision and letting the highest-precision operand determine the result type for real or string values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="subtraction-operator.md" %}
+[subtraction-operator.md](subtraction-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Subtract one operand from another with the - operator, which also serves as the unary minus for changing sign, computing integer results at BIGINT precision.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="multiplication-operator.md" %}
+[multiplication-operator.md](multiplication-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Multiply two operands with the * operator.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="division-operator.md" %}
+[division-operator.md](division-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Divide operands with the / operator, returning NULL on division by zero and controlling decimal digits with the div_precision_increment system variable.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="modulo-operator.md" %}
+[modulo-operator.md](modulo-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return the remainder of N divided by M with the % modulo operator.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/operators/assignment-operators/README.md
+++ b/server/reference/sql-structure/operators/assignment-operators/README.md
@@ -7,3 +7,26 @@ description: >-
 
 # Assignment Operators
 
+{% columns %}
+{% column %}
+{% content-ref url="assignment-operator.md" %}
+[assignment-operator.md](assignment-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign a value to a user-defined or local variable with the := operator, which, unlike =, can be used in any context.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="assignment-operators-assignment-operator.md" %}
+[assignment-operators-assignment-operator.md](assignment-operators-assignment-operator.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Assign a value with the = operator, which doubles as a comparison operator and is valid for assignment only in SET statements and the SET clause of UPDATE.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/operators/logical-operators/README.md
+++ b/server/reference/sql-structure/operators/logical-operators/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Logical Operators
 
+{% columns %}
+{% column %}
+{% content-ref url="and.md" %}
+[and.md](and.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Evaluate logical AND with AND or &&, returning 1 when all operands are non-zero and not NULL, 0 when any operand is 0, and NULL otherwise.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="not.md" %}
+[not.md](not.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Negate an operand with logical NOT or !, returning 1 for 0, 0 for non-zero values, and NULL for NULL, with precedence affected by the HIGH_NOT_PRECEDENCE SQL_MODE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="or.md" %}
+[or.md](or.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Evaluate logical OR with OR or ||, returning 1 when any operand is non-zero and handling NULL operands per SQL logic; || concatenates strings under PIPES_AS_CONCAT.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="xor.md" %}
+[xor.md](xor.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Evaluate exclusive OR with XOR, returning NULL if either operand is NULL and otherwise 1 when an odd number of operands is non-zero.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-structure/sequences/sequence-functions/README.md
+++ b/server/reference/sql-structure/sequences/sequence-functions/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # SEQUENCE Functions
 
+{% columns %}
+{% column %}
+{% content-ref url="lastval.md" %}
+[lastval.md](lastval.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+LASTVAL is a synonym for PREVIOUS VALUE FOR, returning the most recent value generated from a sequence in the current connection.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="next-value-for-sequence_name.md" %}
+[next-value-for-sequence_name.md](next-value-for-sequence_name.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Generate the next value of a sequence with NEXT VALUE FOR (ANSI SQL), NEXTVAL() (PostgreSQL), or sequence_name.nextval in Oracle mode.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="nextval.md" %}
+[nextval.md](nextval.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+NEXTVAL is a synonym for NEXT VALUE FOR, generating the next value of a sequence.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="previous-value-for-sequence_name.md" %}
+[previous-value-for-sequence_name.md](previous-value-for-sequence_name.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Get the most recent value generated from a sequence in the current connection with PREVIOUS VALUE FOR (DB2), LASTVAL() (PostgreSQL), or sequence_name.currval in Oracle mode.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setval.md" %}
+[setval.md](setval.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Set the next value returned by a sequence with SETVAL(), a PostgreSQL-compatible function extended with is_used and round arguments that never lowers the sequence below its current value.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5k — depth-5 authored columns, landings-only).

Small-page treatment: convert to `{% columns %}` with 22 descriptions authored inline (drafted from page content, spot-verified against source). No child pages modified.

| Landing page | Columns |
|---|---|
| `reference/sql-structure/operators/arithmetic-operators/README.md` | 5 |
| `reference/sql-structure/operators/assignment-operators/README.md` | 2 |
| `reference/sql-structure/operators/logical-operators/README.md` | 4 |
| `reference/sql-structure/sequences/sequence-functions/README.md` | 5 |
| `reference/sql-structure/nosql/handler/README.md` | 2 |
| `reference/sql-structure/nosql/handlersocket/README.md` | 4 |

Notable verification: the two assignment-operator pages are correctly differentiated (`:=` usable in any context vs `=` valid only in SET / UPDATE SET clause).

## Verification
- Column balances 5/5, 2/2, 4/4, 5/5, 2/2, 4/4; all 22 content-ref targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)