### PR TITLE
dev-docs: GitBook redirects cookbook + skill/command + cross-links

### DIFF
--- a/.claude/commands/redirects-csv.md
+++ b/.claude/commands/redirects-csv.md
@@ -1,0 +1,21 @@
+---
+description: Build a GitBook redirect CSV for renamed/moved/retired mariadb-docs pages (header source,destination; destination = full URL).
+argument-hint: "(optional) the retired→canonical pairs, a DOCS ticket / PR, or the paths that moved"
+allowed-tools: Bash, Read, Grep, Glob, Write
+---
+
+# /redirects-csv
+
+Run the **`gitbook-redirects`** skill (`.claude/skills/gitbook-redirects/SKILL.md`) for
+`$ARGUMENTS`. Full reference: `dev-docs/cookbook-gitbook-redirects.md`.
+
+In short (full procedure + gotchas in the skill and cookbook):
+1. Gather the old→new pairs from `$ARGUMENTS` (or the current branch's deletions/renames),
+   including retired section/landing pages.
+2. Build the CSV: header **`source,destination`**; `source` = site-relative path
+   (`/server/...`, no `.md`, `README`→dir); `destination` = **full URL**
+   (`https://mariadb.com/docs/server/...`). Verify the base against one live page.
+3. Write it to the scratchpad (never commit it) and hand it to a GitBook site admin to import
+   (Settings → Redirects). It cannot be applied via Git/API/MCP.
+
+Arguments: $ARGUMENTS

--- a/.claude/skills/gitbook-redirects/SKILL.md
+++ b/.claude/skills/gitbook-redirects/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gitbook-redirects
+description: Build a GitBook redirect CSV when mariadb-docs pages are renamed, moved, split, or retired. Use when the user asks to "create a redirects CSV", "make GitBook redirects", "set up redirects for moved/retired pages", or when a page-restructuring task removes or relocates published URLs. Produces the CSV; a GitBook site admin imports it manually (no API/MCP).
+allowed-tools: Bash, Read, Grep, Glob, Write
+owners: [shinz]
+last_verified: 2026-07-06
+status: active
+---
+
+# gitbook-redirects
+
+Produce a **GitBook redirect CSV** so old URLs don't dead-end after pages are renamed, moved,
+split, or retired. `mariadb-docs` has no in-repo redirect mechanism; GitBook redirects are
+configured **manually** in the site UI (no API/MCP), so this skill's deliverable is the CSV — a
+GitBook site admin imports it.
+
+Full reference (read it): **`dev-docs/cookbook-gitbook-redirects.md`**. This skill is the
+procedure; the cookbook is the canonical explanation.
+
+## When to use
+
+The user says: "create a redirects CSV", "make GitBook redirects", "redirect the old URLs",
+"set up redirects for the pages we moved/retired". Also run it as a follow-up whenever a task
+(often a `DOCS-XXXX` consolidation, split, or rename) removes or relocates published URLs — in
+**addition** to repointing in-repo inbound links (lychee only catches in-repo breakage).
+
+## Procedure
+
+1. **Gather the old → new pairs.** From the task, the PR diff, or the user: every retired/moved
+   page (its old path) and where it now lives (the surviving canonical page). Include retired
+   **section/landing** pages too, pointed at the nearest surviving landing — not just leaf pages.
+   For deletions, `git log --diff-filter=D --name-only` on the branch lists what was removed.
+
+2. **Derive each path:**
+   - old URL → **`source`**: a **site-relative path** with leading slash, including the space
+     prefix, `.md` dropped, `README.md` → its directory. Server space = `/server/...`.
+   - new page → **`destination`**: a **full absolute URL** — `https://mariadb.com/docs/server/<path>`.
+   - Watch slug quirks: the on-disk basename is the slug (suffixes like `-1` carry through).
+
+3. **Verify the base once.** Open one real canonical page in a browser (or confirm with the
+   user) that its live URL matches the `https://mariadb.com/docs/server/...` you generated. If
+   the host/base differs, it's a find-and-replace on the prefix.
+
+4. **Write the CSV** to a working file outside the repo (e.g. the scratchpad — it is **not**
+   committed):
+   - Header **exactly** `source,destination`.
+   - One row per retired page + section landing.
+
+5. **Hand it off.** Tell the user to import it in GitBook → the site → **Settings → Redirects**
+   (single redirect or CSV import). Note the two failure modes so they can self-diagnose:
+   `Invalid destination URL` → a destination isn't a full URL; a header error → it isn't
+   `source,destination`.
+
+## Output shape
+
+```csv
+source,destination
+/server/server-usage/basics/mariadb-usage-guide-1,https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-usage-guide
+```
+
+## Guardrails
+
+- **Do not** commit the CSV to the repo, and **do not** attempt the import yourself — there is
+  no Git/API/MCP path; it's a manual GitBook UI action by a site admin.
+- Still repoint in-repo inbound links to the retired pages separately (that's not what
+  redirects cover).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Guidance for Claude Code (and other AI agents) working in the **MariaDB document
 - **`bulk-campaign`** — drive a batched, verified, resumable multi-file pass across one space (e.g. a railroad-diagram campaign or a terminology rename), tied to a DOCS ticket; keeps one campaign fact-check report.
 - **`propose-improvement`** (`/propose-improvement <topic>`) — file an agent-tooling proposal (new skill or broader change) as a DOCS Task + write the interviewed proposal MD.
 - **`report-skill-bug`** (`/skill-bug <name>`) — file a DOCS Task (label `claude-skill-bug`) when a skill breaks.
+- **`gitbook-redirects`** (`/redirects-csv`) — build a GitBook redirect CSV when pages are renamed/moved/retired (header `source,destination`; destination must be a full URL). Reference: `dev-docs/cookbook-gitbook-redirects.md`.
 
 ## Agent-tooling layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Guidance for Claude Code (and other AI agents) working in the **MariaDB document
 | Pre-PR checklist (mirror CI locally) | `dev-docs/cookbook-pre-pr.md` |
 | DOCS Jira workflow (project facts, transitions, branch model) | `dev-docs/cookbook-jira-workflow.md` |
 | Fact-check paper trail (report format, where it lives, lifecycle) | `dev-docs/cookbook-fact-trail.md` |
+| GitBook redirects (CSV format for retired/moved URLs) | `dev-docs/cookbook-gitbook-redirects.md` |
 
 ## Skills
 

--- a/dev-docs/cookbook-gitbook-redirects.md
+++ b/dev-docs/cookbook-gitbook-redirects.md
@@ -1,0 +1,91 @@
+# Cookbook: GitBook redirects
+
+`mariadb-docs` has **no in-repo redirect mechanism** — there is no `.gitbook.yaml` or
+redirects file that Git controls. When you rename, move, split, or consolidate pages, the old
+URLs die and external bookmarks / search-engine results dead-end.
+
+GitBook itself **does** support redirects, but they are configured **manually** in the GitBook
+site UI (there is no API or MCP for it). So the repo-side job is to **produce a redirect CSV**
+and hand it to whoever administers the GitBook site; they import it.
+
+## When to produce a redirect CSV
+
+Any change that removes or relocates a published URL:
+
+- page renames or slug changes,
+- moving a page to a different section,
+- splitting one page into several,
+- retiring duplicate pages / consolidating trees (e.g. DOCS-6312).
+
+Do this **in addition to** rewriting in-repo inbound links — lychee only catches in-repo
+breakage, never external bookmarks.
+
+## The CSV format (this is the part that trips people up)
+
+| Column | What GitBook wants | Example |
+|--------|--------------------|---------|
+| header row | **exactly** `source,destination` | `source,destination` |
+| `source` | the **old** URL as a **site-relative path**, leading slash, including the space prefix; no `.md` | `/server/server-usage/basics/mariadb-usage-guide-1` |
+| `destination` | the **new** location as a **full absolute URL** | `https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-usage-guide` |
+
+Two mistakes cause almost every import failure:
+
+1. **Wrong header.** GitBook rejects `from,to`. It must be `source,destination`.
+2. **Bare path in `destination`.** A site-relative path in the destination column fails with
+   **`Invalid destination URL`** for every row. The destination must be a **full `https://…`
+   URL**, even though the source is a path. (The source is a dead path by definition, so
+   GitBook doesn't validate it; the destination it *does* validate as a real URL.)
+
+### Deriving the paths
+
+A published URL maps from the file path like this:
+
+- drop the `.md` extension,
+- `README.md` → its directory,
+- the site path is `/<space>/<path-from-space-root>` — for the server space that is
+  `/server/...` (the docs site mounts each space under its slug: `/server`, `/galera`,
+  `/maxscale`, …),
+- the public base is `https://mariadb.com/docs`, so a full URL is
+  `https://mariadb.com/docs/server/<path>`.
+
+**Sanity-check the base once:** open the real, current canonical page in a browser and confirm
+its URL matches what you generated. If the host/base differs, it's a find-and-replace on the
+prefix and the rest holds.
+
+Watch for slug quirks — the on-disk basename is the slug, so suffix oddities carry through
+(e.g. in DOCS-6312 the surviving `adding-and-changing-data` and `alter-table` pages kept a `-1`
+suffix while their retired twins did not).
+
+## Worked example (DOCS-6312)
+
+Consolidating the two quickstart-guide trees retired 16 `server-usage/` URLs in favor of
+`mariadb-quickstart-guides/`. The delivered CSV:
+
+```csv
+source,destination
+/server/server-usage/basics/mariadb-usage-guide-1,https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-usage-guide
+/server/server-usage/tables/mariadb-indexes-guide-1,https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-indexes-guide
+/server/server-usage/data-handling/mariadb-adding-and-changing-data-guide,https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-adding-and-changing-data-guide-1
+```
+
+Include a row for each retired **section/landing** too (point it at the nearest surviving
+landing), not just the leaf pages.
+
+## Importing (the manual step)
+
+The person with GitBook site admin access does this — it is not a Git operation:
+
+1. GitBook → the site → **Settings → Redirects**.
+2. Add a single redirect, or **Import** the CSV.
+3. If rows error, read the message: `Invalid destination URL` → destination isn't a full URL;
+   a header error → it isn't `source,destination`.
+
+## Checklist
+
+- [ ] In-repo inbound links to the old paths already repointed (separate from redirects).
+- [ ] CSV header is `source,destination`.
+- [ ] `source` = site-relative path (`/server/…`, no `.md`, README→dir).
+- [ ] `destination` = full `https://mariadb.com/docs/server/…` URL.
+- [ ] Base URL verified against one real live page.
+- [ ] A row for every retired page **and** every retired section landing.
+- [ ] Handed to a GitBook site admin to import (you can't do it via Git/API/MCP).

--- a/dev-docs/cookbook-jira-workflow.md
+++ b/dev-docs/cookbook-jira-workflow.md
@@ -63,6 +63,8 @@ exists. Supporting commands: `/jira-create <desc>` (file a new ticket),
 - Work lands via **PR** (so codespell / lychee / alias-expansion CI runs). Keep `DOCS-XXXX` in
   the branch name and commit messages.
 - The skills **never** commit, push, or open the PR — those stay user-driven.
+- If the ticket renames, moves, or retires published pages, also produce a GitBook redirect CSV
+  (`dev-docs/cookbook-gitbook-redirects.md` or `/redirects-csv`) — old URLs dead-end otherwise.
 
 ## `doc-from-ticket` and source verification
 

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -58,6 +58,9 @@ samples legitimately contain `{`, `%`, and raw URLs.
 - **`SUMMARY.md`:** if you added/moved/renamed a page, its `SUMMARY.md` entry exists, points at
   the right path, and matches the surrounding indentation/link style. (The nightly error-sync
   job legitimately auto-commits `server/SUMMARY.md` — that's an authorized exception.)
+- **Retired/moved URLs → redirects:** if the PR renames, moves, or deletes published pages,
+  produce a GitBook redirect CSV so old bookmarks don't dead-end (there's no in-repo redirect
+  mechanism). See `dev-docs/cookbook-gitbook-redirects.md` or run `/redirects-csv`.
 - **GitBook blocks:** hints use a valid style (`info`/`warning`/`danger`/`success`); `tabs`,
   `code`, `content-ref` blocks are balanced (every open has its `end…`).
 - **Links:** same-space links are relative `.md` paths; cross-space links use `{alias}`.


### PR DESCRIPTION
Makes "how to build a GitBook redirect CSV" discoverable to the whole team (and future agent sessions), since `mariadb-docs` has no in-repo redirect mechanism and GitBook redirects are configured manually in the site UI.

**What's here**
- **`dev-docs/cookbook-gitbook-redirects.md`** — the playbook. Captures the two gotchas that made the DOCS-6312 import fail on the first tries: the header must be `source,destination` (not `from,to`), and the `destination` column must be a full absolute URL (a bare path fails with `Invalid destination URL`; the `source` column stays a path). Plus path-derivation rules, a base-URL sanity check, slug quirks, the manual import step, a checklist, and a worked DOCS-6312 example.
- **`.claude/skills/gitbook-redirects/SKILL.md` + `.claude/commands/redirects-csv.md`** — promote it to a skill and a `/redirects-csv` slash command so it shows up in the command list and can be invoked by name.
- **Discoverability wiring:** entries in CLAUDE.md's *Where things are* table and *Skills* list, plus cross-links from `cookbook-pre-pr.md` and `cookbook-jira-workflow.md` so page-restructuring work reaches it even if someone skips the index.

Two independent discovery paths: the CLAUDE.md index (auto-loaded when working in the tree) and the `/redirects-csv` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)