### PR TITLE
DOCS-6335 Fix dead links across Connectors docs (lychee sweep)

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -73,7 +73,27 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude '127\.0\.0\.1' \
       --exclude 'http://localhost:[0-9]+.*' \
       --exclude 'https://localhost:[0-9]+.*' \
+      --exclude 'access\.redhat\.com' \
+      --exclude 'docs\.redhat\.com' \
+      --exclude 'blogs\.oracle\.com' \
+      --exclude 'bugs\.mysql\.com' \
+      --exclude 'forums\.mysql\.com' \
+      --exclude 'www\.mysql\.com' \
+      --exclude 'en\.opensuse\.org' \
+      --exclude 'www\.cyberciti\.biz' \
+      --exclude 'linux\.die\.net' \
+      --exclude 'mariadb\.org\/feedback_plugin' \
       --exclude 'r\.mariadb\.com' \
+      --exclude 'security-certs\.docs\.ubuntu\.com' \
+      --exclude 'www\.linux-pam\.org' \
+      --exclude 'www\.bzip\.org' \
+      --exclude 'selinuxproject\.org' \
+      --exclude 'www\.gnu\.org' \
+      --exclude 'manpages\.ubuntu\.com' \
+      --exclude 'packages\.ubuntu\.com' \
+      --exclude 'www\.canonware\.com' \
+      --exclude 'www\.npmjs\.com' \
+      --exclude 'npmjs\.org' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.codespellignore
+++ b/.codespellignore
@@ -12,3 +12,4 @@ ment
 mater
 te
 bu
+benchs

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -61,6 +61,8 @@ jobs:
             --exclude manpages\.ubuntu\.com
             --exclude packages\.ubuntu\.com
             --exclude www\.canonware\.com
