### PR TITLE
Remove HashiCorp Vault plugin from ES 11.4/11.8 differences pages

### DIFF
--- a/connectors/mariadb-connector-c/batch-operations-with-mariadb-connector-c.md
+++ b/connectors/mariadb-connector-c/batch-operations-with-mariadb-connector-c.md
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 }
 ```
 
-Confirm the rows were inserted by using [MariaDB Client]({server}/clients-and-utilities/mariadb-client) to execute a [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) statement:
+Confirm the rows were inserted by using [MariaDB Client](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/mariadb-client) to execute a [SELECT](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/selecting-data/select) statement:
 
 ```sql
 SELECT * FROM test.contacts;

--- a/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.4.md
+++ b/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.4.md
@@ -18,12 +18,12 @@ In addition to this, there are Enterprise Features and some backported features.
 * [MariaDB Enterprise Audit](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/mariadb-enterprise-audit)
 * Index limit increased to 128 indexes.
 * Slow master shutdown as default
-  * [MariaDB Enterprise Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) (powered by Galera)
-  * [Enhanced Enterprise Data-at-Rest Encryption](mariadb-enterprise-server-data-at-rest-encryption/)
-  * XA Support
-  * Non-Blocking operation for DDLs
-  * TLS certificate expiration monitoring
-  * SSL/TLS is enabled by default
+* [MariaDB Enterprise Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) (powered by Galera)
+* [Enhanced Enterprise Data-at-Rest Encryption](mariadb-enterprise-server-data-at-rest-encryption/)
+* XA Support
+* Non-Blocking operation for DDLs
+* TLS certificate expiration monitoring
+* SSL/TLS is enabled by default
 * Dynamic resize of [InnoDB redo log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-redo-log)
 * Dynamic change of [InnoDB purge](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-purge) threads
 * Sybase SQL mode for extended aliases

--- a/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.4.md
+++ b/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.4.md
@@ -24,7 +24,6 @@ In addition to this, there are Enterprise Features and some backported features.
   * Non-Blocking operation for DDLs
   * TLS certificate expiration monitoring
   * SSL/TLS is enabled by default
-* [Hashicorp Vault Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin)
 * Dynamic resize of [InnoDB redo log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-redo-log)
 * Dynamic change of [InnoDB purge](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-purge) threads
 * Sybase SQL mode for extended aliases

--- a/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.8.md
+++ b/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.8.md
@@ -18,12 +18,12 @@ In addition to this, there are Enterprise Features and some backported features.
 * [MariaDB Enterprise Audit](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/mariadb-enterprise-audit)
 * Index limit increased to 128 indexes.
 * Slow master shutdown as default
-  * [MariaDB Enterprise Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) (powered by Galera)
-  * [Enhanced Enterprise Data-at-Rest Encryption](mariadb-enterprise-server-data-at-rest-encryption/)
-  * XA Support
-  * Non-Blocking operation for DDLs
-  * TLS certificate expiration monitoring
-  * SSL/TLS is enabled by default
+* [MariaDB Enterprise Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) (powered by Galera)
+* [Enhanced Enterprise Data-at-Rest Encryption](mariadb-enterprise-server-data-at-rest-encryption/)
+* XA Support
+* Non-Blocking operation for DDLs
+* TLS certificate expiration monitoring
+* SSL/TLS is enabled by default
 * Dynamic resize of [InnoDB redo log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-redo-log)
 * Dynamic change of [InnoDB purge](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-purge) threads
 * Sybase SQL mode for extended aliases

--- a/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.8.md
+++ b/release-notes/enterprise-server/about/mariadb-enterprise-server-differences/differences-in-mariadb-enterprise-server-11.8.md
@@ -24,7 +24,6 @@ In addition to this, there are Enterprise Features and some backported features.
   * Non-Blocking operation for DDLs
   * TLS certificate expiration monitoring
   * SSL/TLS is enabled by default
-* [Hashicorp Vault Plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin)
 * Dynamic resize of [InnoDB redo log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-redo-log)
 * Dynamic change of [InnoDB purge](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/innodb/innodb-purge) threads
 * Sybase SQL mode for extended aliases


### PR DESCRIPTION
The ES **11.4** and **11.8** "Differences" pages list the **HashiCorp Vault plugin** under *Enterprise Features*, but it is not Enterprise-only in those releases.

**Fact-check (against `mariadb-server` / Community source):**
- The `hashicorp_key_management` plugin was added to Community Server in **10.9.1** (MDEV-19281, May 2022).
- Verified present in the Community trees for **11.4** (`mariadb-11.4.0` tag) and **11.8**.

Since it ships in Community 11.4/11.8, it doesn't belong in the "in ES but not CS" list. Bullet removed from both pages.

Reported by Hartmut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)