### PR TITLE
DOCS-6223 Document LOCAL spvar syntax for prepared statements and cur…

### DIFF
--- a/server/reference/sql-statements/prepared-statements/deallocate-drop-prepare.md
+++ b/server/reference/sql-statements/prepared-statements/deallocate-drop-prepare.md
@@ -9,7 +9,7 @@ description: >-
 ## Syntax
 
 ```bnf
-{DEALLOCATE | DROP} PREPARE stmt_name
+{DEALLOCATE | DROP} PREPARE [LOCAL] stmt_name
 ```
 
 ## Description
@@ -28,6 +28,32 @@ If the specified statement has not been PREPAREd, an error similar to the follow
 
 ```sql
 ERROR 1243 (HY000): Unknown prepared statement handler (stmt_name) given to DEALLOCATE PREPARE
+```
+
+### LOCAL Statement Names
+
+{% hint style="info" %}
+`{DEALLOCATE | DROP} PREPARE LOCAL` is available from MariaDB 13.1.1.
+{% endhint %}
+
+Inside a stored procedure, `LOCAL` deallocates the prepared statement whose name is the _value_ of the stored-procedure variable `spvar`:
+
+```sql
+{DEALLOCATE | DROP} PREPARE LOCAL spvar;
+```
+
+It is only valid inside a stored procedure, and like the plain form is not permitted in stored functions or triggers.
+
+**Example:**
+
+```sql
+CREATE PROCEDURE p1()
+BEGIN
+  DECLARE spvar_with_ps_name VARCHAR(64) DEFAULT 'my_stmt';
+
+  PREPARE my_stmt FROM 'SELECT 1';
+  DEALLOCATE PREPARE LOCAL spvar_with_ps_name;
+END;
 ```
 
 ## Example

--- a/server/reference/sql-statements/prepared-statements/execute-statement.md
+++ b/server/reference/sql-statements/prepared-statements/execute-statement.md
@@ -9,7 +9,7 @@ description: >-
 ## Syntax
 
 ```bnf
-EXECUTE stmt_name
+EXECUTE [LOCAL] stmt_name
     [USING expression[, expression] ...]
 ```
 
@@ -34,6 +34,27 @@ ERROR 1243 (HY000): Unknown prepared statement handler (stmt_name) given to EXEC
 You can only use user variables (@var\_name) as parameters.
 {% endtab %}
 {% endtabs %}
+
+### LOCAL Statement Names
+
+{% hint style="info" %}
+`EXECUTE LOCAL` is available from MariaDB 13.1.1.
+{% endhint %}
+
+Inside a stored procedure, `EXECUTE LOCAL spvar` executes the prepared statement whose name is the _value_ of the stored-procedure variable `spvar`, rather than a literal name. A `USING` clause is supported as usual. `EXECUTE LOCAL` is only valid inside a stored procedure, and like the plain form is not permitted in stored functions or triggers.
+
+**Example:**
+
+```sql
+CREATE PROCEDURE p1()
+BEGIN
+  DECLARE spvar_with_ps_name VARCHAR(64) DEFAULT 'my_stmt';
+  DECLARE a INT DEFAULT 5;
+
+  PREPARE my_stmt FROM 'SELECT ?';
+  EXECUTE LOCAL spvar_with_ps_name USING a;
+END;
+```
 
 ## Example
 

--- a/server/reference/sql-statements/prepared-statements/prepare-statement.md
+++ b/server/reference/sql-statements/prepared-statements/prepare-statement.md
@@ -9,7 +9,7 @@ description: >-
 ## Syntax
 
 ```bnf
-PREPARE stmt_name FROM preparable_stmt
+PREPARE [LOCAL] stmt_name FROM preparable_stmt
 ```
 
 ## Description
@@ -53,6 +53,35 @@ ERROR 1461 (42000): Can't create more than max_prepared_stmt_count statements
 ### Oracle Mode
 
 In [Oracle mode](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/about/compatibility-and-differences/sql_modeoracle), `PREPARE stmt FROM 'SELECT :1, :2'` is used instead of `?`.
