### PR TITLE
DOCS-5973: Columnize 7 encryption + reference-misc depth-5 landings (batch 5o)

### DIFF
--- a/server/reference/data-types/string-data-types/character-sets/README.md
+++ b/server/reference/data-types/string-data-types/character-sets/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Character Sets and Collations
 
+{% columns %}
+{% column %}
+{% content-ref url="character-set-and-collation-overview.md" %}
+[character-set-and-collation-overview.md](character-set-and-collation-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn the core concepts of character sets and collations in MariaDB, including how they define string storage and sorting rules.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setting-character-sets-and-collations.md" %}
+[setting-character-sets-and-collations.md](setting-character-sets-and-collations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete Setting Character Sets and Collations data type guide for MariaDB. Complete reference for syntax, valid values, storage requirements, and range.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="supported-character-sets-and-collations.md" %}
+[supported-character-sets-and-collations.md](supported-character-sets-and-collations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete character sets reference: SHOW CHARACTER SET command, information_schema.CHARACTER_SETS/COLLATIONS tables, NO PAD queries, and ci/cs flags.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="unicode.md" %}
+[unicode.md](unicode.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explore MariaDB's support for Unicode, covering the differences between the utf8mb3 and utf8mb4 character sets for multi-byte storage.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="internationalization-and-localization/" %}
+[internationalization-and-localization](internationalization-and-localization/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Discover how MariaDB supports internationalization and localization, enabling databases to store and process data in multiple languages.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/mariadb-internals/mariadb-source-code-internals/README.md
+++ b/server/reference/product-development/mariadb-internals/mariadb-source-code-internals/README.md
@@ -8,11 +8,26 @@ description: >-
 
 {% include "../../../../.gitbook/includes/this-page-contains-backgrou....md" %}
 
+{% columns %}
+{% column %}
 {% content-ref url="stored-procedure-internals.md" %}
 [stored-procedure-internals.md](stored-procedure-internals.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Explores the internal implementation and execution flow of stored procedures, including how they are parsed and stored by the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="connect-memory-usage.md" %}
 [connect-memory-usage.md](connect-memory-usage.md)
 {% endcontent-ref %}
+{% endcolumn %}
 
+{% column %}
+Provides a technical breakdown of how the server allocates and manages memory for each client connection and thread.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/system-tables/sys-schema/sys-schema-stored-procedures/README.md
+++ b/server/reference/system-tables/sys-schema/sys-schema-stored-procedures/README.md
@@ -7,3 +7,86 @@ description: >-
 
 # Sys Schema Stored Procedures
 
+{% columns %}
+{% column %}
+{% content-ref url="create_synonym_db.md" %}
+[create_synonym_db.md](create_synonym_db.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The create_synonym_db stored procedure creates a new database that contains views mirroring all tables from a source database, useful for creating aliases.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="optimizer_switch-helper-functions.md" %}
+[optimizer_switch-helper-functions.md](optimizer_switch-helper-functions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+These helper functions allow you to easily enable or disable specific optimizer_switch flags for the current session.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ps_trace_statement_digest.md" %}
+[ps_trace_statement_digest.md](ps_trace_statement_digest.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This procedure traces a specific statement digest in the Performance Schema, capturing details about its execution for performance analysis.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ps_trace_thread.md" %}
+[ps_trace_thread.md](ps_trace_thread.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The ps_trace_thread procedure captures a trace of Performance Schema instrumentation for a specific thread and dumps it to a .dot formatted graph file.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="ps_truncate_all_tables.md" %}
+[ps_truncate_all_tables.md](ps_truncate_all_tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This procedure truncates all Performance Schema summary tables, effectively resetting all aggregated performance statistics.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="statement_performance_analyzer.md" %}
+[statement_performance_analyzer.md](statement_performance_analyzer.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This diagnostic procedure creates a report of the statements currently running or recently run on the server, aiding in performance troubleshooting.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="table_exists.md" %}
+[table_exists.md](table_exists.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The table_exists procedure checks for the existence of a specific table, view, or temporary table within a given database.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/system-tables/the-mysql-database-tables/spider-mysql-database-tables/README.md
+++ b/server/reference/system-tables/the-mysql-database-tables/spider-mysql-database-tables/README.md
@@ -7,3 +7,110 @@ description: >-
 
 # Spider mysql Database Tables
 
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_link_failed_log-table.md" %}
+[mysql-spider_link_failed_log-table.md](mysql-spider_link_failed_log-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table logs failures when attempting to establish connections to remote Spider links, helping to diagnose network or configuration issues.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_link_mon_servers-table.md" %}
+[mysql-spider_link_mon_servers-table.md](mysql-spider_link_mon_servers-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table defines the remote servers used for link monitoring in the Spider storage engine, ensuring high availability and failover handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_table_crd-table.md" %}
+[mysql-spider_table_crd-table.md](mysql-spider_table_crd-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.spider_table_crd table stores cardinality statistics for Spider tables, which the optimizer uses to create efficient query plans.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_table_position_for_recovery-table.md" %}
+[mysql-spider_table_position_for_recovery-table.md](mysql-spider_table_position_for_recovery-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table records XA transaction positions for Spider tables, essential for recovering distributed transactions after a crash.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_table_sts-table.md" %}
+[mysql-spider_table_sts-table.md](mysql-spider_table_sts-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.spider_table_sts table holds statistics such as row counts and data length for Spider tables, supporting the optimizer.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_tables-table.md" %}
+[mysql-spider_tables-table.md](mysql-spider_tables-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table stores specific parameters and metadata for Spider tables, defining how they map to remote backend tables.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_xa-table.md" %}
+[mysql-spider_xa-table.md](mysql-spider_xa-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.spider_xa table tracks the status of XA transactions involving Spider tables, ensuring atomicity across distributed nodes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_xa_failed_log-table.md" %}
+[mysql-spider_xa_failed_log-table.md](mysql-spider_xa_failed_log-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This table logs details of failed XA transactions in the Spider storage engine, providing a record for troubleshooting distributed transaction errors.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mysql-spider_xa_member-table.md" %}
+[mysql-spider_xa_member-table.md](mysql-spider_xa_member-table.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The mysql.spider_xa_member table lists the member nodes participating in a distributed XA transaction managed by the Spider engine.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/encryption/data-at-rest-encryption/aria-encryption/README.md
+++ b/server/security/encryption/data-at-rest-encryption/aria-encryption/README.md
@@ -23,3 +23,50 @@ layout:
 
 # Aria Encryption
 
+{% columns %}
+{% column %}
+{% content-ref url="aria-encryption-overview.md" %}
+[aria-encryption-overview.md](aria-encryption-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to encrypting Aria tables, covering the necessary system variables (aria_encrypt_tables, encrypt_tmp_disk_tables) and how to verify encryption status by inspecting data files.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-enabling-encryption.md" %}
+[aria-enabling-encryption.md](aria-enabling-encryption.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Step-by-step guide to enabling encryption for user-created and internal temporary Aria tables, including the requirement to manually rebuild existing tables using ALTER TABLE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-encryption-keys.md" %}
+[aria-encryption-keys.md](aria-encryption-keys.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details how Aria manages encryption keys (using ID 1 for user tables and ID 2 for temporary tables) and notes limitations regarding key rotation and per-table key assignment.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aria-disabling-encryption.md" %}
+[aria-disabling-encryption.md](aria-disabling-encryption.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for safely disabling encryption on Aria tables, emphasizing the need to rebuild tables to an unencrypted state before removing key management plugins.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/encryption/data-at-rest-encryption/innodb-encryption/README.md
+++ b/server/security/encryption/data-at-rest-encryption/innodb-encryption/README.md
@@ -23,3 +23,74 @@ layout:
 
 # InnoDB Encryption
 
+{% columns %}
+{% column %}
+{% content-ref url="innodb-encryption-overview.md" %}
+[innodb-encryption-overview.md](innodb-encryption-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to InnoDB's encryption architecture, explaining how data is encrypted/decrypted during disk I/O, the role of the buffer pool (where data is unencrypted), and how to verify encryption stat
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-enabling-encryption.md" %}
+[innodb-enabling-encryption.md](innodb-enabling-encryption.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Step-by-step guide to enabling encryption for InnoDB, covering the configuration of innodb_encrypt_tables for automatic encryption and the use of ENCRYPTED=YES table options for per-table encryption.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-encryption-keys.md" %}
+[innodb-encryption-keys.md](innodb-encryption-keys.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How InnoDB manages encryption keys using 32-bit integer IDs, including the default key ID (innodb_default_encryption_key_id), assigning specific keys to tables, and the process of key rotation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="disabling-innodb-encryption.md" %}
+[disabling-innodb-encryption.md](disabling-innodb-encryption.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for safely disabling encryption on InnoDB tables, emphasizing the critical need to decrypt all tablespaces and redo logs using background threads or ALTER TABLE.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-background-encryption-threads.md" %}
+[innodb-background-encryption-threads.md](innodb-background-encryption-threads.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the operation of background threads (configured via innodb_encryption_threads) which handle key rotation, and the encryption/decryption of tablespaces when global settings.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="innodb-encryption-troubleshooting.md" %}
+[innodb-encryption-troubleshooting.md](innodb-encryption-troubleshooting.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Solutions for common issues such as Error 1005 (Wrong create options) when configuring encryption, and handling cases where encryption key IDs are set for unencrypted tables.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/README.md
+++ b/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/README.md
@@ -23,3 +23,86 @@ layout:
 
 # Key Management and Encryption Plugins
 
+{% columns %}
+{% column %}
+{% content-ref url="encryption-key-management.md" %}
+[encryption-key-management.md](encryption-key-management.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Overview of key management in MariaDB, discussing the need for plugins to manage encryption keys, support for multiple keys (ID 1 for system, ID 2 for temp), and key rotation capabilities.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="file-key-management-encryption-plugin.md" %}
+[file-key-management-encryption-plugin.md](file-key-management-encryption-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Details the File Key Management plugin, which reads encryption keys from a plain-text (or encrypted) file, serving as a simple solution or reference implementation for data-at-rest encryption.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aws-key-management-encryption-plugin.md" %}
+[aws-key-management-encryption-plugin.md](aws-key-management-encryption-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to the AWS Key Management plugin, which uses Amazon KMS to generate and store master keys, decrypting them at startup to enable data-at-rest encryption with key rotation support.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aws-key-management-encryption-plugin-advanced-usage.md" %}
+[aws-key-management-encryption-plugin-advanced-usage.md](aws-key-management-encryption-plugin-advanced-usage.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Step-by-step tutorial for setting up the AWS KMS plugin, covering the creation of a Customer Master Key (CMK) in AWS, configuring IAM roles for EC2, and installing the plugin from source.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="aws-key-management-encryption-plugin-setup-guide.md" %}
+[aws-key-management-encryption-plugin-setup-guide.md](aws-key-management-encryption-plugin-setup-guide.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Advanced configuration guide for the AWS KMS plugin, detailing how to secure key access using IAM policies, restrict usage by IP address, and implement Multi-Factor Authentication (MFA).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="hashicorp-key-management-plugin.md" %}
+[hashicorp-key-management-plugin.md](hashicorp-key-management-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guide to using the HashiCorp Key Management plugin, which integrates MariaDB with HashiCorp Vault for centralized, secure key storage and lifecycle management.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="uninstall-key-management-plugins.md" %}
+[uninstall-key-management-plugins.md](uninstall-key-management-plugins.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Final step of removing key management plugins from the configuration once all data and logs have been confirmed as unencrypted.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Part of the DOCS-5973 Server landing-page columns campaign (batch 5o — depth-5, landings-only). All descriptions reused verbatim from existing child frontmatter (no authoring, no child edits).

| Landing page | Columns |
|---|---|
| `security/encryption/data-at-rest-encryption/aria-encryption/README.md` | 4 |
| `.../data-at-rest-encryption/innodb-encryption/README.md` | 6 |
| `.../data-at-rest-encryption/key-management-and-encryption-plugins/README.md` | 7 |
| `reference/data-types/string-data-types/character-sets/README.md` | 5 |
| `reference/system-tables/sys-schema/sys-schema-stored-procedures/README.md` | 7 |
| `reference/system-tables/the-mysql-database-tables/spider-mysql-database-tables/README.md` | 9 |
| `reference/product-development/mariadb-internals/mariadb-source-code-internals/README.md` | 2 |

## Verification
- Column balances all match (4/6/7/5/7/9/2); all 40 content-ref targets resolve.
- Landings contain no external/`/broken/` links; codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)