### PR TITLE
DOCS-6138: Add missing CS 12.2 and 12.3 system-variable pages

### DIFF
--- a/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
+++ b/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
@@ -167,6 +167,8 @@ For a list of all new variables added since MariaDB 11.8, see:
 
 * [System Variables Added in MariaDB 12.0](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.0)
 * [System Variables Added in MariaDB 12.1](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.1)
+* [System Variables Added in MariaDB 12.2](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.2)
+* [System Variables Added in MariaDB 12.3](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.3)
 
 ## Incompatible Changes
 

--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -1108,6 +1108,8 @@
       * [SQL Error Log System Variables and Options](ha-and-performance/optimization-and-tuning/system-variables/sql-error-log-system-variables-and-options.md)
       * [SSL/TLS Status Variables](ha-and-performance/optimization-and-tuning/system-variables/ssltls-status-variables.md)
       * [System and Status Variables Added By Major Release](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md)
+        * [System Variables Added in MariaDB 12.3](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.3.md)
+        * [System Variables Added in MariaDB 12.2](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.2.md)
         * [System Variables Added in MariaDB 12.1](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.1.md)
         * [System Variables Added in MariaDB 12.0](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.0.md)
         * [System Variables Added in MariaDB 11.8](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-11-8.md)

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md
@@ -9,6 +9,30 @@ description: >-
 
 {% columns %}
 {% column %}
+{% content-ref url="system-variables-added-in-mariadb-12.3.md" %}
+[system-variables-added-in-mariadb-12.3.md](system-variables-added-in-mariadb-12.3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Lists the system variables added in the MariaDB 12.3 series, with links to each and the release in which it was added.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
+{% content-ref url="system-variables-added-in-mariadb-12.2.md" %}
+[system-variables-added-in-mariadb-12.2.md](system-variables-added-in-mariadb-12.2.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Lists the system variables added in the MariaDB 12.2 series. No new system variables were added in this series.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="system-variables-added-in-mariadb-12.1.md" %}
 [system-variables-added-in-mariadb-12.1.md](system-variables-added-in-mariadb-12.1.md)
 {% endcontent-ref %}

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.2.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.2.md
@@ -1,0 +1,18 @@
+---
+description: System variables added in the MariaDB 12.2 series.
+---
+
+# System Variables Added in MariaDB 12.2
+
+This is a list of [system variables](../server-system-variables.md) that have been added in the [MariaDB 12.2](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.2/mariadb-12.2-changes-and-improvements) series.
+
+No new system variables were added in the MariaDB 12.2 series. The 12.2 release focused on optimizer hints and Oracle-compatibility functions rather than new configuration options.
+
+## See Also
+
+* [System Variables Added in MariaDB 12.1](system-variables-added-in-mariadb-12.1.md)
+* [System Variables Added in MariaDB 12.3](system-variables-added-in-mariadb-12.3.md)
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.3.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.3.md
@@ -1,0 +1,17 @@
+---
+description: System variables added in the MariaDB 12.3 series.
+---
+
+# System Variables Added in MariaDB 12.3
+
+This is a list of [system variables](../server-system-variables.md) that have been added in the [MariaDB 12.3](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/12.3/mariadb-12.3-changes-and-improvements) series.
+
+<table><thead><tr><th width="567.7999267578125">Variable</th><th>Added</th></tr></thead><tbody><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_directory">binlog_directory</a></td><td>MariaDB 12.3.1</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_row_event_fragment_threshold">binlog_row_event_fragment_threshold</a></td><td>MariaDB 12.3.1</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_storage_engine">binlog_storage_engine</a></td><td>MariaDB 12.3.1</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#innodb_binlog_state_interval">innodb_binlog_state_interval</a></td><td>MariaDB 12.3.1</td></tr><tr><td>path</td><td>MariaDB 12.3.1</td></tr></tbody></table>
+
+## See Also
+
+* [System Variables Added in MariaDB 12.2](system-variables-added-in-mariadb-12.2.md)
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
## What

First scoped deliverable for DOCS-6138. Adds the two missing pages in the **System Variables Added by Major Release** set that Ralf flagged (CS 12.2 and 12.3), and wires them into navigation.

## Why

The set had pages through 12.0 and 12.1 but stopped there. Ralf's comment: *"we are missing 12.2 and 12.3."* These are the CS reference pages where version metadata already lives and has infrastructure — the bounded, buildable slice of this ticket.

## Data & verification

Source-verified against the MariaDB server tags by diffing the `sys_vars` test result files (`sysvars_server_notembedded` / `innodb` / `aria` / `wsrep`) across `mariadb-12.1.2 → 12.2.2 → 12.3.2`:

- **12.2** — the variable set is byte-identical to 12.1.2: **no new system variables** in the series. The 12.2 changelog confirms it (zero "system variable" mentions; the release was optimizer-hints / Oracle-compat-function focused). The page states this explicitly.
- **12.3.1** — five new variables: `binlog_directory`, `binlog_row_event_fragment_threshold`, `binlog_storage_engine`, `innodb_binlog_state_interval` (the binlog-in-engine feature; all four documented in the replication/binlog vars page) and `path` (a new session variable for stored-routine search order, not yet documented → listed unlinked, as the 12.1 page does for `caching_sha2_*`).

**Scope note:** the `sys_vars` diff is authoritative for core server/InnoDB/Aria/Galera variables but does not enumerate plugin-provided variables (auth/audit plugins aren't in those test files). No new plugin variables are flagged in the 12.2/12.3 changelogs, so this doesn't bite here, but the page isn't claimed to be plugin-complete. (These `added-in` pages are hand-curated in GitBook, with no generator — the existing 12.1 page itself omits `innodb_adaptive_hash_index_cells` and `new_mode`.)

## Changes

- New: `system-variables-added-in-mariadb-12.2.md`, `system-variables-added-in-mariadb-12.3.md`
- Landing page (`README.md`) content-refs + server `SUMMARY.md` nav entries
- 12.3 *Changes & Improvements* "Variables" section now links the 12.2 and 12.3 pages

The remaining DOCS-6138 targets (ES annotations on existing reference pages, and an ES 12.3 pilot page for Ralf's review) will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)