+            --exclude www\.npmjs\.com
+            --exclude npmjs\.org
             ${{ steps.changes.outputs.all_changed_files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/connectors/connectors-quickstart-guides/connector-python-guide.md
+++ b/connectors/connectors-quickstart-guides/connector-python-guide.md
@@ -262,6 +262,6 @@ asyncio.run(main())
 
 * [PyPI MariaDB Connector/Python](https://pypi.org/project/mariadb/)
 * [MariaDB Connector/Python Documentation](https://mariadb-corporation.github.io/mariadb-connector-python/)
-* [Migration Guide (1.1 to 2.0)](https://mariadb-corporation.github.io/mariadb-connector-python/migration-from-1.1-to-2.0.html)
-* [Async/Await Support](https://mariadb-corporation.github.io/mariadb-connector-python/async-usage.html)
+* Migration Guide (1.1 to 2.0)
+* Async/Await Support
 * [MariaDB Developers Python Quickstart (GitHub)](https://github.com/mariadb-developers/python-quickstart)

--- a/connectors/connectors-quickstart-guides/mariadb-connector-c-guide.md
+++ b/connectors/connectors-quickstart-guides/mariadb-connector-c-guide.md
@@ -44,7 +44,7 @@ If you're using Linux, the simplest way to install MariaDB Connector/C is via yo
 You can set up your repository using:
 
 * MariaDB Corporation's [MariaDB Package Repository setup script](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
-* MariaDB Foundation's [MariaDB Repository Configuration Tool](/broken/spaces/SsmexDFPv2xG2OTyO5yV/pages/0B9HhpsUkjLe15Lk8wbL).
+* MariaDB Foundation's MariaDB Repository Configuration Tool.
 
 **Install with `yum`/`dnf` (RHEL, CentOS, Fedora)**
 

--- a/connectors/mariadb-connector-c/api-prepared-statement-functions/mysql_stmt_param_count.md
+++ b/connectors/mariadb-connector-c/api-prepared-statement-functions/mysql_stmt_param_count.md
@@ -31,7 +31,7 @@ This function will not deliver a valid result until [mysql\_stmt\_prepare()](mys
 
 ## See Also
 
-* [mysql\_stmt\_prepare()](https://github.com/mariadb-corporation/docs-connectors/blob/test/mariadb-connector-c/mariadb-connectorc-api-prepared-statement-functions/mysql_stmt_prepare\(\)/README.md)
+* [mysql\_stmt\_prepare()](mysql_stmt_prepare.md)
 * [mysql\_stmt\_field\_count()](mysql_stmt_field_count.md)
 
 {% @marketo/form formId="4316" %}

--- a/connectors/mariadb-connector-c/mariadb-binlogreplication-api-reference/replication-api-function-reference/mariadb_rpl_fetch.md
+++ b/connectors/mariadb-connector-c/mariadb-binlogreplication-api-reference/replication-api-function-reference/mariadb_rpl_fetch.md
@@ -20,7 +20,7 @@ MARIADB_RPL_EVENT *mariadb_rpl_fetch(MARIADB_RPL *rpl,
 
 ### Return Value
 
-Returns a pointer to a [`MARIADB_RPL_EVENT`](http://replication-api-data-structures.md/#mariadb_rpl_event) structure containing the next event on success, or `NULL` when the EOF packet is received or an error occurs.
+Returns a pointer to a [`MARIADB_RPL_EVENT`](../binlog-api-data-structures.md#mariadb_rpl_event) structure containing the next event on success, or `NULL` when the EOF packet is received or an error occurs.
 
 ### Note
 

--- a/connectors/mariadb-connector-c/mariadb-connector-c-guide.md
+++ b/connectors/mariadb-connector-c/mariadb-connector-c-guide.md
@@ -136,7 +136,7 @@ The function reference is available at:
 * [MariaDB Client Library for C API Functions](api-functions/)
 * [MariaDB Client Library for C API Prepared Statement Functions](api-prepared-statement-functions/)
 
-It is also downloadable in html format from [mariadb-client-doc.zip](https://mariadb.org/files/mariadb-client-doc.zip)
+It is also downloadable in html format from mariadb-client-doc.zip
 
 ## Configuring MariaDB Connector/C with Option Files
 

--- a/connectors/mariadb-connector-c/other-c-c-connectors/mysql-client-library-32358.md
+++ b/connectors/mariadb-connector-c/other-c-c-connectors/mysql-client-library-32358.md
@@ -41,7 +41,7 @@ Monty Program AB is about to start a project for creating a new free client libr
 
 If you want to be part of this development effort, you can discuss this on the [maria-developers mailing list](https://launchpad.net/~maria-developers).
 
-If you are interested in sponsoring this effort, you can [contact Monty Program](https://montyprogram.com/contact).
+If you are interested in sponsoring this effort, you can contact Monty Program.
 
 ## See also:
 

--- a/connectors/mariadb-connector-nodejs/connector-nodejs-batch-api.md
+++ b/connectors/mariadb-connector-nodejs/connector-nodejs-batch-api.md
@@ -41,7 +41,7 @@ connection.query("INSERT INTO BASKET(customerId) values (?)", [1], (err, res) =>
 ### Performance comparison
 
 Some benchmark to do some 100 inserts with one parameter of 100 characters:
-(benchmark source - see [standard insert](https://github.com/mariadb-corporation/mariadb-connector-nodejs/benchmarks/benchs/insert_pipelining.js) and [batch insert](https://github.com/mariadb-corporation/mariadb-connector-nodejs/benchmarks/benchs/insert_batch.js) )
+(benchmark source - see [standard insert](https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/master/benchmarks/benchs/insert_pipelining.js) and [batch insert](https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/master/benchmarks/benchs/insert_batch.js) )
 
 ![pipelining](../.gitbook/assets/batch-bench.png)
 

--- a/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
+++ b/connectors/mariadb-connector-nodejs/getting-started-with-the-node-js-connector.md
@@ -83,7 +83,7 @@ asyncFunction().then(() => {
 
 The MariaDB Connector has a [Promise](connector-nodejs-promise-api.md) *(Default)* and [callback](connector-nodejs-callback-api.md)[^1] API.
 
-[Typescript specific docs are also available](../mariadb-connector-nodejs/connector-nodejs-promise-api#typescript-usage).
+[Typescript specific docs are also available](../mariadb-connector-nodejs/connector-nodejs-promise-api.md#typescript-usage).
 
 [^1]: The callback API is provided for compatibility with the mysql and mysql2 APIs.
 

--- a/connectors/mariadb-connector-nodejs/other-nodejs-connectors/javascript-mariasql-for-nodejs.md
+++ b/connectors/mariadb-connector-nodejs/other-nodejs-connectors/javascript-mariasql-for-nodejs.md
@@ -17,7 +17,7 @@ Install it with the `npm` package installer:
 npm install mariasql
 ```
 
-In [benchmarks](https://mscdex.github.com/node-mysql-benchmarks/), mariasql performs much better than libmysqlclient.
+In [benchmarks](https://mscdex.github.io/node-mysql-benchmarks/), mariasql performs much better than libmysqlclient.
 
 The source code is located at [github:node-mariasql](https://github.com/mscdex/node-mariasql).
 

--- a/connectors/other/mariadb-jupyter-kernel/using-the-kernel/general-mariadb-jupyter-kernel-usage-information.md
+++ b/connectors/other/mariadb-jupyter-kernel/using-the-kernel/general-mariadb-jupyter-kernel-usage-information.md
@@ -7,7 +7,7 @@ description: >-
 
 # General MariaDB Jupyter Kernel Usage Information
 
-If you installed the kernel, installed its [kernelspec](https://jupyter-client.readthedocs.io/en/stable/api/kernelspec.html) and you have MariaDB installed on your system, you just need to open [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), and when you create a new notebook, pick MariaDB as your kernel.
+If you installed the kernel, installed its kernelspec and you have MariaDB installed on your system, you just need to open [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), and when you create a new notebook, pick MariaDB as your kernel.
 
 ![](../../../.gitbook/assets/lab_open.png)
 

--- a/connectors/other/mariadb-jupyter-kernel/using-the-kernel/sql-autocompletion-and-introspection.md
+++ b/connectors/other/mariadb-jupyter-kernel/using-the-kernel/sql-autocompletion-and-introspection.md
@@ -64,7 +64,7 @@ Here's a summary of our autocompletion capabilities, but we strongly recommend y
 ## Introspection
 
 Code introspection in Jupyter can be triggered with the `SHIFT-TAB` combination.\
-This feature was designed to help you understand your database environment faster whilst typing SQL statements, for instance checking the table schema by inspecting on the table name before selecting a bunch of columns, or even checking the documentation of a SQL function to see the function signature and some practical examples and spare you an extra search on [MariaDB Documentation](broken-reference).
+This feature was designed to help you understand your database environment faster whilst typing SQL statements, for instance checking the table schema by inspecting on the table name before selecting a bunch of columns, or even checking the documentation of a SQL function to see the function signature and some practical examples and spare you an extra search on MariaDB Documentation.
 
 Although we tried to make introspection look exactly the same in both classic Jupyter Notebook and Jupyterlab interfaces, it wasn't possible due to some fundamental difference in how Notebook renders the introspection tooltip in comparison to the newer JupyterLab interface.\
 For the moment, to see the full introspection information in Notebook that the MariaDB kernel sends to the frontend, you'll need to hit `shift-tab` then click on the expand button from the tooltip to get the `HTML` representation of the introspection information.


### PR DESCRIPTION
Whole-space **lychee sweep** of `connectors/**` (292 pages), run with the CI `link-check-pr.yml` exclude set so results predict CI. Because lychee only checks *changed* files, pre-existing dead links surface one PR at a time (they bit PR #743); this flushes them out in one pass.

**Sweep:** 2,584 links checked → 22 errors + 1 timeout. 7 errors were the GSSAPI page already fixed in PR #743, leaving **12 broken links + 1 timeout** fixed here across 10 files, plus 3 npm 403s handled via a CI exclude.

### Repointed (verified HTTP 200)
- `connector-nodejs-batch-api.md` — 2 benchmark URLs missing `/blob/master/`.
- `javascript-mariasql-for-nodejs.md` — `mscdex.github.com` → `.github.io` (typo host).
- `getting-started-with-the-node-js-connector.md` — link missing `.md` → `connector-nodejs-promise-api.md#typescript-usage`.
- `mysql_stmt_param_count.md` (C) — 404 in the retired `docs-connectors` repo → internal `mysql_stmt_prepare.md`.
- `mariadb_rpl_fetch.md` (C) — malformed `http://replication-api-data-structures.md/#…` → `../binlog-api-data-structures.md#mariadb_rpl_event`.

### Unlinked (dead, no verified replacement — text kept, href dropped)
- `connector-python-guide.md` — 2× `mariadb-corporation.github.io/…` (migration / async) 404.
- `mariadb-connector-c-guide.md` (quickstart) — GitBook `/broken/spaces/…` artifact.
- `mariadb-connector-c-guide.md` (C) — `mariadb.org/files/mariadb-client-doc.zip` 404.
- jupyter kernel: `jupyter-client.readthedocs.io/…/kernelspec.html` 404 (moved), and a `broken-reference` artifact.
- `mysql-client-library-32358.md` — `montyprogram.com/contact` (defunct domain, timeout).

Text is preserved so the connector teams can supply correct targets later.

### CI / tooling
- Added `www.npmjs.com` + `npmjs.org` to `link-check-pr.yml` (npm bot-blocks crawlers with 403, like the ~28 domains already excluded; the links work for readers and npm is the canonical page).
- Reconciled `.claude/hooks/doc-lint.sh` — it had **drifted** to 10 of the workflow's 28 excludes despite a comment claiming parity; now matches the full set + npm, so local `docs-check` truly mirrors CI.
- `.codespellignore`: added `benchs` (the real `benchmarks/benchs/` directory name; codespell flagged it on the repointed URL line).

Sweep report attached to DOCS-6335. GSSAPI links intentionally excluded (fixed in #743).

🤖 Generated with [Claude Code](https://claude.com/claude-code)