+
+### LOCAL Statement Names
+
+{% hint style="info" %}
+`PREPARE LOCAL` is available from MariaDB 13.1.1.
+{% endhint %}
+
+Inside a stored procedure, `PREPARE LOCAL` takes the prepared statement name from the _value_ of a stored-procedure variable instead of from a literal identifier:
+
+```sql
+PREPARE LOCAL spvar FROM preparable_stmt;
+```
+
+Here `spvar` is a local variable (or routine parameter) whose string value is used as the prepared statement name — useful when the name must be computed at runtime. `LOCAL` does not create a separate namespace: a statement prepared with `PREPARE LOCAL` can be executed or deallocated by its resolved name with a plain [EXECUTE](execute-statement.md) or [DEALLOCATE PREPARE](deallocate-drop-prepare.md), and the reverse also works.
+
+`PREPARE LOCAL` is only valid inside a stored procedure, and like the plain form is not permitted in stored functions or triggers.
+
+**Example:**
+
+```sql
+CREATE PROCEDURE p1()
+BEGIN
+  DECLARE spvar_with_ps_name VARCHAR(64) DEFAULT 'my_stmt';
+
+  PREPARE LOCAL spvar_with_ps_name FROM 'SELECT 1';
+  EXECUTE my_stmt;
+  DEALLOCATE PREPARE my_stmt;
+END;
+```
 
 ## Permitted Statements
 

--- a/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/open.md
+++ b/server/reference/sql-statements/programmatic-compound-statements/programmatic-compound-statements-cursors/open.md
@@ -15,6 +15,13 @@ OPEN cursor_name [[USING variable[,...]] | [expression[,...]]];
 OPEN cursor_variable FOR dynamic_sql_string;
 ```
 {% endcode %}
+
+{% code title="-- From MariaDB 13.1.1" %}
+```sql
+OPEN cursor_variable FOR PREPARE stmt_name;
+OPEN cursor_variable FOR LOCAL spvar;
+```
+{% endcode %}
 {% endtab %}
 
 {% tab title="< 10.3" %}
@@ -33,6 +40,21 @@ The query associated to the `DECLARE CURSOR` is executed when `OPEN` is executed
 This is necessary in order to [FETCH](fetch.md) rows from a cursor.
 
 See [Cursor Overview](cursor-overview.md) for an example.
+
+### Opening a Cursor Over a Prepared Statement
+
+{% hint style="info" %}
+`OPEN ... FOR PREPARE` and `OPEN ... FOR LOCAL` are available from MariaDB 13.1.1.
+{% endhint %}
+
+In Oracle mode, a `SYS_REFCURSOR` can be opened over an already-prepared statement:
+
+* `OPEN cursor_variable FOR PREPARE stmt_name;` opens the cursor over the prepared statement named `stmt_name`.
+* `OPEN cursor_variable FOR LOCAL spvar;` opens the cursor over the prepared statement whose name is the _value_ of the stored-procedure variable `spvar`.
+
+`OPEN ... FOR LOCAL` is only valid inside a stored procedure, and like the other LOCAL forms is not permitted in stored functions or triggers.
+
+Both forms require a weak cursor variable (`SYS_REFCURSOR`). Using them with a strongly-typed `REF CURSOR` (one declared with a `RETURN` clause) returns an error.
 
 ## See Also
 


### PR DESCRIPTION
…sors

MDEV-39022 (MariaDB 13.1.1) adds the LOCAL statement-name forms PREPARE/EXECUTE/DEALLOCATE PREPARE LOCAL, and the SYS_REFCURSOR forms OPEN ... FOR PREPARE and OPEN ... FOR LOCAL. Document each on the prepared-statement pages and the cursor OPEN page, including the stored-procedure-only restriction and the weak-cursor requirement.