### PR TITLE
Fix ES upgrade-paths content-ref links rendering as GitHub URLs

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/README.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/README.md
@@ -24,8 +24,8 @@ layout:
 
 {% columns %}
 {% column %}
-{% content-ref url="mariadb-enterprise-server-11.8/" %}
-[mariadb-enterprise-server-11.8](mariadb-enterprise-server-11.8/)
+{% content-ref url="mariadb-enterprise-server-11.8/README.md" %}
+[mariadb-enterprise-server-11.8](mariadb-enterprise-server-11.8/README.md)
 {% endcontent-ref %}
 {% endcolumn %}
 
@@ -36,8 +36,8 @@ Upgrade guide for MariaDB Enterprise Server 11.8, highlighting significant perfo
 
 {% columns %}
 {% column %}
-{% content-ref url="mariadb-enterprise-server-11.4/" %}
-[mariadb-enterprise-server-11.4](mariadb-enterprise-server-11.4/)
+{% content-ref url="mariadb-enterprise-server-11.4/README.md" %}
+[mariadb-enterprise-server-11.4](mariadb-enterprise-server-11.4/README.md)
 {% endcontent-ref %}
 {% endcolumn %}
 
@@ -48,8 +48,8 @@ Instructions for upgrading to MariaDB Enterprise Server 11.4, which introduces n
 
 {% columns %}
 {% column %}
-{% content-ref url="mariadb-enterprise-server-10.6/" %}
-[mariadb-enterprise-server-10.6](mariadb-enterprise-server-10.6/)
+{% content-ref url="mariadb-enterprise-server-10.6/README.md" %}
+[mariadb-enterprise-server-10.6](mariadb-enterprise-server-10.6/README.md)
 {% endcontent-ref %}
 {% endcolumn %}
 


### PR DESCRIPTION
## Problem

On the [Enterprise Server upgrade-paths landing page](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths), three of the four cards (11.8, 11.4, 10.6) render as **raw GitHub blob URLs** instead of internal doc links. Reported by Pramod.

## Cause

GitBook's `content-ref` resolver mishandles relative targets whose directory name ends in a version dot (`mariadb-enterprise-server-11.8/`, `…-11.4/`, `…-10.6/`) and falls back to a GitHub URL. The dot-free `archived/` card resolved correctly, which is the tell.

## Fix

Point each affected `content-ref` at the folder's `README.md` explicitly, so the path no longer ends in a bare version dot — matching the resolvable form the Community Server sibling page already uses. The working `archived/` card is left unchanged.

## Verification

- Confirmed all four `README.md` targets exist.
- codespell clean; structural checks (frontmatter, block balance, link style, `SUMMARY.md`) pass. lychee runs in CI.
- Rendered result is resolved server-side by GitBook — final visual confirmation on the GitBook build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)