### PR TITLE
DOCS-6310: convert genuine landing pages to columns

### DIFF
--- a/server/architecture/topologies/single-node-topologies/README.md
+++ b/server/architecture/topologies/single-node-topologies/README.md
@@ -12,38 +12,78 @@ Installation and configuration instructions are available for the deployment of 
 
 ### MariaDB ColumnStore
 
-These instructions detail a single-node deployment of a columnar data store, for MariaDB Community Server, with data optionally stored on S3-compatible object storage:
+{% columns %}
+{% column %}
+{% content-ref url="community-server-with-columnstore.md" %}
+[community-server-with-columnstore.md](community-server-with-columnstore.md)
+{% endcontent-ref %}
+{% endcolumn %}
 
-* [Single-Node ColumnStore Topology with MariaDB Community Server](community-server-with-columnstore.md)
+{% column %}
+These instructions detail a single-node deployment of a columnar data store, for MariaDB Community Server, with data optionally stored on S3-compatible object storage.
+{% endcolumn %}
+{% endcolumns %}
 
 For high availability and scalability, see "[Enterprise ColumnStore with Object Storage](../columnstore-object-storage/)" or "[Enterprise ColumnStore with Shared Local Storage](../columnstore-shared-local-storage/)".
 
 ### MariaDB Community Server
 
-These instructions detail a single-node deployment of MariaDB Community Server:
+{% columns %}
+{% column %}
+{% content-ref url="community-server.md" %}
+[community-server.md](community-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
 
-* [Single-Node Server Topology with MariaDB Community Server](community-server.md)
+{% column %}
+These instructions detail a single-node deployment of MariaDB Community Server.
+{% endcolumn %}
+{% endcolumns %}
 
 ### MariaDB Enterprise ColumnStore with Local Storage
 
-These instructions detail a single-node deployment of a columnar data store:
+{% columns %}
+{% column %}
+{% content-ref url="enterprise-server-with-columnstore-local-storage/" %}
+[enterprise-server-with-columnstore-local-storage](enterprise-server-with-columnstore-local-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
 
-* [Single-Node Enterprise ColumnStore Local Storage Topology with MariaDB Enterprise Server](enterprise-server-with-columnstore-local-storage/)
+{% column %}
+These instructions detail a single-node deployment of a columnar data store.
+{% endcolumn %}
+{% endcolumns %}
 
 For high availability and scalability, see "[Enterprise ColumnStore with Shared Local Storage](../columnstore-shared-local-storage/)".
 
 ### MariaDB Enterprise ColumnStore with Object Storage
 
-These instructions detail a single-node deployment of a columnar data store for MariaDB Enterprise Server, with data stored on S3-compatible object storage:
+{% columns %}
+{% column %}
+{% content-ref url="enterprise-server-with-columnstore-object-storage/" %}
+[enterprise-server-with-columnstore-object-storage](enterprise-server-with-columnstore-object-storage/)
+{% endcontent-ref %}
+{% endcolumn %}
 
-* [Single-Node Enterprise ColumnStore Object Storage Topology with MariaDB Enterprise Server](enterprise-server-with-columnstore-object-storage/)
+{% column %}
+These instructions detail a single-node deployment of a columnar data store for MariaDB Enterprise Server, with data stored on S3-compatible object storage.
+{% endcolumn %}
+{% endcolumns %}
 
 For high availability and scalability, see "[Enterprise ColumnStore with Object Storage](../columnstore-object-storage/)".
 
 ### MariaDB Enterprise Server
 
-These instructions detail a single-node deployment of MariaDB Enterprise Server:
+{% columns %}
+{% column %}
+{% content-ref url="enterprise-server.md" %}
+[enterprise-server.md](enterprise-server.md)
+{% endcontent-ref %}
+{% endcolumn %}
 
-* [Single-Node Enterprise Server Topology with MariaDB Enterprise Server](enterprise-server.md)
+{% column %}
+These instructions detail a single-node deployment of MariaDB Enterprise Server.
+{% endcolumn %}
+{% endcolumns %}
 
 \\

--- a/server/server-management/starting-and-stopping-mariadb/systemd/README.md
+++ b/server/server-management/starting-and-stopping-mariadb/systemd/README.md
@@ -22,8 +22,29 @@ The service name is `mariadb.service`.
 
 ## In this Section
 
-* [Starting MariaDB on systemd](starting.md) — installing, starting, stopping, restarting, and inspecting the MariaDB service, including multi-instance setups, Galera Cluster integration, and the systemd journal.
-* [Configuring MariaDB for systemd](configuring.md) — drop-in configuration files, timeouts, open-file and core-size limits, `LimitMEMLOCK` (`io_uring` and `aio`), error-log redirection, home-directory access, umask, data directory, socket activation, and converting `mariadbd-safe` options to `systemd` options. Also includes a quick-setup script for developers running MariaDB from a build directory.
+{% columns %}
+{% column %}
+{% content-ref url="starting.md" %}
+[starting.md](starting.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Installing, starting, stopping, restarting, and inspecting the MariaDB service, including multi-instance setups, Galera Cluster integration, and the systemd journal.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="configuring.md" %}
+[configuring.md](configuring.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Drop-in configuration files, timeouts, open-file and core-size limits, `LimitMEMLOCK` (`io_uring` and `aio`), error-log redirection, home-directory access, umask, data directory, socket activation, and converting `mariadbd-safe` options to `systemd` options. Also includes a quick-setup script for developers running MariaDB from a build directory.
+{% endcolumn %}
+{% endcolumns %}
 
 ## Contents of the MariaDB Service's Unit File
 


### PR DESCRIPTION
Follow-on to DOCS-5973 (landing-page columns campaign).

## What changed

Converted the child-link landing pages among the 13 deferred pages to the established `{% columns %}` `content-ref` + description layout, preserving each link's set and order:

- **`architecture/topologies/single-node-topologies`** — each `###` group's child link wrapped in a columns block; existing intro prose moved into the description column; the "For high availability…" cross-refs kept.
- **`server-management/.../systemd`** — the "In this Section" list (2 child links) wrapped in columns; the existing inline descriptions moved into the description column.

## Scope note (important)

On inspection, only these 2 of the 13 pages listed on the ticket are actually child-link landing pages. The other 11 are **not**, so they're intentionally left unchanged:

- **9 `architecture/topologies/*` pages** (spider-federated, spider-sharded, htap, primary-replica, galera-cluster, columnstore-object-storage, columnstore-shared-local-storage, and the two enterprise-columnstore single-node pages) are **deployment-procedure runbooks** — their child navigation is a "Procedure Steps" HTML `<table>`, not a bulleted child-link list. Columnizing those is a different, more invasive transformation and several are ES-specific (SME review territory).
- **`alter-table`** is a **help-tables reference article** (`# ALTER TABLE / ## Syntax / … / ## See Also`) with no child-link list; adding `{% columns %}` risks the `markdown_extractor.py` / shipped `HELP` output.
- **`schema-changes`** is a reference article (DDL cross-reference list + feature table), not a landing page.

Detail + recommendation for re-scoping the remainder is in the DOCS-6310 ticket comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)