### PR TITLE
DOCS-6214: document 2026Q2 platform deprecations in Community Server release notes

### DIFF
--- a/release-notes/community-server/10.11/10.11.18.md
+++ b/release-notes/community-server/10.11/10.11.18.md
@@ -34,6 +34,10 @@ MariaDB 10.11.18 is a [Stable (GA)](../about/release-criteria.md) **corrective r
 
 * The server failed to parse schema-qualified table names when the unquoted table name began with a digit [MDEV-39654](https://jira.mariadb.org/browse/MDEV-39654)
 
+### General
+
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 10.11](what-is-mariadb-1011.md) for Fedora 42
+
 ### Security
 
 Fixes for the following security vulnerabilities

--- a/release-notes/community-server/11.4/11.4.12.md
+++ b/release-notes/community-server/11.4/11.4.12.md
@@ -34,6 +34,10 @@ MariaDB 11.4.12 is a [Stable (GA)](../about/release-criteria.md) **corrective re
 
 * The server failed to parse schema-qualified table names when the unquoted table name began with a digit [MDEV-39654](https://jira.mariadb.org/browse/MDEV-39654)
 
+### General
+
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.4](what-is-mariadb-114.md) for Ubuntu 25.04 "Plucky Puffin" and Fedora 42
+
 ### Security
 
 Fixes for the following security vulnerabilities

--- a/release-notes/community-server/11.8/11.8.8.md
+++ b/release-notes/community-server/11.8/11.8.8.md
@@ -32,6 +32,10 @@ MariaDB 11.8.8 is a [Stable (GA)](../about/release-criteria.md) **corrective rel
 
 * The server failed to parse schema-qualified table names when the unquoted table name began with a digit [MDEV-39654](https://jira.mariadb.org/browse/MDEV-39654)
 
+### General
+
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.8](what-is-mariadb-118.md) for Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
+
 ### Security
 
 Fixes for the following security vulnerabilities

--- a/release-notes/community-server/12.3/12.3.2.md
+++ b/release-notes/community-server/12.3/12.3.2.md
@@ -49,7 +49,7 @@ Thanks, and enjoy MariaDB!
 ### MariaDB Cluster (Galera)
 
 * A new `mariadb-server-galera` package now exists for Deb and RPM packages for ease of installing a galera system and pulling in its dependencies. Without galera, `mariadb-server` can be used
-* Those on Galera systems will need to install `mariadb-server-galera` explicity as an upgrade from previous versions will result in galera dependencies being installed but not updated having a package dependency of MariaDB requiring them. Also the systemd service definations will not be galera-capable for bootstrap or SST transfers without the `mariadb-server-galera` package
+* Those on Galera systems will need to install `mariadb-server-galera` explicitly as an upgrade from previous versions will result in galera dependencies being installed but not updated having a package dependency of MariaDB requiring them. Also the systemd service definitions will not be galera-capable for bootstrap or SST transfers without the `mariadb-server-galera` package
 * RPMs currently require explicit installation of `galera-4` along with the any dependencies used for SST, such as rsync, socat, lsof, grep, gawk, iproute, coreutils, findutils, and/or tar
 * The `wsrep_info` plugin is installed by default with the `mariadb-server-galera` package
 
@@ -64,6 +64,10 @@ Thanks, and enjoy MariaDB!
 ### Systemd
 
 * Use of the `MYSQLD_OPTS` as an environment variable for systemd services is deprecated and will be removed in a later release. Place configuration option in configuration files
+
+### General
+
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 12.3](mariadb-12.3-changes-and-improvements.md) for Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
 
 ### Security
 


### PR DESCRIPTION
Documents the 2026Q2 platform deprecations in the Community Server release notes, per [DOCS-6214](https://mariadbcorp.atlassian.net/browse/DOCS-6214).

## What changed

Added a **General** subsection (single bullet, matching the historical house style) recording the final platform builds, placed **above** the Security section so Security stays last before the Changelog:

| Release | Last release for |
|---|---|
| `10.11.18` | Fedora 42 |
| `11.4.12` | Ubuntu 25.04 "Plucky Puffin" and Fedora 42 |
| `11.8.8` | Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42 |
| `12.3.2` | Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42 |

Also fixed two typos in the 12.3.2 Galera notes (`explicity`→`explicitly`, `definations`→`definitions`).

## Decisions

- **Community Server only.**
- **Deprecations only** — no per-release source ties an added platform to these versions.
- **13.0.1 excluded** — platform notes don't go on RC / initial-GA release notes.
- **OpenSUSE Leap 15.6 omitted** — it's in the policy page for these versions, but didn't actually ship as its final build here. The policy page row is left as-is and tracked separately in [DOCS-6339](https://mariadbcorp.atlassian.net/browse/DOCS-6339).

Source of truth for the mapping: `release-notes/community-server/about/platform-deprecation-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6214]: https://mariadbcorp.atlassian.net/browse/DOCS-6214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-6339]: https://mariadbcorp.atlassian.net/browse/DOCS-6339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