### PR TITLE
DOCS-5973: Columnize advanced-configurations + cassandra depth-5 landings (batch 5q)

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/README.md
@@ -24,3 +24,63 @@ layout:
 # Advanced Configuration
 
 Articles of how to setup your MariaDB optimally on different systems
+
+{% columns %}
+{% column %}
+{% content-ref url="atomic-write-support.md" %}
+[atomic-write-support.md](atomic-write-support.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the concept of atomic writes in MariaDB, which improve performance and data integrity on SSDs by bypassing the InnoDB doublewrite buffer, supported on devices like Fusion-io and Shannon SSDs.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configuring-linux-for-mariadb.md" %}
+[configuring-linux-for-mariadb.md](configuring-linux-for-mariadb.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guidance on tuning Linux kernel settings for MariaDB performance, including I/O schedulers (using `none` or `mq-deadline`), open file limits, and core file sizes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configuring-mariadb-for-optimal-performance.md" %}
+[configuring-mariadb-for-optimal-performance.md](configuring-mariadb-for-optimal-performance.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete MariaDB performance tuning: innodb_buffer_pool_size, aria_pagecache_buffer_size, thread_handling configuration, and SHOW GLOBAL STATUS monitoring.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configuring-swappiness.md" %}
+[configuring-swappiness.md](configuring-swappiness.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Recommendations for setting the Linux `vm.swappiness` kernel parameter (ideally to 1) to prevent the OS from swapping out MariaDB memory pages, which degrades performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="fusion-io/" %}
+[fusion-io](fusion-io/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Introduction to using Fusion-io flash memory cards with MariaDB to significantly boost I/O throughput and reduce latency, including benefits like atomic write support.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/legacy-storage-engines/cassandra/README.md
+++ b/server/server-usage/storage-engines/legacy-storage-engines/cassandra/README.md
@@ -9,3 +9,14 @@ description: >-
 {% include "../../../../.gitbook/includes/the-cassandra-storage-engin....md" %}
 
 A storage engine interface to [Cassandra](https://cassandra.apache.org/). Read the original [announcement information about CassandraSE](https://mariadb.org/announcing-the-cassandra-storage-engine/).
+
+- [Building Cassandra Storage Engine for Packaging](building-cassandra-storage-engine-for-packaging.md)
+- [Building Cassandra Storage Engine](building-cassandra-storage-engine.md)
+- [Cassandra Status Variables](cassandra-status-variables.md)
+- [Cassandra Storage Engine Future Plans](cassandra-storage-engine-future-plans.md)
+- [Cassandra Storage Engine Issues](cassandra-storage-engine-issues.md)
+- [Cassandra Storage Engine Overview](cassandra-storage-engine-overview.md)
+- [Cassandra Storage Engine Use Example](cassandra-storage-engine-use-example.md)
+- [Cassandra System Variables](cassandra-system-variables.md)
+- [Handling Joins With Cassandra](handling-joins-with-cassandra.md)
+- [Virtual Machine to Test the Cassandra Storage Engine](virtual-machine-to-test-the-cassandra-storage-engine.md)


### PR DESCRIPTION
Finishes the in-scope depth-5 landing pages for the DOCS-5973 landing-page campaign.

## Pages
- **`mariadb-performance-advanced-configurations`** → `{% columns %}` for its 5 children (SUMMARY order). Each child already had a real frontmatter `description:`, reused verbatim inline.
- **`legacy-storage-engines/cassandra`** → plain bulleted link list for its 10 children (SUMMARY order, no descriptions). All 10 children share one identical placeholder description ("removed in 10.6"), so columns would repeat the same sentence ten times — bullets match the description-less-catalog treatment used elsewhere in the campaign.

Landing-only edits; no child pages touched. Column/bullet order matches `server/SUMMARY.md`.

## Depth-5 status
This completes depth-5's in-scope pages. Deferred by decision: the 2 Enterprise ColumnStore single-node runbooks (curated, left as-is) and 10 orphan `sql-structure/geometry/*` stubs (not in SUMMARY → routed to DOCS-6308's sibling orphan sweep, DOCS-6307).

## Checks
codespell + lychee (via `doc-lint.sh`) pass; GitBook blocks balanced (columns 5/5, content-ref 5/5); all link targets verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)