### PR TITLE
DOCS-6138: Enterprise Server 12.3 system-variables pilot page

### DIFF
--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -1108,6 +1108,7 @@
       * [SQL Error Log System Variables and Options](ha-and-performance/optimization-and-tuning/system-variables/sql-error-log-system-variables-and-options.md)
       * [SSL/TLS Status Variables](ha-and-performance/optimization-and-tuning/system-variables/ssltls-status-variables.md)
       * [System and Status Variables Added By Major Release](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md)
+        * [System Variables Added in Enterprise Server 12.3](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-enterprise-server-12.3.md)
         * [System Variables Added in MariaDB 12.3](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.3.md)
         * [System Variables Added in MariaDB 12.2](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.2.md)
         * [System Variables Added in MariaDB 12.1](ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-mariadb-12.1.md)

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/README.md
@@ -9,6 +9,18 @@ description: >-
 
 {% columns %}
 {% column %}
+{% content-ref url="system-variables-added-in-enterprise-server-12.3.md" %}
+[system-variables-added-in-enterprise-server-12.3.md](system-variables-added-in-enterprise-server-12.3.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Lists the system variables new in MariaDB Enterprise Server 12.3, relative to Enterprise Server 11.8.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="system-variables-added-in-mariadb-12.3.md" %}
 [system-variables-added-in-mariadb-12.3.md](system-variables-added-in-mariadb-12.3.md)
 {% endcontent-ref %}

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-enterprise-server-12.3.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/system-and-status-variables-added-by-major-release/system-variables-added-in-enterprise-server-12.3.md
@@ -1,0 +1,19 @@
+---
+description: System variables added in MariaDB Enterprise Server 12.3.
+---
+
+# System Variables Added in Enterprise Server 12.3
+
+This is a list of [system variables](../server-system-variables.md) that are new in MariaDB Enterprise Server 12.3, relative to the previous Enterprise Server release series, Enterprise Server 11.8.
+
+Because Enterprise Server backports selected features across release lines, some system variables that were introduced in Community Server 12.0, 12.1, and 12.3 are **not** listed here: they had already been backported into Enterprise Server 11.8 and so were not new in Enterprise Server 12.3. Examples are `analyze_max_length`, `aria_pagecache_segments`, `max_open_cursors`, and `metadata_locks_instances`.
+
+<table><thead><tr><th width="567.7999267578125">Variable</th><th>Added</th></tr></thead><tbody><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_directory">binlog_directory</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_row_event_fragment_threshold">binlog_row_event_fragment_threshold</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#binlog_storage_engine">binlog_storage_engine</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#create_tmp_table_binlog_formats">create_tmp_table_binlog_formats</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#innodb_binlog_state_interval">innodb_binlog_state_interval</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#master_info_file">master_info_file</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../server-system-variables.md#optimizer_record_context">optimizer_record_context</a></td><td>Enterprise Server 12.3</td></tr><tr><td>path</td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#replicate_same_server_id">replicate_same_server_id</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../standard-replication/replication-and-binary-log-system-variables.md#show_slave_auth_info">show_slave_auth_info</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="../../../../security/encryption/data-in-transit-encryption/ssltls-system-variables.md#ssl_passphrase">ssl_passphrase</a></td><td>Enterprise Server 12.3</td></tr><tr><td><a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/reference/galera-cluster-system-variables#wsrep_applier_retry_count">wsrep_applier_retry_count</a></td><td>Enterprise Server 12.3</td></tr></tbody></table>
+
+## See Also
+
+* [System Variables Added in MariaDB 12.3](system-variables-added-in-mariadb-12.3.md) (Community Server)
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
## What

Third scoped deliverable for DOCS-6138 — the **Enterprise Server 12.3 pilot page** Ralf asked for. Mirrors the CS "System Variables Added by Major Release" format for Enterprise Server. If the approach is approved, it can be rolled out for other ES lines (11.4, 11.8).

Builds on the CS 12.2/12.3 pages from #716 (merged); the "See Also → CS 12.3" link and the shared nav edits assume that content is in place.

## Data & verification

Lists the **12** system variables new in ES 12.3 relative to ES 11.8, derived by diffing the `sys_vars` test result files between the `11.8-enterprise` and `12.3-enterprise` source lines:

- CS 12.3.1 additions: `binlog_directory`, `binlog_row_event_fragment_threshold`, `binlog_storage_engine`, `innodb_binlog_state_interval`, `path`
- CS 12.0 additions not backported to ES 11.8: `create_tmp_table_binlog_formats`, `master_info_file`, `replicate_same_server_id`, `show_slave_auth_info`, `ssl_passphrase`
- CS 12.1 additions not backported to ES 11.8: `optimizer_record_context`, `wsrep_applier_retry_count`

The diff **correctly excludes** variables already backported into ES 11.8 — `analyze_max_length`, `aria_pagecache_segments`, `max_open_cursors`, `metadata_locks_instances` — which is exactly the ES-customer-relevant distinction this ticket is about. The page calls these out explicitly so the omission reads as intentional.

## Notes for Ralf's review

- **ES 12.3 is gamma (12.3.2-1), not GA yet**, and has no ES 12.3 release notes. The "Added" column therefore says `Enterprise Server 12.3` as plain text — no patch number, no release link (nothing to cite; ES patch releases can't be pinned from the available tree regardless).
- **Scope** is core server/InnoDB/Aria/Galera variables (what the `sys_vars` test enumeration covers). Plugin-provided variables (auth/audit) are out of scope — same known gap as the CS pages.
- Open question for you: is this format/placement right to roll out for ES 11.4 and 11.8 next?

🤖 Generated with [Claude Code](https://claude.com/claude-code)