### PR TITLE
DOCS-5973: Columnize 5 small geometry landings (batch 5l)

### DIFF
--- a/server/reference/sql-statements/geometry-constructors/linestring-properties/README.md
+++ b/server/reference/sql-statements/geometry-constructors/linestring-properties/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # LineString Properties
 
+{% columns %}
+{% column %}
+{% content-ref url="linestring-properties-endpoint.md" %}
+[linestring-properties-endpoint.md](linestring-properties-endpoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_ENDPOINT. Returns the last point of a LineString geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="glength.md" %}
+[glength.md](glength.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_LENGTH. Calculates the length of a LineString or MultiLineString in its associated spatial reference units.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linestring-properties-numpoints.md" %}
+[linestring-properties-numpoints.md](linestring-properties-numpoints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_NUMPOINTS. Returns the number of points in a LineString geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linestring-properties-pointn.md" %}
+[linestring-properties-pointn.md](linestring-properties-pointn.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_POINTN. Returns the N-th point in a LineString geometry, where N is a 1-based index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="linestring-properties-startpoint.md" %}
+[linestring-properties-startpoint.md](linestring-properties-startpoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_STARTPOINT. Returns the first point of a LineString geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_endpoint.md" %}
+[st_endpoint.md](st_endpoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the end Point of a LineString. This function retrieves the final coordinate in the linear geometry sequence.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_numpoints.md" %}
+[st_numpoints.md](st_numpoints.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the count of Points in a LineString. This function calculates the total number of vertices defining the line.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_pointn.md" %}
+[st_pointn.md](st_pointn.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the N-th Point in a LineString. This function retrieves a specific point from the sequence based on its 1-based index.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_startpoint.md" %}
+[st_startpoint.md](st_startpoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the start Point of a LineString. This function retrieves the initial coordinate in the linear geometry sequence.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/geometry-constructors/mbr-minimum-bounding-rectangle/README.md
+++ b/server/reference/sql-statements/geometry-constructors/mbr-minimum-bounding-rectangle/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # MBR (Minimum Bounding Rectangle)
 
+{% columns %}
+{% column %}
+{% content-ref url="mbr-definition.md" %}
+[mbr-definition.md](mbr-definition.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Understand Minimum Bounding Rectangles. An MBR is the smallest rectangle that completely encloses a geometry, defined by its minimum and maximum X and Y coordinates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrcontains.md" %}
+[mbrcontains.md](mbrcontains.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if one MBR contains another. Returns 1 if the Minimum Bounding Rectangle of the first geometry completely encloses the MBR of the second geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrcoveredby.md" %}
+[mbrcoveredby.md](mbrcoveredby.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if one MBR is covered by another. Returns 1 if the MBR of the first geometry is entirely contained within the MBR of the second geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrdisjoint.md" %}
+[mbrdisjoint.md](mbrdisjoint.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if two MBRs are disjoint. Returns 1 if the Minimum Bounding Rectangles of the two geometries do not intersect or touch at all.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrequal.md" %}
+[mbrequal.md](mbrequal.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if two MBRs are identical. Returns 1 if the Minimum Bounding Rectangles of both geometries share the exact same coordinates.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrintersects.md" %}
+[mbrintersects.md](mbrintersects.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if two MBRs intersect. Returns 1 if the Minimum Bounding Rectangles of the geometries share any portion of space, including boundaries.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbroverlaps.md" %}
+[mbroverlaps.md](mbroverlaps.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if two MBRs overlap. Returns 1 if the MBRs intersect but neither completely contains the other, and they have the same dimension.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrtouches.md" %}
+[mbrtouches.md](mbrtouches.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if two MBRs touch. Returns 1 if the MBRs intersect only at their boundaries and do not share any interior points.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mbrwithin.md" %}
+[mbrwithin.md](mbrwithin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if one MBR is within another. Returns 1 if the MBR of the first geometry is completely enclosed by the MBR of the second geometry.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/geometry-constructors/miscellaneous-gis-functions/README.md
+++ b/server/reference/sql-statements/geometry-constructors/miscellaneous-gis-functions/README.md
@@ -7,3 +7,98 @@ description: >-
 
 # Miscellaneous GIS functions
 
+{% columns %}
+{% column %}
+{% content-ref url="st_collect.md" %}
+[st_collect.md](st_collect.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Aggregate multiple geometries into a collection. This function creates a MultiPoint, MultiLineString, MultiPolygon, or GeometryCollection from a set of geometry arguments.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_geohash.md" %}
+[st_geohash.md](st_geohash.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Generate a Geohash string from a point or coordinates. This function encodes spatial locations into short, alphanumeric strings for efficient indexing and proximity searches.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_isvalid.md" %}
+[st_isvalid.md](st_isvalid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Check if a geometry is valid. This function returns 1 if the geometry complies with OGC specifications (e.g., no self-intersections), 0 otherwise.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_latfromgeohash.md" %}
+[st_latfromgeohash.md](st_latfromgeohash.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Decode a Geohash to retrieve the latitude. This function returns the latitude coordinate (Y-axis) from a given Geohash string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_longfromgeohash.md" %}
+[st_longfromgeohash.md](st_longfromgeohash.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Decode a Geohash to retrieve the longitude. This function returns the longitude coordinate (X-axis) from a given Geohash string.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_pointfromgeohash.md" %}
+[st_pointfromgeohash.md](st_pointfromgeohash.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Create a Point geometry from a Geohash. This function decodes a Geohash string into a Point object representing the location's center.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_simplify.md" %}
+[st_simplify.md](st_simplify.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Simplify a geometry using the Douglas-Peucker algorithm. This function reduces the number of vertices in a geometry while preserving its general shape, useful for rendering maps.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_validate.md" %}
+[st_validate.md](st_validate.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Validate and optionally return a geometry. This function checks if a geometry is valid according to OGC rules; it returns the geometry if valid, or NULL if not.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/geometry-constructors/point-properties/README.md
+++ b/server/reference/sql-statements/geometry-constructors/point-properties/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # Point Properties
 
+{% columns %}
+{% column %}
+{% content-ref url="point-properties-x.md" %}
+[point-properties-x.md](point-properties-x.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_X. Returns the X-coordinate value of a Point geometry as a double-precision number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="point-properties-y.md" %}
+[point-properties-y.md](point-properties-y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_Y. Returns the Y-coordinate value of a Point geometry as a double-precision number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_x.md" %}
+[st_x.md](st_x.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the X-coordinate of a Point geometry. This function extracts the horizontal coordinate value as a double-precision number.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_y.md" %}
+[st_y.md](st_y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the Y-coordinate of a Point geometry. This function extracts the vertical coordinate value as a double-precision number.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/geometry-constructors/polygon-properties/README.md
+++ b/server/reference/sql-statements/geometry-constructors/polygon-properties/README.md
@@ -7,3 +7,122 @@ description: >-
 
 # Polygon Properties
 
+{% columns %}
+{% column %}
+{% content-ref url="centroid.md" %}
+[centroid.md](centroid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_CENTROID. Returns the mathematical centroid of the Polygon or MultiPolygon as a Point geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="polygon-properties-area.md" %}
+[polygon-properties-area.md](polygon-properties-area.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_AREA. Returns the double-precision area of the Polygon or MultiPolygon, calculated in its spatial reference system.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="polygon-properties-exteriorring.md" %}
+[polygon-properties-exteriorring.md](polygon-properties-exteriorring.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_ExteriorRing. Returns the exterior ring of a Polygon as a LineString.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="polygon-properties-interiorringn.md" %}
+[polygon-properties-interiorringn.md](polygon-properties-interiorringn.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_InteriorRingN. Returns the N-th interior ring of a Polygon as a LineString.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="polygon-properties-numinteriorrings.md" %}
+[polygon-properties-numinteriorrings.md](polygon-properties-numinteriorrings.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Synonym for ST_NumInteriorRings. Returns the number of interior rings in a Polygon geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_area.md" %}
+[st_area.md](st_area.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the area of a Polygon or MultiPolygon. The result is a double-precision number measured in the geometry's spatial reference units.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_centroid.md" %}
+[st_centroid.md](st_centroid.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the centroid of a Polygon or MultiPolygon. The result is a Point geometry representing the mathematical center of mass.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_exteriorring.md" %}
+[st_exteriorring.md](st_exteriorring.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the exterior ring of a Polygon. This function extracts the outer boundary of the polygon as a LineString geometry.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_interiorringn.md" %}
+[st_interiorringn.md](st_interiorringn.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the N-th interior ring of a Polygon. This function retrieves a specific inner hole of the polygon as a LineString.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="st_numinteriorrings.md" %}
+[st_numinteriorrings.md](st_numinteriorrings.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Returns the count of interior rings in a Polygon. This function calculates the total number of inner holes within the polygon.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5l — depth-5 authored columns, landings-only). Completes the geometry section for depth-5.

Small-page treatment: convert to `{% columns %}`. All 40 child descriptions reused verbatim from existing child frontmatter (no authoring, no child edits).

| Landing page | Columns |
|---|---|
| `reference/sql-statements/geometry-constructors/point-properties/README.md` | 4 |
| `.../geometry-constructors/linestring-properties/README.md` | 9 |
| `.../geometry-constructors/mbr-minimum-bounding-rectangle/README.md` | 9 |
| `.../geometry-constructors/miscellaneous-gis-functions/README.md` | 8 |
| `.../geometry-constructors/polygon-properties/README.md` | 10 |

## Verification
- Column balances 4/4, 9/9, 9/9, 8/8, 10/10; all 40 content-ref targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)