### PR TITLE
DOCS-5973: Columnize 4 depth-6 landings with authored descriptions (batch 6c)

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/replication-statements/legacy-replication-statements/README.md
+++ b/server/reference/sql-statements/administrative-sql-statements/replication-statements/legacy-replication-statements/README.md
@@ -4,3 +4,62 @@ description: Category for old replication statements
 
 # Legacy Replication Statements
 
+{% columns %}
+{% column %}
+{% content-ref url="legacy-commands-reset-slave.md" %}
+[legacy-commands-reset-slave.md](legacy-commands-reset-slave.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Former name for RESET REPLICA, kept as an alias; resets a replica's connection and position information.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="legacy-commands-show-slave-hosts.md" %}
+[legacy-commands-show-slave-hosts.md](legacy-commands-show-slave-hosts.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Former name for SHOW REPLICA HOSTS, kept as an alias; lists the replicas registered with a primary.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="legacy-commands-show-slave-status.md" %}
+[legacy-commands-show-slave-status.md](legacy-commands-show-slave-status.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Former name for SHOW REPLICA STATUS, kept as an alias; reports a replica's connection, thread, and position state.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="legacy-commands-start-slave.md" %}
+[legacy-commands-start-slave.md](legacy-commands-start-slave.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Former name for START REPLICA, kept as an alias; starts the replica threads.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="legacy-commands-stop-slave.md" %}
+[legacy-commands-stop-slave.md](legacy-commands-stop-slave.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Former name for STOP REPLICA, kept as an alias; stops the replica threads.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/sql-statements/data-manipulation/selecting-data/set-operations/README.md
+++ b/server/reference/sql-statements/data-manipulation/selecting-data/set-operations/README.md
@@ -7,3 +7,62 @@ description: >-
 
 # Set Operations
 
+{% columns %}
+{% column %}
+{% content-ref url="precedence-control-in-table-operations.md" %}
+[precedence-control-in-table-operations.md](precedence-control-in-table-operations.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Control the execution order of UNION, EXCEPT, and INTERSECT operations. Learn how to use parentheses to define explicit operation priority.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="except.md" %}
+[except.md](except.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return rows from the first result set that do not appear in the second. This set operator performs a subtraction of two datasets.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="intersect.md" %}
+[intersect.md](intersect.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Return only the rows that appear in both result sets. INTERSECT implicitly applies DISTINCT and follows the same column-naming, ORDER BY, and LIMIT rules as UNION.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="minus.md" %}
+[minus.md](minus.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Oracle-compatible synonym for the EXCEPT operator. It returns rows from the first query that are not present in the second query.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="union.md" %}
+[union.md](union.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Combine results from multiple SELECT statements into a single result set. This operator can optionally remove duplicates or include all rows.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # MariaDB Enterprise Server 11.4
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-11.4.md" %}
+[upgrade-to-mariadb-enterprise-server-11.4.md](upgrade-to-mariadb-enterprise-server-11.4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for upgrading to MariaDB Enterprise Server 11.4, which introduces new data types like UUID and INET4, advanced JSON functions, and non-blocking online schema changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-11.4.x-to-11.4.y.md" %}
+[upgrade-mariadb-enterprise-server-from-11.4.x-to-11.4.y.md](upgrade-mariadb-enterprise-server-from-11.4.x-to-11.4.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for upgrading to MariaDB Enterprise Server 11.4, which introduces new data types like UUID and INET4, advanced JSON functions, and non-blocking online schema changes.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-10.6-to-11.4.md" %}
+[upgrade-mariadb-enterprise-server-from-10.6-to-11.4.md](upgrade-mariadb-enterprise-server-from-10.6-to-11.4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade MariaDB Enterprise Server from 10.6 to 11.4, covering the query-optimizer changes introduced in 11.0, with both a standard in-place upgrade and a staged, replication-based rollout.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md" %}
+[upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md](upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for upgrading to MariaDB Enterprise Server 11.4, which introduces new data types like UUID and INET4, advanced JSON functions, and non-blocking online schema changes.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/README.md
@@ -7,3 +7,50 @@ description: >-
 
 # MariaDB Enterprise Server 11.8
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-11.8.md" %}
+[upgrade-to-mariadb-enterprise-server-11.8.md](upgrade-to-mariadb-enterprise-server-11.8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade guide for MariaDB Enterprise Server 11.8, highlighting significant performance improvements in transactional throughput, new vector search optimizations, and enhanced observability features.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-11.8.x-to-11.8.y.md" %}
+[upgrade-mariadb-enterprise-server-from-11.8.x-to-11.8.y.md](upgrade-mariadb-enterprise-server-from-11.8.x-to-11.8.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions for performing a minor release upgrade of MariaDB Enterprise Server within the 11.8 series, from an earlier 11.8.x release to a later 11.8.y release.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md" %}
+[upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md](upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Perform a major-version upgrade of MariaDB Enterprise Server directly from 10.6 to 11.8 on systemd-based Linux, including prerequisites, backup, and the upgrade procedure.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md" %}
+[upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md](upgrade-from-mariadb-community-server-10.6-to-mariadb-enterprise-server-11.8.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Upgrade directly from MariaDB Community Server 10.6 to MariaDB Enterprise Server 11.8 — combining a product switch (Community to Enterprise) and a major version jump (10.6 to 11.8) in a single upgrade
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Depth-6 landing-page campaign, batch 6c — the small landings that needed authored descriptions. Completes depth-6's in-scope pages.

## Pages → columns (8 descriptions authored inline; rest reused verbatim)
- **`legacy-replication-statements`** (5): the SLAVE statements — each described as the former name for its REPLICA equivalent, kept as an alias (matches each page's "Old name for…" content).
- **`set-operations`** (5): authored INTERSECT (rows in both result sets; implicitly DISTINCT; same naming/ORDER BY/LIMIT rules as UNION). Kept the page's pre-10.6 version note out of the landing prose per house style.
- **`upgrade-paths/mariadb-enterprise-server-11.4`** (4): authored the 10.6→11.4 upgrade path.
- **`upgrade-paths/mariadb-enterprise-server-11.8`** (4): authored the 10.6→11.8 upgrade path.

Authored descriptions live inline on the landings; no child pages edited. Column order matches `server/SUMMARY.md`. All 18 content-ref targets verified; no external links introduced.

## Checks
codespell passes; block balance + link targets verified locally; lychee runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)