### PR TITLE
DOCS-5973: Columnize 11 small depth-6 landings (batch 6b)

### DIFF
--- a/server/reference/data-types/string-data-types/character-sets/internationalization-and-localization/README.md
+++ b/server/reference/data-types/string-data-types/character-sets/internationalization-and-localization/README.md
@@ -6,3 +6,62 @@ description: >-
 
 # Internationalization and Localization
 
+{% columns %}
+{% column %}
+{% content-ref url="coordinated-universal-time.md" %}
+[coordinated-universal-time.md](coordinated-universal-time.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Coordinated Universal Time (UTC) is the primary time standard by which the world regulates clocks and time, and is the internal storage format for MariaDB timestamp values.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="locales-plugin.md" %}
+[locales-plugin.md](locales-plugin.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+The LOCALES plugin enables the INFORMATION_SCHEMA.LOCALES table and SHOW LOCALES statement, allowing users to view all locales compiled into the server.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="server-locale.md" %}
+[server-locale.md](server-locale.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Server locale settings control the language for date and time functions via lc_time_names and the language for error messages via lc_messages.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="setting-the-language-for-error-messages.md" %}
+[setting-the-language-for-error-messages.md](setting-the-language-for-error-messages.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Learn how to configure the lc_messages and lc_messages_dir system variables to display server error messages in a supported local language.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="time-zones.md" %}
+[time-zones.md](time-zones.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How MariaDB tracks and converts time zone settings, including named time zones, the time-zone system tables, and per-session configuration.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/quality/qa-datasets/README.md
+++ b/server/reference/product-development/server-development/quality/qa-datasets/README.md
@@ -6,3 +6,50 @@ description: >-
 
 # QA Datasets
 
+{% columns %}
+{% column %}
+{% content-ref url="dbt-3-dataset.md" %}
+[dbt-3-dataset.md](dbt-3-dataset.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on the standardized datasets and database dumps used for DBT-3 Dataset tests.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="dbt-3-queries.md" %}
+[dbt-3-queries.md](dbt-3-queries.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on the standardized datasets and database dumps used for DBT-3 Queries tests.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="openstreetmap-dataset.md" %}
+[openstreetmap-dataset.md](openstreetmap-dataset.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on the standardized datasets and database dumps used for OpenStreetMap tests.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="osmdb06sql.md" %}
+[osmdb06sql.md](osmdb06sql.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information on the standardized datasets and database dumps used for OpenStreetMap.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/README.md
+++ b/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # LOAD Data into Tables or Index
 
+{% columns %}
+{% column %}
+{% content-ref url="load-data-infile.md" %}
+[load-data-infile.md](load-data-infile.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Import rows into a table at high speed from a text file, with control over field and line formatting, column mapping, and duplicate handling.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="load-index.md" %}
+[load-index.md](load-index.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Preload table indexes into the key cache. This command, used for MyISAM tables, loads index blocks into memory to warm up the cache and improve subsequent query performance.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="load-xml.md" %}
+[load-xml.md](load-xml.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Read data from an XML file into a table. This command parses XML content, mapping elements and attributes to table columns for direct data import.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/selecting-data/common-table-expressions/README.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/common-table-expressions/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Common Table Expressions (CTE)
 
+{% columns %}
+{% column %}
+{% content-ref url="recursive-common-table-expressions-overview.md" %}
+[recursive-common-table-expressions-overview.md](recursive-common-table-expressions-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Process hierarchical data using recursive CTEs. These expressions reference themselves to repeatedly execute a subquery, perfect for traversing tree structures or generating sequences.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="non-recursive-common-table-expressions-overview.md" %}
+[non-recursive-common-table-expressions-overview.md](non-recursive-common-table-expressions-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Define simple temporary result sets. Non-recursive CTEs act like query-local views, improving readability by allowing you to define and reuse subqueries within a single statement.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="with.md" %}
+[with.md](with.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Complete WITH clause reference: WITH [RECURSIVE] AS (SELECT...) syntax, recursive CTE support, CYCLE...RESTRICT cycle detection, and max_recursive_iterations.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/fusion-io/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/fusion-io/README.md
@@ -23,3 +23,14 @@ layout:
 
 # Fusion-io
 
+{% columns %}
+{% column %}
+{% content-ref url="fusion-io-introduction.md" %}
+[fusion-io-introduction.md](fusion-io-introduction.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Fusion-io develops PCIe based NAND flash memory cards and related software that can be used to speed up MariaDB databases.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/rpm/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/rpm/README.md
@@ -23,3 +23,110 @@ layout:
 
 # Installing MariaDB RPM Files
 
+{% columns %}
+{% column %}
+{% content-ref url="about-the-mariadb-rpm-files.md" %}
+[about-the-mariadb-rpm-files.md](about-the-mariadb-rpm-files.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides an overview of the RPM packages available for MariaDB, listing the various RPMs such as server, client, backup, and shared libraries, and explaining their contents and dependencies.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="yum.md" %}
+[yum.md](yum.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+How to install MariaDB on systems that use the yum or dnf package managers
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-with-zypper.md" %}
+[installing-mariadb-with-zypper.md](installing-mariadb-with-zypper.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Detailed steps for installing MariaDB on SLES and OpenSUSE using the `zypper` package manager, including repository configuration and package installation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="checking-mariadb-rpm-package-signatures.md" %}
+[checking-mariadb-rpm-package-signatures.md](checking-mariadb-rpm-package-signatures.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on how to verify the integrity of MariaDB RPM packages using GPG signatures, including importing the public key and running `rpm --checksig`.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-mariadb-with-the-rpm-tool.md" %}
+[installing-mariadb-with-the-rpm-tool.md](installing-mariadb-with-the-rpm-tool.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide to installing MariaDB using the low-level `rpm` command, suitable for situations where package managers like `yum` or `dnf` are not available or preferred.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-for-directadmin-using-rpms.md" %}
+[mariadb-for-directadmin-using-rpms.md](mariadb-for-directadmin-using-rpms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Specific instructions for installing MariaDB RPMs on servers running the DirectAdmin control panel, including necessary configuration edits to prevent conflicts.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-installation-version-10121-via-rpms-on-centos-7.md" %}
+[mariadb-installation-version-10121-via-rpms-on-centos-7.md](mariadb-installation-version-10121-via-rpms-on-centos-7.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A detailed walkthrough for installing a specific legacy version of MariaDB (10.1.21) on CentOS 7 using individual RPM packages, including dependency resolution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="troubleshooting-mariadb-installs-on-rhel-centos.md" %}
+[troubleshooting-mariadb-installs-on-rhel-centos.md](troubleshooting-mariadb-installs-on-rhel-centos.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Solutions for common installation issues on RHEL and CentOS, such as conflicts with existing MySQL installations and handling configuration file backups (.rpmsave).
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="why-source-rpms-srpms-arent-packaged-for-some-platforms.md" %}
+[why-source-rpms-srpms-arent-packaged-for-some-platforms.md](why-source-rpms-srpms-arent-packaged-for-some-platforms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the limitations in providing Source RPMs (SRPMs) for certain platforms due to CMake version requirements and build system dependencies.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/compiling-mariadb-with-extra-modulesoptions/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/compiling-mariadb-with-extra-modulesoptions/README.md
@@ -23,3 +23,26 @@ layout:
 
 # Compiling MariaDB with Extra Modules/Options
 
+{% columns %}
+{% column %}
+{% content-ref url="specifying-which-plugins-to-build.md" %}
+[specifying-which-plugins-to-build.md](specifying-which-plugins-to-build.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to use CMake options like `PLUGIN_xxx` to control which plugins are built statically, dynamically, or not at all during compilation.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="using-mariadb-with-tcmalloc-or-jemalloc.md" %}
+[using-mariadb-with-tcmalloc-or-jemalloc.md](using-mariadb-with-tcmalloc-or-jemalloc.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on building and configuring MariaDB to use alternative memory allocators like TCMalloc or jemalloc for improved performance and profiling.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/troubleshooting-installation-issues/installation-issues-on-debian-and-ubuntu/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/troubleshooting-installation-issues/installation-issues-on-debian-and-ubuntu/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Installation Issues on Debian and Ubuntu
 
+{% columns %}
+{% column %}
+{% content-ref url="apt-upgrade-fails-but-the-database-is-running.md" %}
+[apt-upgrade-fails-but-the-database-is-running.md](apt-upgrade-fails-but-the-database-is-running.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Solutions for when `apt-get upgrade` hangs or fails because the MariaDB service takes too long to start, triggering a timeout in the init script.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="differences-in-mariadb-in-debian-and-ubuntu.md" %}
+[differences-in-mariadb-in-debian-and-ubuntu.md](differences-in-mariadb-in-debian-and-ubuntu.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains the differences between official Debian/Ubuntu repository packages and those from MariaDB.org, particularly regarding library linking and configuration defaults.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-5533-debian-and-ubuntu-installation-issues.md" %}
+[mariadb-5533-debian-and-ubuntu-installation-issues.md](mariadb-5533-debian-and-ubuntu-installation-issues.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Specific instructions for resolving dependency breakage that occurred with the release of MariaDB 5.5.33 on Debian and Ubuntu systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-debian-live-images.md" %}
+[mariadb-debian-live-images.md](mariadb-debian-live-images.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Information about using MariaDB Debian Live images for testing and offline installation, including boot options and default credentials.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="moving-from-mysql-to-mariadb-in-debian-9.md" %}
+[moving-from-mysql-to-mariadb-in-debian-9.md](moving-from-mysql-to-mariadb-in-debian-9.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide on migrating from MySQL 5.5 to MariaDB 10.1 during an operating system upgrade to Debian 9 (Stretch).
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/platform-specific-upgrade-guides/upgrading-on-linux/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/platform-specific-upgrade-guides/upgrading-on-linux/README.md
@@ -20,3 +20,26 @@ layout:
 
 # Upgrading on Linux
 
+{% columns %}
+{% column %}
+{% content-ref url="../../upgrading-between-major-mariadb-versions.md" %}
+[../../upgrading-between-major-mariadb-versions.md](../../upgrading-between-major-mariadb-versions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade between major MariaDB versions, which is normally straightforward thanks to backward-compatible data files, connection protocol, and replication.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="../../upgrading-between-minor-versions-on-linux.md" %}
+[../../upgrading-between-minor-versions-on-linux.md](../../upgrading-between-minor-versions-on-linux.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Step-by-step minor version upgrade (e.g., 11.4.4 to 11.4.5) for MariaDB Community Server on Linux using YUM, APT, or ZYpp — backup, stop, upgrade packages, restart, and run mariadb-upgrade.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # Archived Upgrade Guides (Unmaintained/EOL ES Versions)
 
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-10.5/" %}
+[mariadb-enterprise-server-10.5](mariadb-enterprise-server-10.5/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A collection of upgrade guides for older, end-of-life versions of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-10.4/" %}
+[mariadb-enterprise-server-10.4](mariadb-enterprise-server-10.4/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A collection of upgrade guides for older, end-of-life versions of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="mariadb-enterprise-server-10.3/" %}
+[mariadb-enterprise-server-10.3](mariadb-enterprise-server-10.3/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A collection of upgrade guides for older, end-of-life versions of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # MariaDB Enterprise Server 10.6
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-10.6.md" %}
+[upgrade-to-mariadb-enterprise-server-10.6.md](upgrade-to-mariadb-enterprise-server-10.6.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade documentation for MariaDB Enterprise Server 10.6, featuring Atomic DDL support, JSON_TABLE function, improved Oracle compatibility modes, and the removal of older storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md" %}
+[upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md](upgrade-mariadb-enterprise-server-from-10.6.x-to-10.6.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade documentation for MariaDB Enterprise Server 10.6, featuring Atomic DDL support, JSON_TABLE function, improved Oracle compatibility modes, and the removal of older storage engines.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.6.md" %}
+[upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.6.md](upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.6.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade documentation for MariaDB Enterprise Server 10.6, featuring Atomic DDL support, JSON_TABLE function, improved Oracle compatibility modes, and the removal of older storage engines.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Depth-6 landing-page campaign, batch 6b — the small landings whose children are all already described.

## Pages → columns (child frontmatter descriptions reused verbatim inline)
internationalization-and-localization (5), qa-datasets (4), load-data-into-tables-or-index (3), common-table-expressions (3), fusion-io (1), rpm (9), compiling-mariadb-with-extra-modulesoptions (2), installation-issues-on-debian-and-ubuntu (5), upgrading-on-linux (2), upgrade-paths/archived (3), mariadb-enterprise-server-10.6 (3).

## Boilerplate fixed inline (3)
Three child descriptions surfaced the "Complete…Complete" / dangling-"and." pattern; rewritten in the landing column (not in the child frontmatter, to keep child link-debt out of lychee scope):
- **time-zones**, **load-data-infile**, **upgrading-between-major** (on upgrading-on-linux).

Landing-only edits; frontmatter + heading preserved. Column order matches `server/SUMMARY.md`. All 40 content-ref targets verified to exist (including the cross-tree upgrading reference). No external links introduced.

## Checks
codespell passes; block balance and link targets verified locally; lychee runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)