### PR TITLE
DOCS-5973: Columnize 11 depth-7/8/9 landings (batch 7b)

### DIFF
--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/README.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/README.md
@@ -30,3 +30,75 @@ generally an 8Gb image was configured, of which 1/2 Gb was reserved for swap\
 and the rest for a single root partition "/".
 
 For details on setting up a host server to run these VMs, see [Buildbot Setup for VM host](../buildbot-setup-for-vm-host.md).
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-freebsd-92.md" %}
+[buildbot-setup-for-virtual-machines-freebsd-92.md](buildbot-setup-for-virtual-machines-freebsd-92.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-general-principles.md" %}
+[buildbot-setup-for-virtual-machines-general-principles.md](buildbot-setup-for-virtual-machines-general-principles.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-additional-steps/" %}
+[buildbot-setup-for-virtual-machines-additional-steps](buildbot-setup-for-virtual-machines-additional-steps/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian/" %}
+[buildbot-setup-for-virtual-machines-debian](buildbot-setup-for-virtual-machines-debian/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-red-hat/" %}
+[buildbot-setup-for-virtual-machines-red-hat](buildbot-setup-for-virtual-machines-red-hat/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu/" %}
+[buildbot-setup-for-virtual-machines-ubuntu](buildbot-setup-for-virtual-machines-ubuntu/)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-additional-steps/README.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-additional-steps/README.md
@@ -6,3 +6,86 @@ description: >-
 
 # Buildbot Setup for Virtual Machines - Additional Steps
 
+{% columns %}
+{% column %}
+{% content-ref url="install-cassandra-on-fulltest-vms.md" %}
+[install-cassandra-on-fulltest-vms.md](install-cassandra-on-fulltest-vms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="install-cmake-on-build-vms.md" %}
+[install-cmake-on-build-vms.md](install-cmake-on-build-vms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-correct-libraries-for-pam-and-readline.md" %}
+[installing-correct-libraries-for-pam-and-readline.md](installing-correct-libraries-for-pam-and-readline.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-the-boost-library-needed-for-the-oqgraph-storage-engine.md" %}
+[installing-the-boost-library-needed-for-the-oqgraph-storage-engine.md](installing-the-boost-library-needed-for-the-oqgraph-storage-engine.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="installing-vm-images-for-testing-deb-upgrade-between-versions.md" %}
+[installing-vm-images-for-testing-deb-upgrade-between-versions.md](installing-vm-images-for-testing-deb-upgrade-between-versions.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="resizing-a-virtual-machine-image.md" %}
+[resizing-a-virtual-machine-image.md](resizing-a-virtual-machine-image.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="update-debian-4-mirrors-for-buildbot-vms.md" %}
+[update-debian-4-mirrors-for-buildbot-vms.md](update-debian-4-mirrors-for-buildbot-vms.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-debian/README.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-debian/README.md
@@ -6,3 +6,74 @@ description: >-
 
 # Buildbot Setup for Virtual Machines - Debian
 
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-4-amd64.md" %}
+[buildbot-setup-for-virtual-machines-debian-4-amd64.md](buildbot-setup-for-virtual-machines-debian-4-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-4-i386.md" %}
+[buildbot-setup-for-virtual-machines-debian-4-i386.md](buildbot-setup-for-virtual-machines-debian-4-i386.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-5-amd64.md" %}
+[buildbot-setup-for-virtual-machines-debian-5-amd64.md](buildbot-setup-for-virtual-machines-debian-5-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-5-i386.md" %}
+[buildbot-setup-for-virtual-machines-debian-5-i386.md](buildbot-setup-for-virtual-machines-debian-5-i386.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-6-amd64.md" %}
+[buildbot-setup-for-virtual-machines-debian-6-amd64.md](buildbot-setup-for-virtual-machines-debian-6-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-debian-6-i386.md" %}
+[buildbot-setup-for-virtual-machines-debian-6-i386.md](buildbot-setup-for-virtual-machines-debian-6-i386.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-red-hat/README.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-red-hat/README.md
@@ -6,3 +6,110 @@ description: >-
 
 # Buildbot Setup for Virtual Machines - Red Hat
 
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-centos-5-amd64.md" %}
+[buildbot-setup-for-virtual-machines-centos-5-amd64.md](buildbot-setup-for-virtual-machines-centos-5-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-centos-5-i386.md" %}
+[buildbot-setup-for-virtual-machines-centos-5-i386.md](buildbot-setup-for-virtual-machines-centos-5-i386.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-centos-62.md" %}
+[buildbot-setup-for-virtual-machines-centos-62.md](buildbot-setup-for-virtual-machines-centos-62.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-fedora-16.md" %}
+[buildbot-setup-for-virtual-machines-fedora-16.md](buildbot-setup-for-virtual-machines-fedora-16.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-fedora-17.md" %}
+[buildbot-setup-for-virtual-machines-fedora-17.md](buildbot-setup-for-virtual-machines-fedora-17.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-fedora-18.md" %}
+[buildbot-setup-for-virtual-machines-fedora-18.md](buildbot-setup-for-virtual-machines-fedora-18.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-fedora-19.md" %}
+[buildbot-setup-for-virtual-machines-fedora-19.md](buildbot-setup-for-virtual-machines-fedora-19.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-fedora-20.md" %}
+[buildbot-setup-for-virtual-machines-fedora-20.md](buildbot-setup-for-virtual-machines-fedora-20.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-red-hat-6-x86.md" %}
+[buildbot-setup-for-virtual-machines-red-hat-6-x86.md](buildbot-setup-for-virtual-machines-red-hat-6-x86.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-ubuntu/README.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-ubuntu/README.md
@@ -6,3 +6,146 @@ description: >-
 
 # Buildbot Setup for Virtual Machines - Ubuntu
 
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1004-alpha-i386-and-amd64.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1004-alpha-i386-and-amd64.md](buildbot-setup-for-virtual-machines-ubuntu-1004-alpha-i386-and-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1010-maverick.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1010-maverick.md](buildbot-setup-for-virtual-machines-ubuntu-1010-maverick.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1104-natty.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1104-natty.md](buildbot-setup-for-virtual-machines-ubuntu-1104-natty.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1110-oneiric.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1110-oneiric.md](buildbot-setup-for-virtual-machines-ubuntu-1110-oneiric.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1204-precise.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1204-precise.md](buildbot-setup-for-virtual-machines-ubuntu-1204-precise.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1210-quantal.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1210-quantal.md](buildbot-setup-for-virtual-machines-ubuntu-1210-quantal.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1304-raring.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1304-raring.md](buildbot-setup-for-virtual-machines-ubuntu-1304-raring.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1310-saucy.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1310-saucy.md](buildbot-setup-for-virtual-machines-ubuntu-1310-saucy.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-1404-trusty.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-1404-trusty.md](buildbot-setup-for-virtual-machines-ubuntu-1404-trusty.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-804-810-and-910.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-804-810-and-910.md](buildbot-setup-for-virtual-machines-ubuntu-804-810-and-910.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-904-amd64.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-904-amd64.md](buildbot-setup-for-virtual-machines-ubuntu-904-amd64.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="buildbot-setup-for-virtual-machines-ubuntu-904-i386.md" %}
+[buildbot-setup-for-virtual-machines-ubuntu-904-i386.md](buildbot-setup-for-virtual-machines-ubuntu-904-i386.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Explains how to provision and configure virtual machine instances specifically for Buildbot testing.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.3/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # MariaDB Enterprise Server 10.3
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-10.3.md" %}
+[upgrade-to-mariadb-enterprise-server-10.3.md](upgrade-to-mariadb-enterprise-server-10.3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-10.3.x-to-10.3.y.md" %}
+[upgrade-mariadb-enterprise-server-from-10.3.x-to-10.3.y.md](upgrade-mariadb-enterprise-server-from-10.3.x-to-10.3.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.3.md" %}
+[upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.3.md](upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.4/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # MariaDB Enterprise Server 10.4
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-10.4.md" %}
+[upgrade-to-mariadb-enterprise-server-10.4.md](upgrade-to-mariadb-enterprise-server-10.4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-10.4.x-to-10.4.y.md" %}
+[upgrade-mariadb-enterprise-server-from-10.4.x-to-10.4.y.md](upgrade-mariadb-enterprise-server-from-10.4.x-to-10.4.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.4.md" %}
+[upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.4.md](upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.4.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/archived/mariadb-enterprise-server-10.5/README.md
@@ -6,3 +6,50 @@ description: >-
 
 # MariaDB Enterprise Server 10.5
 
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-to-mariadb-enterprise-server-10.5.md" %}
+[upgrade-to-mariadb-enterprise-server-10.5.md](upgrade-to-mariadb-enterprise-server-10.5.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-mariadb-enterprise-server-from-10.5.x-to-10.5.y.md" %}
+[upgrade-mariadb-enterprise-server-from-10.5.x-to-10.5.y.md](upgrade-mariadb-enterprise-server-from-10.5.x-to-10.5.y.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.5.md" %}
+[upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.5.md](upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-10.5.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An upgrade guide for an older, end-of-life version of MariaDB Enterprise Server, kept for reference purposes for legacy systems.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="compatibility-and-breaking-changes-for-mariadb-enterprise-server-10.5.md" %}
+[compatibility-and-breaking-changes-for-mariadb-enterprise-server-10.5.md](compatibility-and-breaking-changes-for-mariadb-enterprise-server-10.5.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Technical reference to the architectural changes and breaking points when upgrading to MariaDB Enterprise Server 10.5, such as the completed switch to MariaDB-prefixed executable names.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/federated-mariadb-enterprise-spider-topology-operations/README.md
+++ b/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/federated-mariadb-enterprise-spider-topology-operations/README.md
@@ -6,3 +6,38 @@ description: >-
 
 # Federated MariaDB Enterprise Spider Topology Operations
 
+{% columns %}
+{% column %}
+{% content-ref url="spider-federated-overview.md" %}
+[spider-federated-overview.md](spider-federated-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+An overview of the federated topology for Spider, where a single Spider node aggregates data from multiple remote data nodes, acting as a unified access point.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="federated-mariadb-enterprise-spider-topology-backup-and-restore.md" %}
+[federated-mariadb-enterprise-spider-topology-backup-and-restore.md](federated-mariadb-enterprise-spider-topology-backup-and-restore.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Procedures for performing consistent backups and restores in a federated Spider topology using MariaDB Backup and MariaDB Dump, ensuring data synchronization.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="federated-mariadb-enterprise-spider-topology-migrate-tables.md" %}
+[federated-mariadb-enterprise-spider-topology-migrate-tables.md](federated-mariadb-enterprise-spider-topology-migrate-tables.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+A guide on how to migrate tables from a standard MariaDB deployment to a Federated Spider topology, distributing data across multiple backend nodes.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/odbc-mariadb-enterprise-spider-topology-operations/README.md
+++ b/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/odbc-mariadb-enterprise-spider-topology-operations/README.md
@@ -7,3 +7,14 @@ description: >-
 
 # ODBC MariaDB Enterprise Spider Topology Operations
 
+{% columns %}
+{% column %}
+{% content-ref url="use-spider-odbc-to-connect-to-oracle.md" %}
+[use-spider-odbc-to-connect-to-oracle.md](use-spider-odbc-to-connect-to-oracle.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+This guide details how to configure Spider to connect to an Oracle database via ODBC, enabling data migration and federated access to Oracle tables.
+{% endcolumn %}
+{% endcolumns %}

--- a/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/sharded-mariadb-enterprise-spider-topology-operations/README.md
+++ b/server/server-usage/storage-engines/spider/spider-storage-engine-introduction/mariadb-enterprise-spider-operations/sharded-mariadb-enterprise-spider-topology-operations/README.md
@@ -7,3 +7,38 @@ description: >-
 
 # Sharded MariaDB Enterprise Spider Topology Operations
 
+{% columns %}
+{% column %}
+{% content-ref url="spider-sharded-overview.md" %}
+[spider-sharded-overview.md](spider-sharded-overview.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Provides an overview of using Spider for sharding in MariaDB Enterprise Server, allowing data distribution across multiple nodes for horizontal scalability.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sharded-mariadb-enterprise-spider-topology-add-a-shard.md" %}
+[sharded-mariadb-enterprise-spider-topology-add-a-shard.md](sharded-mariadb-enterprise-spider-topology-add-a-shard.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Instructions on how to expand a sharded Spider topology by adding new data nodes (shards) and rebalancing the data distribution.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="sharded-mariadb-enterprise-spider-topology-backup-and-restore.md" %}
+[sharded-mariadb-enterprise-spider-topology-backup-and-restore.md](sharded-mariadb-enterprise-spider-topology-backup-and-restore.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Guidelines for backing up and restoring a sharded Spider topology, ensuring consistency across multiple shards using tools like MariaDB Backup.
+{% endcolumn %}
+{% endcolumns %}


### PR DESCRIPTION
Depth-7/8/9 landing-page campaign, batch 7b — the final columns batch. Completes the campaign's in-scope pages.

## Pages → columns
- **Archived ES upgrade paths:** mariadb-enterprise-server-10.3 (3), 10.4 (3), 10.5 (4).
- **ES Spider topology-operations:** federated (3), odbc (1), sharded (3).
- **Buildbot VM-setup subtree:** `buildbot-setup-for-virtual-machines` (d8, 6) + d9 `additional-steps` (7), `debian` (6), `red-hat` (9), `ubuntu` (12).

## Notes
- **1 authored description** — ES-10.5 "Compatibility and Breaking Changes" (all other children reused their frontmatter descriptions verbatim).
- **d8 `buildbot-setup-for-virtual-machines`** has a genuine multi-paragraph intro; the 6-child columns were appended after the existing prose (prose and trailing "Buildbot Setup for VM host" link preserved), matching the `database-applications` precedent — not a regenerate.

Authored text lives inline on the landing; no child pages edited. Column order matches `server/SUMMARY.md`. All 57 content-ref targets verified; no external links introduced.

## Checks
codespell passes; block balance + link targets verified locally; lychee runs in CI.

## After this
Only 3 curated prose defers remain in the whole campaign: `data-definition/alter/alter-table`, and ES `innodb/.../schema-changes` — flagged for hand editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)