### PR TITLE
DOCS-6327 Fix Connector/Python docs against source (v1.1 + v2.0)

### DIFF
--- a/connectors/mariadb-connector-python/async-usage.md
+++ b/connectors/mariadb-connector-python/async-usage.md
@@ -40,7 +40,7 @@ async def main():
     conn = await mariadb.asyncConnect("mariadb://user:password@localhost/mydb")
     
     try:
-        cursor = await conn.cursor()
+        cursor = conn.cursor()
         try:
             # Execute query
             await cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
@@ -610,7 +610,7 @@ import mariadb
 
 async def main():
     conn = await mariadb.asyncConnect("mariadb://localhost/mydb")
-    cursor = await conn.cursor()
+    cursor = conn.cursor()
     await cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
     row = await cursor.fetchone()
     await cursor.close()

--- a/connectors/mariadb-connector-python/connection.md
+++ b/connectors/mariadb-connector-python/connection.md
@@ -38,14 +38,14 @@ The `mariadb.connect()` function accepts the following parameters:
 ### Timeout Parameters
 
 - **`connect_timeout`** (`float`) - Timeout in seconds for establishing the initial connection to the server. Default: `10.0`
-- **`socket_timeout`** (`float`) - I/O timeout in seconds for socket operations (read and write). Primary timeout parameter for the pure-Python connector. Default: `30.0`
+- **`socket_timeout`** (`float`) - I/O timeout in seconds for socket operations (read and write). Primary timeout parameter for the pure-Python connector. Default: `None` (no timeout; blocking)
 - **`query_timeout`** (`int`) - Maximum query execution time in seconds (0 means no timeout). Default: `0`
 - **`read_timeout`** *(C extension only)* (`float`) - Read (receive) timeout in seconds, passed directly to `libmariadb`. On the pure-Python connector this value is accepted but mapped to `socket_timeout`. Default: same as `socket_timeout`
 - **`write_timeout`** *(C extension only)* (`float`) - Write (send) timeout in seconds, passed directly to `libmariadb`. On the pure-Python connector this value is accepted but mapped to `socket_timeout`. Default: same as `socket_timeout`
 
 ### SSL/TLS Parameters
 
-- **`ssl`**, **`use_ssl`** (`bool`) - Enable SSL/TLS encryption. Default: `False`
+- **`ssl`**, **`use_ssl`** (`bool`) - Enable SSL/TLS encryption. Default: `True` in version 2.0 (secure by default); `False` in the version 1.1 C extension
 - **`ssl_ca`** (`str`) - Path to Certificate Authority (CA) certificate file in PEM format. Default: `None`
 - **`ssl_cert`** (`str`) - Path to client certificate file in PEM format. Default: `None`
 - **`ssl_key`** (`str`) - Path to client private key file in PEM format. Default: `None`
@@ -53,7 +53,7 @@ The `mariadb.connect()` function accepts the following parameters:
 - **`ssl_cipher`** (`str`) - List of permitted cipher suites for SSL/TLS. Default: `None`
 - **`ssl_crl`** (`str`) - Path to certificate revocation list file. Default: `None`
 - **`ssl_crlpath`** (`str`) - Path to directory containing CRL files. Default: `None`
-- **`ssl_verify_cert`** (`bool`) - Enable server certificate verification. Default: `False`
+- **`ssl_verify_cert`** (`bool`) - Enable server certificate verification. Default: `True` in version 2.0; `False` in version 1.1
 - **`tls_version`** (`str`) - TLS version(s) to use (e.g., `'TLSv1.2'`, `'TLSv1.3'`, `'TLSv1.2,TLSv1.3'`). Automatically enables SSL. Default: `None`
 - **`tls_fp`** *(C extension only)* (`str`) - SHA-256 fingerprint of the expected server certificate, used for certificate pinning. Default: `None`
 - **`tls_fp_list`** *(C extension only)* (`str`) - Path to a file containing a list of accepted server certificate SHA-256 fingerprints. Default: `None`
