### PR TITLE
DOCS-6331 Fix Connector/ODBC docs against source (v3.2.10)

### DIFF
--- a/connectors/mariadb-connector-odbc/building-mariadb-connectorodbc-from-source.md
+++ b/connectors/mariadb-connector-odbc/building-mariadb-connectorodbc-from-source.md
@@ -73,7 +73,7 @@ This example will put your source tree into the 3.0.8 version state.
 You can build MariaDB Connector/ODBC by executing the [cmake](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command like the following:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCONC_WITH_MSI=OFF -DCMAKE_INSTALL_PREFIX=/usr/local .
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_INSTALL_PREFIX=/usr/local .
 cmake --build . --config RelWithDebInfo
 ```
 

--- a/connectors/mariadb-connector-odbc/creating-a-data-source-with-mariadb-connectorodbc.md
+++ b/connectors/mariadb-connector-odbc/creating-a-data-source-with-mariadb-connectorodbc.md
@@ -10,7 +10,7 @@ description: >-
 **MariaDB Connector/ODBC** is a database driver that uses the industry standard [Open Database Connectivity (ODBC) API](https://en.wikipedia.org/wiki/Open_Database_Connectivity). Some of the key features of the driver are:
 
 * It is [LGPL-licensed](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/faq/licensing-questions/licensing-faq).
-* It is compliant with the ODBC 3.5 standard.
+* It is compliant with the ODBC 3.8 standard.
 * It can be used as a drop-in replacement for MySQL Connector/ODBC.
 * It supports both Unicode and ANSI modes.
 * It primarily uses the MariaDB/MySQL binary protocol (i.e. server-side [prepared statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/prepared-statements)).
@@ -60,8 +60,8 @@ The first step is to configure UnixODBC to recognize MariaDB Connector/ODBC as a
 For example, create a template file similar to the following, with a name like `MariaDB_odbc_driver_template.ini`:
 
 ```
-[MariaDB ODBC 3.0 Driver]
-Description = MariaDB Connector/ODBC v.3.0
+[MariaDB ODBC 3.2 Driver]
+Description = MariaDB Connector/ODBC v.3.2
 Driver = /usr/lib64/libmaodbc.so
 ```
 
@@ -71,7 +71,7 @@ And then install it to the system's global `/etc/odbcinst.ini` file with the fol
 sudo odbcinst -i -d -f MariaDB_odbc_driver_template.ini
 ```
 
-At this point, you should be able to connect to MariaDB by using the `Driver` with the `SQLDriverConnect` function. To connect with `SQLDriverConnect`, you would need to specify `Driver={MariaDB ODBC 3.0 Driver}` in your connection string along with your other connection parameters.
+At this point, you should be able to connect to MariaDB by using the `Driver` with the `SQLDriverConnect` function. To connect with `SQLDriverConnect`, you would need to specify `Driver={MariaDB ODBC 3.2 Driver}` in your connection string along with your other connection parameters.
 
 See [Parameters](mariadb-connector-odbc-guide.md#parameters) for connection string options.
 
@@ -84,7 +84,7 @@ For example, create a template file similar to the following, with a name like `
 ```
 [MariaDB-server]
 Description=MariaDB server
-Driver=MariaDB ODBC 3.0 Driver
+Driver=MariaDB ODBC 3.2 Driver
 SERVER=<your server>
 USER=<your user>
 PASSWORD=<your password>
@@ -188,10 +188,10 @@ To add MariaDB Connector/ODBC as a `Driver`, the configuration file would look s
 
 ```
 [ODBC Drivers]
-MariaDB ODBC 3.1 Driver = installed
+MariaDB ODBC 3.2 Unicode Driver = installed
 
-[MariaDB ODBC 3.1 Driver]
-Description=MariaDB Connector/ODBC v.3.1
+[MariaDB ODBC 3.2 Unicode Driver]
+Description=MariaDB Connector/ODBC v.3.2
 Driver=/Library/MariaDB/MariaDB-Connector-ODBC/libmaodbc.dylib
 Threading=0
 ```
@@ -219,7 +219,7 @@ TraceFile = /tmp/odbc-tracefile.log
 TraceAutoStop = 1
 
 [ODBC Data Sources]
-MariaDB-server = MariaDB ODBC 3.1 Driver
+MariaDB-server = MariaDB ODBC 3.2 Unicode Driver
 
 [MariaDB-server]
 Description = MariaDB server

--- a/connectors/mariadb-connector-odbc/mariadb-connector-odbc-guide.md
+++ b/connectors/mariadb-connector-odbc/mariadb-connector-odbc-guide.md
@@ -12,7 +12,7 @@ description: >-
 **MariaDB Connector/ODBC** is a database driver that uses the industry standard [Open Database Connectivity (ODBC) API](https://en.wikipedia.org/wiki/Open_Database_Connectivity). Some of the key features of the driver are:
 
 * It is [LGPL-licensed](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/faq/licensing-questions/licensing-faq).
-* It is compliant with the ODBC 3.5 standard.
+* It is compliant with the ODBC 3.8 standard.
 * It can be used as a drop-in replacement for MySQL Connector/ODBC.
 * It supports both Unicode and ANSI modes.
 * It primarily uses the MariaDB/MySQL binary protocol (i.e. server-side [prepared statements](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements-and-structure/sql-statements/prepared-statements)).
@@ -169,7 +169,7 @@ The connector will need to use client authentication plugins in the following sc
 
 If you need client authentication plugins in a version which does not bundle them with the connector, then you will also need to install [MariaDB Connector/C](../connectors-quickstart-guides/mariadb-connector-c-guide.md), which installs the client authentication plugins as shared libraries, which can be used by MariaDB Connector/ODBC.
 
-MariaDB Connector/ODBC can be configured to use MariaDB Connector/C's client authentication plugins by setting the `PLUGINDIR` parameter to the MariaDB Connector/C's plugin directory. The plugin directory can also be specified with the `MARIADB_PLUGIN_DIR` environment variable.
+MariaDB Connector/ODBC can be configured to use MariaDB Connector/C's client authentication plugins by setting the `PLUGIN_DIR` parameter to the MariaDB Connector/C's plugin directory. The plugin directory can also be specified with the `MARIADB_PLUGIN_DIR` environment variable.
 
 On Windows, MariaDB Connector/C often installs plugins to one of the following directories:
 
@@ -188,7 +188,7 @@ When you install the client authentication plugins, ensure that they are for the
 ### DSN-Related Parameters
 
 * `DSN`: Name of the DSN
-* `Driver`: The name of the MariaDB ODBC Driver. On Windows, this must be `{MariaDB ODBC 3.1 Driver}` for 3.1 drivers, or for versions from other release series, you must use the corresponding version number for that release series. On Linux, either this must be a path to the driver's shared library or it must match the `Driver` name that you provided when you [configured the Driver with UnixODBC](creating-a-data-source-with-mariadb-connectorodbc.md#configuring-mariadb-connectorodbc-as-a-unixodbc-driver-on-linux).
+* `Driver`: The name of the MariaDB ODBC Driver. On Windows, this must be `{MariaDB ODBC 3.2 Driver}` for 3.2 drivers, or for versions from other release series, you must use the corresponding version number for that release series. On Linux, either this must be a path to the driver's shared library or it must match the `Driver` name that you provided when you [configured the Driver with UnixODBC](creating-a-data-source-with-mariadb-connectorodbc.md#configuring-mariadb-connectorodbc-as-a-unixodbc-driver-on-linux).
 * `Description`: Description of the data source.
 * `SaveFile`: Save a string representation of the DSN to this file.
 * `FileDSN`: The file where the string representation of the DSN can be read.
@@ -211,7 +211,7 @@ When you install the client authentication plugins, ensure that they are for the
   * 4(16) - See `NO_PROMPT`
   * 5(32) - Forces use of dynamic cursor
   * 6(64) - Forbids the use of database.tablename.column syntax
-  * 7(128) Allows `[load-data-infile|LOAD DATA INFILE LOCAL]`
+  * 7(128) - No default cursor
   * 11(2048) - Tells connector to use compression protocol
   * 13(8192) - See `NAMEDPIPE`
   * 16(65536) - See `USE_MYCNF`


### PR DESCRIPTION
Corrects factual errors in the **MariaDB Connector/ODBC** documentation, found by the DOCS-6331 fact-check of the 4-page space against the source at `master` @ `4e175d9` (**v03.02.0010 = 3.2.10 GA**). Each fix was independently re-verified against source. Version-targeting was checked up front: the docs state 3.2 is the current series and `master` = 3.2.10, so no mismatch. The connection-string parameter table verified almost entirely correct against `driver/ma_dsn.c` (`DsnKeys[]`).

**6 discrepancy groups fixed across 3 pages** (README clean).

- **ODBC standard version** — "compliant with the ODBC **3.5** standard" → **3.8** (guide + data-source). The driver reports `SQL_DRIVER_ODBC_VER = "03.80"` and supports `SQL_OV_ODBC3_80` (`ma_connection.cpp:1466`, `ma_environment.cpp:31-32`); the guide's own line 389 already said 3.8.
- **OPTION bit 7 (128)** — "Allows LOAD DATA INFILE LOCAL" → **"No default cursor"** (`MADB_OPT_FLAG_NO_DEFAULT_CURSOR`, `ma_dsn.h:32`). LOCAL INFILE is controlled by the `NOLOCALINFILE` keyword, not an OPTION bit.
- **Typo** — `PLUGINDIR` → `PLUGIN_DIR` (`ma_dsn.c:67`), matching the correct spelling used elsewhere on the same page.
- **Build command** — removed `-DCONC_WITH_MSI=OFF` from the Unix `cmake` invocation; it's a Windows-only option, force-set `OFF` on non-Windows (a no-op there).
- **Stale driver-name examples** (data-source page) — Linux `MariaDB ODBC 3.0 Driver` → `3.2`; macOS `MariaDB ODBC 3.1 Driver` → `MariaDB ODBC 3.2 Unicode Driver`; Windows example `3.1` → `3.2`, per the current 3.2 packaging (`packaging/linux/maodbc.ini.in`, `packaging/macos/scripts/postinstall.in`, `packaging/windows/mariadb_odbc.xml.in`).

### Not changed (deliberate)
`FileDSN`/`TraceFile` are legitimate ODBC **Driver-Manager** keywords (handled by the DM, not the connector) — documenting them is acceptable, not a bug. Undocumented source keywords (`READ_TIMEOUT`, `NOLOCALINFILE`, …) are a coverage gap, not an error. Illustrative stale install versions (`3.1.7`, `git checkout 3.0.8`) left as-is (patterns valid). "Primary vs alias" for `USER`/`PWD`/`OPTION` — both spellings are accepted.

The full claim-by-claim report (with `file:line @ SHA` evidence) lives under `reports_dir/connectors/DOCS-6331/`. `docs-check` (codespell + lychee) passes on all 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)