### PR TITLE
DOCS-6322: fix broken-reference on MaxScale 24.02 Upgrading stub

### DIFF
--- a/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02upgrading/README.md
+++ b/maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02upgrading/README.md
@@ -7,4 +7,4 @@ description: >-
 
 # MaxScale 24.02 Upgrading
 
-This page has moved [here](broken-reference).
+This page has moved. See [Upgrading MaxScale](../../../../maxscale-management/deployment/upgrading-maxscale/README.md).


### PR DESCRIPTION
## What

The archived **MaxScale 24.02 Upgrading** landing page
(`maxscale/maxscale-archive/archive/mariadb-maxscale-24-02/maxscale-24-02upgrading/README.md`)
read *"This page has moved [here](broken-reference)"* — a dangling GitBook
`broken-reference` placeholder (the 24.02 version-specific upgrading content was
never migrated into the archive). Repointed it at the current, maintained
[Upgrading MaxScale](https://mariadb.com/docs/maxscale/maxscale-management/deployment/upgrading-maxscale)
guide.

## Context

Surfaced while investigating **DOCS-6322** (dead docs URLs flagged by the Zendesk
crawler). The four flagged URLs themselves are stale-URL cases handled via GitBook
redirects (CSV handed to the site admin) — this PR fixes the one *in-repo* broken
link found alongside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)