### PR TITLE
DOCS-6329 SmartRouter: note Exasol as an analytical backend

### DIFF
--- a/maxscale/reference/maxscale-routers/maxscale-smartrouter.md
+++ b/maxscale/reference/maxscale-routers/maxscale-smartrouter.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Intelligently route queries based on workload type. SmartRouter directs
-  transactional queries to MariaDB and analytical queries to column-store
-  engines for hybrid processing.
+  Intelligently route queries by workload type. SmartRouter directs
+  transactional queries to MariaDB and analytical queries to an analytical
+  backend such as ColumnStore or Exasol, for hybrid (HTAP) processing.
 ---
 
 # MaxScale SmartRouter
@@ -12,6 +12,12 @@ description: >-
 SmartRouter is the query router of the SmartQuery framework. Based on the type of the query, each query is routed to the server or cluster that can best handle it.
 
 For workloads where both transactional and analytical queries are needed, SmartRouter unites the Transactional (OLTP) and Analytical (OLAP) workloads into a single entry point in MaxScale. This allows a MaxScale client to freely mix transactional and analytical queries using the same connection. This is known as Hybrid Transactional and Analytical Processing, HTAP.
+
+The transactional cluster is typically a primary-replica MariaDB deployment fronted by [ReadWriteSplit](maxscale-readwritesplit.md). The analytical cluster can be MariaDB ColumnStore or an Exasol analytics engine — the configuration examples below use ColumnStore, but SmartRouter treats each configured target the same way and routes each query to whichever one answers it fastest.
+
+{% hint style="info" %}
+To use Exasol as the analytical cluster, configure it through the [Exasolrouter](maxscale-exasolrouter.md), which is available from MaxScale 25.10.1.
+{% endhint %}
 
 ## Settings
 


### PR DESCRIPTION
## What

The [SmartRouter reference page](https://mariadb.com/docs/maxscale/reference/maxscale-routers/maxscale-smartrouter) described the analytical cluster as ColumnStore only. As reported in DOCS-6329, this omits Exasol.

SmartRouter is engine-agnostic: it routes each read to whichever configured target answers fastest. As of **MaxScale 25.10.1**, the analytical target can be an **Exasol** analytics engine via the [Exasolrouter](https://mariadb.com/docs/maxscale/reference/maxscale-routers/maxscale-exasolrouter) — whose own reference page states it is "primarily intended to be used together with SmartRouter."

## Changes

- Frontmatter `description`: names both ColumnStore and Exasol as analytical backends.
- **Overview**: adds a sentence explaining the analytical cluster can be ColumnStore or Exasol, clarifying SmartRouter treats each target the same way; plus an info hint pointing to the Exasolrouter (MaxScale 25.10.1+).

The ColumnStore-based configuration examples are unchanged.

## Verification

Fact-checked against the MaxScale source (`exasolrouter` module, GA in 25.10.1) and the existing public Exasolrouter reference + tutorial pages. `docs-check` (codespell + lychee + structural) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)