@@ -81,14 +81,14 @@ For a description of configuration file handling and accepted settings, see the 
 
 - **`binary`** (`bool`) - Use binary protocol (prepared statements) by default. Default: `False`
 - **`max_allowed_packet`** (`int`) - Maximum packet size in bytes. Default: `16777216` (16MB)
-- **`cache_prep_stmts`** (`bool`) - Enable prepared statement caching. Default: `True`
+- **`cache_prep_stmts`** (`bool`) - Enable the shared prepared-statement cache. Default: `False`
 - **`prep_stmt_cache_size`** (`int`) - Maximum number of cached prepared statements. Default: `100`
 - **`pipeline`** (`bool`) - Enable pipelining for prepared statements. Default: `True`
 - **`client_flag`** (`int`) - Additional client capability flags. Default: `0`
 
-### Character Encoding Parameters
+### Character Encoding
 
-- **`character_encoding`**, **`charset`** (`str`) - Character set to use for the connection. Default: `'utf8mb4'`
+The connection character set is fixed at `utf8mb4` and is not configurable through a connection parameter.
 
 ### Result Format Parameters
 
@@ -937,12 +937,10 @@ Id of current connection
 
 #### Connection.database: Optional[str]
 
-(read-only)
+(read/write)
 
-Returns or sets the default database for the current connection.
-
-The default database can also be obtained or changed by database
-attribute.
+Returns or sets the default database for the current connection. Assigning to
+this attribute switches the default database (issuing a `USE` statement).
 
 *Since version 1.1.0.*
 

--- a/connectors/mariadb-connector-python/constants.md
+++ b/connectors/mariadb-connector-python/constants.md
@@ -419,8 +419,6 @@ Extended field types provide additional type information beyond standard SQL typ
 
 Extended field types are defined in module *mariadb.constants.EXT_FIELD_TYPE*
 
-*Since version 2.0*
-
 #### EXT_FIELD_TYPE.NONE
 
 No extended type information (value: 0)

--- a/connectors/mariadb-connector-python/cursor.md
+++ b/connectors/mariadb-connector-python/cursor.md
@@ -23,7 +23,7 @@ Cursors are created using the `connection.cursor()` method and accept the follow
 
 - **`dictionary`** (`bool`) - Return rows as dictionaries instead of tuples. Allows accessing columns by name (e.g., `row['column_name']`). Default: `False`
 
-- **`native_object`** (`bool`) - Return native Python objects for certain database types. Default: `False`
+- **`native_object`** (`bool`) - Return native Python objects for certain database types. Default: `False`. *Available since version 2.0*; passing it to `cursor()` in version 1.1 raises a `TypeError`.
 
 ### Protocol Parameters
 
@@ -302,8 +302,9 @@ conn.close()
 
 #### Cursor.next() -> Optional[Any]
 
-Return the next row from the currently executed SQL statement
-using the same semantics as .fetchone().
+*Version 1.1 only.* Return the next row from the currently executed SQL
+statement using the same semantics as .fetchone(). In version 2.0 this method
+was removed; iterate the cursor directly instead (`for row in cursor:`).
 
 #### Cursor.nextset() -> Optional[bool]
 
@@ -367,7 +368,7 @@ conn.close()
 
 Controls whether result sets are buffered in memory or streamed from the server.
 
-**Buffered (True):**
+**Buffered (True, default):**
 - All result rows are immediately fetched and stored in client memory
 - The entire result set is transferred at once
 - Connection is freed immediately after execute()
@@ -375,7 +376,7 @@ Controls whether result sets are buffered in memory or streamed from the server.
 - Higher memory usage for large result sets
 - Better for small to medium result sets
 
-**Unbuffered (False, default in 2.0):**
+**Unbuffered (False):**
 - Results are streamed row-by-row from the server
 - Only the current row is kept in memory
 - Connection remains blocked until all rows are fetched
