### PR TITLE
DOCS-5973: Columnize install-and-upgrade depth-5 landings (batch 5n)

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/compiling-mariadb-from-source/legacy-guides/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/compiling-mariadb-from-source/legacy-guides/README.md
@@ -23,3 +23,21 @@ layout:
 
 # Legacy Guides
 
+- [Build Environment Setup for macOS](build_environment_setup_for_mac.md)
+- [Building MariaDB on Gentoo](building_mariadb_on_gentoo.md)
+- [Creating a Debian Repository](creating_a_debian_repository.md)
+- [Creating the MariaDB Source Tarball](creating_the_mariadb_source_tarball.md)
+- [Build Environment Setup for Linux](build-environment-setup-for-linux.md)
+- [Building MariaDB from a Source RPM](building-mariadb-from-a-source-rpm.md)
+- [Building MariaDB From Source Using musl-based GNU/Linux](building-mariadb-from-source-using-musl-based-gnulinux.md)
+- [Building MariaDB on CentOS](source-building-mariadb-on-centos.md)
+- [Building MariaDB on Debian](building-mariadb-on-debian.md)
+- [Building MariaDB on Fedora](building-mariadb-on-fedora.md)
+- [Building MariaDB on FreeBSD](building-mariadb-on-freebsd.md)
+- [Building MariaDB on Solaris and OpenSolaris](building-mariadb-on-solaris-and-opensolaris.md)
+- [Building MariaDB on Ubuntu](building-mariadb-on-ubuntu.md)
+- [Building RPM Packages From Source](building-rpm-packages-from-source.md)
+- [Compile and Using MariaDB with Sanitizers (ASAN, UBSAN, TSAN, MSAN)](compile-and-using-mariadb-with-sanitizers-asan-ubsan-tsan-msan.md)
+- [Creating the MariaDB Binary Tarball](creating-the-mariadb-binary-tarball.md)
+- [Compiling with the InnoDB Plugin from Oracle](compiling-with-the-innodb-plugin-from-oracle.md)
+- [Compiling MariaDB with Vanilla XtraDB](compiling-mariadb-with-vanilla-xtradb.md)

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/README.md
@@ -22,3 +22,134 @@ layout:
 
 # MariaDB Binary Packages
 
