### PR TITLE
DOCS-5973: Bullet-list 2 depth-7 benchmark landings (batch 7a)

### DIFF
--- a/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmark-results/README.md
+++ b/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmark-results/README.md
@@ -1,2 +1,19 @@
+---
+description: >-
+  Historical sysbench and thread-pool benchmark results collected during MariaDB
+  Server development.
+---
+
 # Benchmark Results
 
+- [sysbench v0.5 - Single Five Minute Runs on T500 Laptop](sysbench-v0.5-single-five-minute-runs-on-t500-laptop.md)
+- [sysbench v0.5 - Three Times Five Minutes Runs on work with 5.1.42](sysbench-v0.5-three-times-five-minutes-runs-on-work-with-5.1.42.md)
+- [sysbench v0.5 - 3x Five Minute Runs on work with 5.2-wl86](sysbench-v0.5-3x-five-minute-runs-on-work-with-5.2-wl86.md)
+- [sysbench v0.5 - 3x Five Minute Runs on work with 5.1 vs. 5.2-wl86](sysbench-v0.5-3x-five-minute-runs-on-work-with-5.1-vs.-5.2-wl86.md)
+- [sysbench v0.5 - 3x 15 Minute Runs on perro with 5.2-wl86 a](sysbench-v0.5-3x-15-minute-runs-on-perro-with-5.2-wl86-a.md)
+- [sysbench v0.5 - 3x 15 Minute Runs on perro with 5.2-wl86 b](sysbench-v0.5-3x-15-minute-runs-on-perro-with-5.2-wl86-b.md)
+- [Select Random Ranges and Select Random Point](select-random-ranges-and-select-random-point.md)
+- [Sysbench Results](sysbench-results.md)
+- [sysbench v0.5 - Single Five Minute Runs on perro](sysbench-v0.5-single-five-minute-runs-on-perro.md)
+- [sysbench v0.5 - Single Five Minute Runs on work](sysbench-v0.5-single-five-minute-runs-on-work.md)
+- [Threadpool Benchmarks](threadpool-benchmarks.md)

--- a/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/README.md
+++ b/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/README.md
@@ -1,2 +1,23 @@
+---
+description: >-
+  Benchmark tools, setups, and results used in MariaDB Server development,
+  covering sysbench, DBT3, RQG, and engine-specific performance tests.
+---
+
 # Benchmarks
 
+- [Benchmark Builds](benchmark-builds.md)
+- [Benchmarking Aria](benchmarking-aria.md)
+- [DBT3 Automation Scripts](dbt3-automation-scripts.md)
+- [DBT3 Benchmark Results InnoDB](dbt3-benchmark-results-innodb.md)
+- [DBT3 Benchmark Results MyISAM](dbt3-benchmark-results-myisam.md)
+- [DBT3 Example Preparation Time](dbt3-example-preparation-time.md)
+- [MariaDB 5.3 - Asynchronous I/O on Windows with InnoDB](mariadb-53-asynchronous-io-on-windows-with-innodb.md)
+- [MariaDB 5.3/MySQL 5.5 Windows performance patches](mariadb-53mysql-55-windows-performance-patches.md)
+- [mariadb-tools](mariadb-tools.md)
+- [Performance of MEMORY Tables](performance-of-memory-tables.md)
+- [Recommended Settings for Benchmarks](recommended-settings-for-benchmarks.md)
+- [RQG Performance Comparisons](rqg-performance-comparisons.md)
+- [run-sql-bench.pl](run-sql-benchpl.md)
+- [Segmented Key Cache Performance](segmented-key-cache-performance.md)
+- [sysbench Benchmark Setup](sysbench-benchmark-setup.md)


### PR DESCRIPTION
Depth-7 landing-page campaign, batch 7a — the two description-less benchmark landings.

## Pages → bulleted link lists (SUMMARY order, no descriptions)
- `reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmark-results` (11 sysbench/thread-pool run dumps)
- `…/benchmarks-and-long-running-tests/benchmarks` (15 benchmark tools/setups/results)

Both are description-less historical lists, so bullets rather than columns. Both pages lacked frontmatter entirely, so a short `description:` was added to each to satisfy the frontmatter requirement.

Landing-only edits; heading preserved. All 26 bullet targets verified; no external links introduced.

## Checks
codespell passes; bullet targets verified locally; lychee runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)