@@ -601,9 +602,9 @@ Each dictionary key contains a list of values, one for each column in the result
 - **table** - Table alias name, or original table name if no alias
 - **org_table** - Original table name
 - **type** - Column type (values from `mariadb.constants.FIELD_TYPE`)
-- **charset** - Character set (e.g., 'utf8mb4' or 'binary')
+- **charset** - Numeric character set (collation) ID of the column
 - **length** - Maximum length of the column
-- **max_length** - Maximum length of data in the result set
+- **max_length** - Maximum length of the column (in version 2.0 this mirrors **length**)
 - **decimals** - Number of decimals for numeric types
 - **flags** - Field flags (values from `mariadb.constants.FIELD_FLAG`)
 - **ext_type_or_format** - Extended data type (values from `mariadb.constants.EXT_FIELD_TYPE`)
@@ -659,9 +660,9 @@ if metadata:
 #   Original table: users
 #   Schema: mydb
 #   Type: 3
-#   Charset: binary
+#   Charset: 63
 #   Length: 11
-#   Max length: 1
+#   Max length: 11
 #   Decimals: 0
 #   Flags: 16899
 
@@ -837,19 +838,19 @@ Returns the number of rows that the last `execute*()` method produced (for DQL s
 - **0** - Statement executed but no rows were affected/returned
 
 **Important Notes:**
-- For **unbuffered cursors** (default in 2.0), the exact row count is only available **after all rows have been fetched**
+- For **unbuffered cursors**, the exact row count is only available **after all rows have been fetched**
 - For **buffered cursors**, the row count is immediately available after `execute()`
 - For **INSERT/UPDATE/DELETE**, the row count is always immediately available
 
 **Examples:**
 
-**Unbuffered Cursor (Default):**
+**Unbuffered Cursor:**
 
 ```python
 import mariadb
 
 conn = mariadb.connect("mariadb://user:password@localhost/mydb")
-cursor = conn.cursor(buffered=False)  # Default
+cursor = conn.cursor(buffered=False)  # Stream rows from the server
 
 # Execute SELECT
 cursor.execute("SELECT * FROM users")
@@ -972,7 +973,8 @@ conn.close()
 
 (read-only)
 
-Returns the last SQL statement that was executed by the cursor.
+*Version 1.1 only.* Returns the last SQL statement that was executed by the
+cursor. This attribute is not available in version 2.0.
 
 **Example:**
 

--- a/connectors/mariadb-connector-python/faq.md
+++ b/connectors/mariadb-connector-python/faq.md
@@ -246,7 +246,7 @@ import mariadb
 
 async def main():
     conn = await mariadb.asyncConnect("mariadb://user:pass@host/db")
-    cursor = await conn.cursor()
+    cursor = conn.cursor()
     await cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
     row = await cursor.fetchone()
     await cursor.close()
@@ -268,19 +268,19 @@ See [Async/Await Support](async-usage.md) for detailed documentation.
 
 ### What's the difference between prepared and binary?
 
-In version 1.1, the parameter was called `prepared`. In version 2.0, it's renamed to `binary` for clarity:
+Both `prepared` and `binary` already existed as separate cursor options in version 1.1. In version 2.0, `prepared` is deprecated in favor of `binary`; passing `prepared` still works but emits a `DeprecationWarning`:
 
-**Version 1.1:**
-```python
-cursor = conn.cursor(prepared=True)
-```
-
-**Version 2.0:**
+**Version 1.1 (either option):**
 ```python
 cursor = conn.cursor(binary=True)
 ```
 
-The functionality is the same - both use the MariaDB binary protocol (prepared statements).
+**Version 2.0 (use `binary`):**
+```python
+cursor = conn.cursor(binary=True)
+```
+
+Both use the MariaDB binary protocol (prepared statements).
 
 ### Should I use text or binary protocol?
 
@@ -307,7 +307,7 @@ MariaDB Connector/Python uses MariaDB Connector/C for client-server communicatio
 
 ### Q: How do I execute multiple statements with cursor.execute()?
 
-Since MariaDB Connector/Python uses binary protocol for client-server communication, this feature is not supported yet.
+Executing multiple statements in a single `cursor.execute()` call is not supported.
 
 ### Q: Does MariaDB Connector/Python work with Python 2.x?
 
@@ -316,10 +316,9 @@ with older Python 3.x versions, it doesn’t work with Python version 2.x.
 
 ### Q: How can I see a transformed statement? Is there a mogrify() method available?
 
-No, MariaDB Connector/Python uses binary protocol for client/server communication. Before a statement will be executed
-it will be parsed and parameter markers which are different than question marks will be replaced by question
-marks. Afterwards the statement will be sent together with data to the server. The transformed statement can
-be obtained by cursor.statement attribute.
+No, there is no `mogrify()` method. Before a statement is executed, parameter markers other than question
+marks are rewritten to question marks; the statement and its data are then sent separately to the server,
+so the parameter values are not substituted into the SQL string on the client side.
 
 Example:
 

--- a/connectors/mariadb-connector-python/install.md
+++ b/connectors/mariadb-connector-python/install.md
@@ -19,7 +19,7 @@ description: >-
 
 MariaDB Connector/Python 2.0 supports
 
-* Python versions from 3.8 to 3.12
+* Python 3.10 and later
 * MariaDB server versions from version 10.3 or MySQL server versions from version 5.7.
 * MariaDB client library (MariaDB Connector/C) from version 3.3.1 (optional - only required for C extension).
 
@@ -169,7 +169,7 @@ No compiler or system dependencies required.
 To build the C extension from source, you will need:
 
 - C compiler (gcc, clang, or MSVC)
-- Python development files (Usually installed with package **python3-dev**). Minimum supported version is Python 3.8.
+- Python development files (Usually installed with package **python3-dev**). Minimum supported version is Python 3.10 (version 1.1 requires Python 3.8).
 - MariaDB Connector/C libraries and header files (version 3.3.1 or later)
   - Either from MariaDB server package or from MariaDB Connector/C package
   - If your distribution doesn't provide a recent version, download from [MariaDB Connector Download page](https://mariadb.com/downloads/connectors/) or build from source

--- a/connectors/mariadb-connector-python/migration-from-1.1-to-2.0.md
+++ b/connectors/mariadb-connector-python/migration-from-1.1-to-2.0.md
@@ -91,7 +91,7 @@ conn = mariadb.connect(
 
 **Version 2.0:**
 ```python
-# reconnect and auto_reconnect parameters removed
+# reconnect parameter removed
 conn = mariadb.connect(
     host="localhost",
     user="root",
@@ -124,15 +124,19 @@ cursor = conn.cursor(buffered=False)
 
 **Migration**: Replace `cursor_type=CURSOR.READ_ONLY` with `buffered=False`.
 
-### 3. Renamed: prepared → binary
+> **Note**: `cursor_type` is removed only in the pure-Python implementation. The C extension still accepts it.
 
-**Version 1.1:**
+### 3. Deprecated: prepared (use binary)
+
+The `binary` cursor option already existed in version 1.1 alongside `prepared`. In version 2.0, `prepared` is deprecated in favor of `binary`; it still works but emits a `DeprecationWarning`.
+
+**Version 1.1 (either option):**
 ```python
-cursor = conn.cursor(prepared=True)
+cursor = conn.cursor(binary=True)
 cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
 ```
 
-**Version 2.0:**
+**Version 2.0 (use `binary`):**
 ```python
 cursor = conn.cursor(binary=True)
 cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
@@ -331,20 +335,15 @@ cursor.execute("SELECT * FROM users WHERE id = ?", (1,))
 
 ### 4. Prepared Statement Caching
 
-**New in 2.0 - Automatic statement caching:**
+**New in 2.0 - Shared statement cache (opt-in):**
 
 ```python
-# Enabled by default
-conn = mariadb.connect("mariadb://localhost/mydb")
+# The shared prepared-statement cache is disabled by default; enable it explicitly
+conn = mariadb.connect("mariadb://localhost/mydb?cache_prep_stmts=true")
 
-# Configure cache size
+# Configure the cache size (applies when the cache is enabled)
 conn = mariadb.connect(
-    "mariadb://localhost/mydb?prep_stmt_cache_size=500"
-)
-
-# Disable caching (1.1-like behavior)
-conn = mariadb.connect(
-    "mariadb://localhost/mydb?cache_prep_stmts=false"
+    "mariadb://localhost/mydb?cache_prep_stmts=true&prep_stmt_cache_size=500"
 )
 ```
 
@@ -385,7 +384,7 @@ cursor = conn.cursor(buffered=False)
 ```python
 conn = mariadb.connect(
     host="localhost",
-    auto_reconnect=True
+    reconnect=True
 )
 ```
 
@@ -448,8 +447,8 @@ pool = await mariadb.create_async_pool(
 
 ### Python Version Support
 
-- **Version 1.1**: Python 3.7 - 3.11
-- **Version 2.0**: Python 3.8+ (check release notes for exact range)
+- **Version 1.1**: Python 3.8 and later
+- **Version 2.0**: Python 3.10 and later
 
 ### Server Compatibility
 

--- a/connectors/mariadb-connector-python/module.md
+++ b/connectors/mariadb-connector-python/module.md
@@ -19,15 +19,15 @@ MySQL databases, using an API which is compliant with the Python DB API 2.0
 
 ### Connection
 
-### connect(dsn=None, connectionclass=mariadb.connections.Connection, \*\*kwargs)
+### connect(\*args, connectionclass=None, \*\*kwargs)
 
 Creates a MariaDB Connection object.
 
-By default, the standard connectionclass mariadb.connections.Connection
-will be created.
+The first positional argument, when given, is a connection URI string (see
+*Since version 2.0* below). By default, the standard Connection class is used.
 
-Parameter connectionclass specifies a subclass of
-mariadb.Connection object. If not specified, default will be used.
+Parameter connectionclass specifies a subclass of the standard Connection
+class. If not specified, the default is used.
 This optional parameter was added in version 1.1.0.
 
 *Since version 2.0:* Connection can be established using a URI string or keyword arguments. Keyword arguments override URI values when both are provided.
@@ -62,13 +62,11 @@ Connection parameters can also be provided as keyword arguments. The most common
 
 For the full list of accepted parameters — including SSL/TLS options, timeouts, prepared-statement caching, configuration file loading, the result format options (`dictionary`, `named_tuple`, `native_object`), and the parameters that only apply to the C extension — see [The connection class](connection.md).
 
-#### Removed Parameters in Version 2.0
+#### Changed Parameters in Version 2.0
 
-The following parameters have been removed:
-
-- **`reconnect`** / **`auto_reconnect`** - Automatic reconnection is no longer supported. Use connection pools or call `conn.reconnect()` manually.
-- **`cursor_type`** - Replaced by `buffered=False` parameter in cursor creation.
-- **`prepared`** - Replaced by `binary=True` parameter.
+- **`reconnect`** (connection parameter) - Removed. Automatic reconnection is no longer supported; use connection pools or call `conn.reconnect()` manually.
+- **`cursor_type`** (cursor option) - Removed in the pure-Python implementation; use `buffered=False` instead. The C extension still accepts it.
+- **`prepared`** (cursor option) - Deprecated in favor of `binary=True`. It still works but emits a `DeprecationWarning`.
 
 For migration guidance, see the [Migration Guide](migration-from-1.1-to-2.0.md).
 
@@ -99,11 +97,13 @@ utf8mb4
 
 ### Async Connection
 
-### asyncConnect(dsn=None, \*\*kwargs)
+### asyncConnect(\*args, connectionclass=None, \*\*kwargs)
 
 *Since version 2.0*
 
 Creates an asynchronous MariaDB Connection object for use with async/await.
+As with `connect()`, the first positional argument, when given, is a
+connection URI string.
 
 **Usage:**
 
@@ -170,7 +170,7 @@ with pool.acquire() as conn:
 
 Keyword Arguments:
 
-- **\`min_size\`** (`int`) - Minimum number of connections in pool. Default: 5
+- **\`min_size\`** (`int`) - Minimum number of connections in pool. Default: same as `max_size`
 - **\`max_size\`** (`int`) - Maximum number of connections in pool. Default: 10
 - **\`ping_threshold\`** (`float`) - Ping connections idle for more than this many seconds. Default: 0.25
 - **\*\*kwargs** - Connection arguments as described in mariadb.connect() method
@@ -260,8 +260,10 @@ String constant stating the supported DB API level. The value for mariadb is
 
 ### threadsafety
 
-Integer constant stating the level of thread safety. For mariadb the value is 1,
-which means threads can share the module but not the connection.
+Integer constant stating the level of thread safety. In version 2.0 the value
+is `3`, meaning threads may share the module, connections, and cursors. In
+version 1.1 the value is `1`, meaning threads may share the module but not
+connections.
 
 ### paramstyle
 
@@ -277,15 +279,20 @@ String constant stating the version of the used MariaDB Connector/C library.
 
 *Since version 1.1.0*
 
-Returns the version of MariaDB Connector/C library in use as an integer.
-The number has the following format:
-MAJOR_VERSION \* 10000 + MINOR_VERSION \* 1000 + PATCH_VERSION
+Returns a version as an integer. In version 2.0 this is the version of MariaDB
+Connector/Python itself, in the format:
+MAJOR_VERSION \* 10000 + MINOR_VERSION \* 100 + PATCH_VERSION.
+In version 1.1 it is the version of the MariaDB Connector/C library in use, in
+the format:
+MAJOR_VERSION \* 10000 + MINOR_VERSION \* 1000 + PATCH_VERSION.
 
 ### client_version_info
 
 *Since version 1.1.0*
-Returns the version of MariaDB Connector/C library as a tuple in the
-following format:
+Returns a version as a tuple. In version 2.0 this is the version of MariaDB
+Connector/Python itself and may include a release-stage suffix
+(for example `(2, 0, 0, 'rc2')`). In version 1.1 it is the version of the
+MariaDB Connector/C library, in the format:
 (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
 ## Exceptions

--- a/connectors/mariadb-connector-python/pooling.md
+++ b/connectors/mariadb-connector-python/pooling.md
@@ -103,11 +103,16 @@ with pool.acquire() as conn:
 # Connection automatically returned to pool
 ```
 
-**Example - URI Connection:**
+**Example - Connection Parameters:**
+
+The pool factories do not accept a connection URI string; pass connection settings as keyword arguments.
 
 ```python
 pool = mariadb.create_pool(
-    "mariadb://example_user:GHbe_Su3B8@localhost/test",
+    host="localhost",
+    user="example_user",
+    password="GHbe_Su3B8",
+    database="test",
     min_size=10,
     max_size=50
 )
@@ -164,7 +169,10 @@ async def lifespan(app: FastAPI):
     global pool
     # Startup: Create pool
     pool = await mariadb.create_async_pool(
-        "mariadb://user:password@localhost/mydb",
+        host="localhost",
+        user="user",
+        password="password",
+        database="mydb",
         min_size=10,
         max_size=50
     )

--- a/connectors/mariadb-connector-python/transactions-with-mariadb-connector-python.md
+++ b/connectors/mariadb-connector-python/transactions-with-mariadb-connector-python.md
@@ -161,7 +161,7 @@ async def async_transaction_example():
     )
     
     try:
-        cursor = await conn.cursor()
+        cursor = conn.cursor()
         
         # Start transaction (autocommit is False by default)
         await cursor.execute(

--- a/connectors/mariadb-connector-python/usage.md
+++ b/connectors/mariadb-connector-python/usage.md
@@ -116,8 +116,9 @@ As shown in previous example, passing parameters to SQL statements happens by us
 MariaDB Connector/Python uses a question mark as a placeholder, for compatibility reason also %s placeholders are supported.
 Passing parameters is supported in methods `execute()` and `executemany()` of the cursor class.
 
-*Since version 2.0:* By default, the text protocol is used for parameter binding. For binary protocol (prepared statements),
-set `binary=True` at connection or cursor level. Parameter escaping is handled automatically by the connector.
+By default, the text protocol is used for parameter binding. For binary protocol (prepared statements),
+set `binary=True` at the cursor level; *since version 2.0* `binary=True` can also be set at the connection
+level (in `connect()` or via a URI). Parameter escaping is handled automatically by the connector.
 
 ```python
 import mariadb


### PR DESCRIPTION
Corrects factual errors in the **MariaDB Connector/Python** documentation, found by the DOCS-6327 fact-check of every page against the connector source, pinned to both documented release lines: **1.1 (GA)** @ `3bd2378` and **2.0 (RC, 2.0.0rc2)** @ `b413858`. Each fix is source-verified (`file:line @ SHA` in the fact-check report).

Almost all issues are **2.0 staleness** — the pages were largely written against 1.1 behavior and not fully updated for 2.0's new defaults and API. ~235 of ~270 checked claims were already correct; this PR fixes the ~30 that weren't.

### 🔴 Copy-paste-breaking examples
- **`await conn.cursor()` → `conn.cursor()`** — on 2.0 `AsyncConnection.cursor()` is synchronous, so awaiting it raises `TypeError` (`async-usage`, `transactions`, `faq`).
- **Pooling URI examples** — `create_pool`/`create_async_pool` take no positional URI string (a positional arg binds to `min_size` → `TypeError`); switched to keyword connection params (`pooling`).

### 🟠 Wrong facts / defaults
- **2.0 secure-by-default**: `ssl` and `ssl_verify_cert` default `True` (were documented `False`).
- `socket_timeout` default `None` (not `30.0`); `cache_prep_stmts` default `False` (not `True`); cursor `buffered` default `True` (page said unbuffered/False in 2.0); `create_pool` `min_size` defaults to `max_size`.
- `threadsafety` is `3` in 2.0 (was `1`); `client_version` formula/meaning corrected per version.
- Removed the non-existent **`character_encoding`/`charset`** connect parameter (charset is fixed `utf8mb4`); `database` attribute relabeled read/write.
- Python floor is **3.10** for 2.0 / **3.8** for 1.1 (`install`, `migration`).
- metadata `charset` is a numeric id (not a name); `max_length` mirrors `length` in 2.0; `Cursor.next()`/`.statement`/`native_object` marked version-specific.

### 🟡 Mis-framed change notes (reworded)
- The **`prepared`/`binary`/`cursor_type`** story: `binary` already existed in 1.1; `prepared` is **deprecated, not renamed/removed**; `cursor_type` is removed **only in pure-Python** (2.0 C extension still accepts it) — corrected on `module`, `cursor`, `migration`, `faq`.
- `EXT_FIELD_TYPE` "since 2.0" removed (it exists in 1.1).
- `connect()`/`asyncConnect()` signatures corrected (no `dsn` param).
- `faq` multi-statement/`mogrify` answers no longer misattribute the limitation to a binary-protocol default (which also contradicted the same page).

The full claim-by-claim fact-check report (with source evidence) lives outside the repo under `reports_dir/connectors/DOCS-6327/` and will be posted to DOCS-6327 on handoff.

`docs-check` (codespell + lychee + structure) passes on all 11 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)