+{% columns %}
+{% column %}
+{% content-ref url="gpg.md" %}
+[gpg.md](gpg.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information about the GPG keys used to sign MariaDB packages and repositories, including how to import them for verification.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-deb-files.md" %}
+[installing-mariadb-deb-files.md](installing-mariadb-deb-files.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete .deb installation guide: add repo via mariadb_repo_setup, import GPG keys, apt install mariadb-server galera-4, and APT configuration.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="rpm/" %}
+[rpm](rpm/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Install and manage MariaDB Server using RPM packages. This section provides detailed instructions for deploying and upgrading MariaDB on RPM-based Linux distributions. width: default title: visible: true description: visible: true tableOfContents: visible: true outline: visible: true pagination: visible: false metadata: visible: true tags: visible: true
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-alongside-mysql.md" %}
+[installing-mariadb-alongside-mysql.md](installing-mariadb-alongside-mysql.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for installing MariaDB on the same server as an existing MySQL installation, useful for migration testing or running multiple versions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-binary-tarballs.md" %}
+[installing-mariadb-binary-tarballs.md](installing-mariadb-binary-tarballs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to installing MariaDB from pre-compiled binary tarballs on Linux, allowing for flexible installation paths and multiple versions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-msi-packages-on-windows.md" %}
+[installing-mariadb-msi-packages-on-windows.md](installing-mariadb-msi-packages-on-windows.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB installation guide. Complete setup instructions for Linux, Windows, and macOS with configuration and verification for production use.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-on-macos-using-homebrew.md" %}
+[installing-mariadb-on-macos-using-homebrew.md](installing-mariadb-on-macos-using-homebrew.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to install MariaDB Server on macOS using the Homebrew package manager, including starting the service and securing the installation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-server-pkg-packages-on-macos.md" %}
+[installing-mariadb-server-pkg-packages-on-macos.md](installing-mariadb-server-pkg-packages-on-macos.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to install MariaDB Server on macOS. This is possible using Homebrew.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-windows-zip-packages.md" %}
+[installing-mariadb-windows-zip-packages.md](installing-mariadb-windows-zip-packages.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for manually installing MariaDB on Windows from a ZIP archive, useful for portable installations or advanced configuration needs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="package-tarballs.md" %}
+[package-tarballs.md](package-tarballs.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the benefits and use cases for deploying MariaDB using package tarballs (containing RPMs or DEBs) for offline or custom installations.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="repo-mirror.md" %}
+[repo-mirror.md](repo-mirror.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to create and maintain local mirrors of MariaDB package repositories for secure or air-gapped deployments.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/README.md
@@ -22,3 +22,62 @@ layout:
 
 # Compiling MariaDB From Source
 
+{% columns %}
+{% column %}
+{% content-ref url="compiling-mariadb-from-source-the-master-guide.md" %}
+[compiling-mariadb-from-source-the-master-guide.md](compiling-mariadb-from-source-the-master-guide.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete step-by-step guide for compiling and building MariaDB from source on various flavors of Linux and on macOS.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="building_mariadb_on_windows.md" %}
+[building_mariadb_on_windows.md](building_mariadb_on_windows.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide to building MariaDB on Windows using Visual Studio, CMake, and Git, including creating ZIP and MSI packages.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="cross-compiling-mariadb.md" %}
+[cross-compiling-mariadb.md](cross-compiling-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for cross-compiling MariaDB for different architectures, including using Buildroot and CMake toolchain files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="compiling-mariadb-with-extra-modulesoptions/" %}
+[compiling-mariadb-with-extra-modulesoptions](compiling-mariadb-with-extra-modulesoptions/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Compile MariaDB Server with extra modules and options. This section details how to customize your build from source, enabling specific features or optimizations for your deployment. width: default title: visible: true description: visible: true tableOfContents: visible: true outline: visible: true pagination: visible: false metadata: visible: true tags: visible: true
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../compiling-mariadb-from-source/legacy-guides/" %}
+[legacy-guides](../../compiling-mariadb-from-source/legacy-guides/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This section holds building-MariaDB-from-source instructions for building old versions of MariaDB. Recent instructions are in the Compiling MariaDB From Source: The Master Guide page. width: default title: visible: true description: visible: true tableOfContents: visible: true outline: visible: true pagination: visible: false metadata: visible: true tags: visible: true
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/installing-system-tables-mariadb-install-db/README.md
@@ -23,3 +23,26 @@ layout:
 
 # Installing System Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="installing-system-tables-on-unix.md" %}
+[installing-system-tables-on-unix.md](installing-system-tables-on-unix.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for running the `mariadb-install-db` script on Unix-like systems to initialize the MariaDB data directory and system tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-install-db-exe.md" %}
+[mariadb-install-db-exe.md](mariadb-install-db-exe.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the use of `mariadb-install-db.exe` on Windows to create new database instances, set the root password, and register Windows services.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/troubleshooting-installation-issues/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/troubleshooting-installation-issues/README.md
@@ -23,3 +23,62 @@ layout:
 
 # Troubleshooting Installation Issues
 
+{% columns %}
+{% column %}
+{% content-ref url="error-symbol-mysql_get_server_name-version-libmysqlclient_16-not-defined.md" %}
+[error-symbol-mysql_get_server_name-version-libmysqlclient_16-not-defined.md](error-symbol-mysql_get_server_name-version-libmysqlclient_16-not-defined.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Troubleshooting guide for a specific linker error involving `mysql_get_server_name` and `libmysqlclient_16`, typically occurring due to library version mismatches.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installation-issues-on-windows.md" %}
+[installation-issues-on-windows.md](installation-issues-on-windows.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Common installation problems on Windows, such as issues with User Account Control (UAC) or unsupported Windows versions, and their solutions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installation-issues-with-php5.md" %}
+[installation-issues-with-php5.md](installation-issues-with-php5.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Addresses compatibility issues between MariaDB and older PHP5 client libraries, specifically regarding header and library version mismatches.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-on-an-old-linux-version.md" %}
+[installing-on-an-old-linux-version.md](installing-on-an-old-linux-version.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guidance for dealing with glibc or shared library errors when attempting to install modern MariaDB binaries on older Linux distributions.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installation-issues-on-debian-and-ubuntu/" %}
+[installation-issues-on-debian-and-ubuntu](installation-issues-on-debian-and-ubuntu/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A collection of troubleshooting articles specific to Debian and Ubuntu deployments, covering upgrade failures, repository conflicts, and migration issues.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/README.md
@@ -7,3 +7,14 @@ description: >-
 
 # Migrating to MariaDB from Oracle
 
+{% columns %}
+{% column %}
+{% content-ref url="oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md" %}
+[oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md](oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Migrate from Oracle to MariaDB Server. This page provides detailed guidance, tools, and best practices for a smooth and efficient transition of your databases and applications.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/README.md
@@ -7,3 +7,16 @@ description: >-
 
 # Migrating to MariaDB from SQL Server
 
+- [MariaDB Backups Overview for SQL Server Users](mariadb-backups-overview-for-sql-server-users.md)
+- [Understanding MariaDB Architecture](understanding-mariadb-architecture.md)
+- [MariaDB Features Not Available in SQL Server](mariadb-features-not-available-in-sql-server.md)
+- [SQL Server Features Not Available in MariaDB](sql-server-features-not-available-in-mariadb.md)
+- [SQL Server Features Implemented Differently in MariaDB](sql-server-features-implemented-differently-in-mariadb.md)
+- [SQL Server and MariaDB Types Comparison](sql-server-and-mariadb-types-comparison.md)
+- [Syntax Differences between MariaDB and SQL Server](syntax-differences-between-mariadb-and-sql-server.md)
+- [MariaDB Authorization and Permissions for SQL Server Users](mariadb-authorization-and-permissions-for-sql-server-users.md)
+- [MariaDB Replication Overview for SQL Server Users](mariadb-replication-overview-for-sql-server-users.md)
+- [MariaDB Transactions and Isolation Levels for SQL Server Users](mariadb-transactions-and-isolation-levels-for-sql-server-users.md)
+- [Moving Data Between SQL Server and MariaDB](moving-data-between-sql-server-and-mariadb.md)
+- [Repairing MariaDB Tables for SQL Server Users](repairing-mariadb-tables-for-sql-server-users.md)
+- [Setting Up MariaDB for Testing for SQL Server Users](setting-up-mariadb-for-testing-for-sql-server-users.md)

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/README.md
@@ -22,3 +22,50 @@ layout:
 
 # MariaDB Enterprise Server Upgrade Paths
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-11.8/" %}
+[mariadb-enterprise-server-11.8](mariadb-enterprise-server-11.8/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade guide for MariaDB Enterprise Server 11.8, highlighting significant performance improvements in transactional throughput, new vector search optimizations, and enhanced observability features.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-11.4/" %}
+[mariadb-enterprise-server-11.4](mariadb-enterprise-server-11.4/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for upgrading to MariaDB Enterprise Server 11.4, which introduces new data types like UUID and INET4, advanced JSON functions, and non-blocking online schema changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-10.6/" %}
+[mariadb-enterprise-server-10.6](mariadb-enterprise-server-10.6/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade documentation for MariaDB Enterprise Server 10.6, featuring Atomic DDL support, JSON_TABLE function, improved Oracle compatibility modes, and the removal of older storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="archived/" %}
+[archived](archived/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A collection of upgrade guides for older, end-of-life versions of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-unmaintained-mariadb-releases/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-unmaintained-mariadb-releases/README.md
@@ -20,3 +20,146 @@ layout:
 
 # Archived Guides (Unmaintained CS Versions)
 
+{% columns %}
+{% column %}
+{% content-ref url="../upgrading-from-to-specific-versions/upgrading-from-mariadb-11-2-to-mariadb-11-3.md" %}
+[upgrading-from-mariadb-11-2-to-mariadb-11-3.md](../upgrading-from-to-specific-versions/upgrading-from-mariadb-11-2-to-mariadb-11-3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../upgrading-from-to-specific-versions/upgrading-from-mariadb-11-1-to-mariadb-11-2.md" %}
+[upgrading-from-mariadb-11-1-to-mariadb-11-2.md](../upgrading-from-to-specific-versions/upgrading-from-mariadb-11-1-to-mariadb-11-2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-11-0-to-mariadb-11-1.md" %}
+[upgrading-from-mariadb-11-0-to-mariadb-11-1.md](upgrading-from-mariadb-11-0-to-mariadb-11-1.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-10-11-to-mariadb-11-0.md" %}
+[upgrading-from-mariadb-10-11-to-mariadb-11-0.md](upgrading-from-mariadb-10-11-to-mariadb-11-0.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-10-7-to-mariadb-10-8.md" %}
+[upgrading-from-mariadb-10-7-to-mariadb-10-8.md](upgrading-from-mariadb-10-7-to-mariadb-10-8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-10-6-to-mariadb-10-7.md" %}
+[upgrading-from-mariadb-10-6-to-mariadb-10-7.md](upgrading-from-mariadb-10-6-to-mariadb-10-7.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-10-4-to-mariadb-10-5.md" %}
+[upgrading-from-mariadb-10-4-to-mariadb-10-5.md](upgrading-from-mariadb-10-4-to-mariadb-10-5.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-103-to-mariadb-104.md" %}
+[upgrading-from-mariadb-103-to-mariadb-104.md](upgrading-from-mariadb-103-to-mariadb-104.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-102-to-mariadb-103.md" %}
+[upgrading-from-mariadb-102-to-mariadb-103.md](upgrading-from-mariadb-102-to-mariadb-103.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-101-to-mariadb-102.md" %}
+[upgrading-from-mariadb-101-to-mariadb-102.md](upgrading-from-mariadb-101-to-mariadb-102.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-100-to-mariadb-101.md" %}
+[upgrading-from-mariadb-100-to-mariadb-101.md](upgrading-from-mariadb-100-to-mariadb-101.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-53-to-mariadb-55.md" %}
+[upgrading-from-mariadb-53-to-mariadb-55.md](upgrading-from-mariadb-53-to-mariadb-55.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrading guide for unmaintained versions of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5n — depth-5, landings-only). All descriptions reused verbatim from existing child frontmatter (no authoring, no child edits).

| Landing page | Treatment |
|---|---|
| `.../installing-mariadb/binary-packages/README.md` | 11 columns |
| `.../installing-mariadb/compiling-mariadb-from-source/README.md` | 5 columns |
| `.../installing-mariadb/installing-system-tables-mariadb-install-db/README.md` | 2 columns |
| `.../installing-mariadb/troubleshooting-installation-issues/README.md` | 5 columns |
| `.../migrating-to-mariadb/migrating-to-mariadb-from-oracle/README.md` | 1 column |
| `.../upgrading/upgrade-paths/README.md` | 4 columns |
| `.../upgrading/upgrading-to-unmaintained-mariadb-releases/README.md` | 12 columns |
| `.../compiling-mariadb-from-source/legacy-guides/README.md` | 18 bullets |
| `.../migrating-to-mariadb/migrating-to-mariadb-from-sql-server/README.md` | 13 bullets |

Large landings (`legacy-guides` 18, `migrating-from-sql-server` 13) use the bulleted-link treatment.

## Verification
- Column balances all match; bullets 18 + 13; all targets resolve.
- Landings contain no `/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)