### PR TITLE
Remove duplicated installation instructions

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/installation-and-first-run.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/installation-and-first-run.md
@@ -20,7 +20,7 @@ cd Mysql-to-MariaDB-Migration-<version>
 
 The `.zip` archive is equivalent: `unzip` it, then change into the extracted directory and run `./mariadb-migrator`. The version embedded in the archive and directory names matches the release you download.
 
-The data-transfer engine `mariadb-mtk` used by Parallel Restartable Streaming Copy is available from the same [MariaDB community downloads page](https://mariadb.com/downloads/community/). See [Prerequisites](#prerequisites) below.
+The data-transfer engine `mariadb-mtk` used by [Parallel Restartable Streaming Copy](migrate-with-parallel-restartable-streaming-copy.md) is available from the same [MariaDB community downloads page](https://mariadb.com/downloads/community/). See [Prerequisites](#prerequisites) below.
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ The data-transfer engine `mariadb-mtk` used by Parallel Restartable Streaming Co
 * **Python 3.9 or later** on the host that runs the migrator. On the first run, the launcher creates a project-local virtual environment (`.venv`) and installs its Python dependencies into it automatically — no manual `pip install` is needed. On Debian and Ubuntu, install the venv module first: `sudo apt-get install -y python3-venv`.
 * **The `mariadb` client** on the host that runs the migrator, used for connectivity, version, and database checks. If it is missing, the launcher detects your platform and offers to install it on the first run. You can also install it manually, for example with `dnf install mariadb`, `apt-get install mariadb-client`, `zypper install mariadb-client`, or `brew install mariadb`.
 * **Network connectivity** from the host that runs the migrator to both the source MySQL server and the target MariaDB server. The exception is Offline Copy (`staged`) in its `dump_only` or `load_only` phase, which only needs connectivity to one side.
-* For **Parallel Restartable Streaming Copy** (`two_step`), the `mariadb-mtk` engine must be installed by extracting its release archive:
+* For **[Parallel Restartable Streaming Copy](migrate-with-parallel-restartable-streaming-copy.md)** (`two_step`), the `mariadb-mtk` engine must be installed by extracting its release archive:
 
   ```bash
   tar -xzf mariadb-mtk-<version>_<x86_64/arm_64>_linux.tar.gz
@@ -39,7 +39,7 @@ The data-transfer engine `mariadb-mtk` used by Parallel Restartable Streaming Co
   It is available from the [MariaDB community downloads page](https://mariadb.com/downloads/community/). Set the `SQLINESDATA_BIN` environment variable to the full path of the `mariadb-mtk` binary.
 
 {% hint style="info" %}
-`pv` is recommended for live progress visibility but is optional. When it is missing, Offline Copy (`staged`) falls back to a 60-second file-size probe and Serial Streaming Copy (`one_step`) falls back to a 60-second heartbeat.
+`pv` is recommended for live progress visibility but is optional. When it is missing, [Offline Copy](migrate-with-offline-copy.md) (`staged`) falls back to a 60-second file-size probe and [Serial Streaming Copy](migrate-with-serial-streaming-copy.md) (`one_step`) falls back to a 60-second heartbeat.
 {% endhint %}
 
 ### User Privileges

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-offline-copy.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-offline-copy.md
@@ -33,15 +33,7 @@ The host that runs each phase needs **Python 3.9 or later** and the **`mariadb` 
 
 ## Step 1: Download and Start the Migrator
 
-Download the migrator release archive from the [MariaDB community downloads page](https://mariadb.com/downloads/community/) or the [GitHub releases page](https://github.com/mariadb-corporation/Mysql-to-MariaDB-Migration/releases), extract it, and run the launcher on each host that will participate (example for `v1.3.1-beta`):
-
-```bash
-tar -xzf Mysql-to-MariaDB-Migration-1.3.1-beta.tar.gz
-cd Mysql-to-MariaDB-Migration-1.3.1-beta
-./mariadb-migrator
-```
-
-On the first run, the launcher creates a project-local Python environment (`.venv`) and checks for the `mariadb` client, offering to install it if needed. Your system Python is never modified.
+See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing the MariaDB Migrator.
 
 ## Step 2: Understand the Phases
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-parallel-restartable-streaming-copy.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-parallel-restartable-streaming-copy.md
@@ -33,7 +33,7 @@ The target must be **clean** for this mode: Parallel Restartable Streaming Copy 
 
 ### The mariadb-mtk engine
 
-This mode requires the `mariadb-mtk` data-transfer engine (the SQLines Data engine, invoked as `sqldata`). The other three modes do not use it. See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing mariadb-mtk.
+This mode requires the `mariadb-mtk` data-transfer engine. The other three modes do not use it. See the "[Required](installation-and-first-run.md#required)" section of the Installation and First Run page for details on downloading and installing mariadb-mtk.
 
 ## Step 1: Download and Start the Migrator
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-parallel-restartable-streaming-copy.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-parallel-restartable-streaming-copy.md
@@ -33,19 +33,11 @@ The target must be **clean** for this mode: Parallel Restartable Streaming Copy 
 
 ### The mariadb-mtk engine
 
-This mode requires the `mariadb-mtk` data-transfer engine (the SQLines Data engine, invoked as `sqldata`). The other three modes do not use it. Download it from the [MariaDB community downloads page](https://mariadb.com/downloads/community/). The launcher auto-detects a `sqldata` or `sqlinesdata` binary on `PATH`; if it is installed elsewhere, set `SQLINESDATA_BIN` to its full path. The engine may ship a temporary evaluation license; use a production license before production runs.
+This mode requires the `mariadb-mtk` data-transfer engine (the SQLines Data engine, invoked as `sqldata`). The other three modes do not use it. See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing mariadb-mtk.
 
 ## Step 1: Download and Start the Migrator
 
-Download the migrator release archive from the [MariaDB community downloads page](https://mariadb.com/downloads/community/) or the [GitHub releases page](https://github.com/mariadb-corporation/Mysql-to-MariaDB-Migration/releases), extract it, and run the launcher (example for `v1.3.1-beta`):
-
-```bash
-tar -xzf Mysql-to-MariaDB-Migration-1.3.1-beta.tar.gz
-cd Mysql-to-MariaDB-Migration-1.3.1-beta
-./mariadb-migrator
-```
-
-On the first run, the launcher creates a project-local Python environment (`.venv`) and checks for the `mariadb` client. Your system Python is never modified.
+See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing the MariaDB Migrator.
 
 ## Step 2: Preview with Assess & Plan
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-replication.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-replication.md
@@ -39,13 +39,7 @@ A **MySQL 8.4** source additionally needs an upstream `mysqldump` 8.4 or later a
 
 ## Step 1: Download and Start the Migrator
 
-Download the migrator release archive from the [MariaDB community downloads page](https://mariadb.com/downloads/community/) or the [GitHub releases page](https://github.com/mariadb-corporation/Mysql-to-MariaDB-Migration/releases), extract it, and run the launcher (example for `v1.3.1-beta`):
-
-```bash
-tar -xzf Mysql-to-MariaDB-Migration-1.3.1-beta.tar.gz
-cd Mysql-to-MariaDB-Migration-1.3.1-beta
-./mariadb-migrator
-```
+See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing the MariaDB Migrator.
 
 On the first run, the launcher creates a project-local Python environment (`.venv`) and checks for the `mariadb` client. Your system Python is never modified.
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-serial-streaming-copy.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/mysql-to-mariadb-migrator/migrate-with-serial-streaming-copy.md
@@ -40,13 +40,7 @@ Finally, the migrator host needs **Python 3.9 or later** and the **`mariadb` cli
 
 ## Step 1: Download and Start the Migrator
 
-Download the migrator release archive from the [MariaDB community downloads page](https://mariadb.com/downloads/community/) or the [GitHub releases page](https://github.com/mariadb-corporation/Mysql-to-MariaDB-Migration/releases), extract it, and run the launcher (example for `v1.3.1-beta`):
-
-```bash
-tar -xzf Mysql-to-MariaDB-Migration-1.3.1-beta.tar.gz
-cd Mysql-to-MariaDB-Migration-1.3.1-beta
-./mariadb-migrator
-```
+See [Installation and First Run](installation-and-first-run.md) for details on downloading and installing the MariaDB Migrator.
 
 On the first run, the launcher creates a project-local Python environment (`.venv`), installs its dependencies into it, and checks for the `mariadb` client. Your system Python is never modified, and later runs reuse `.venv` and go straight to the menu.
 


### PR DESCRIPTION
Link them to the Installation and First Run doc instead.