### PR TITLE
DOCS-6341: semisync recovery now uses --init-rpl-role=SLAVE (MDEV-33465)

### DIFF
--- a/server/ha-and-performance/standard-replication/semisynchronous-replication.md
+++ b/server/ha-and-performance/standard-replication/semisynchronous-replication.md
@@ -149,9 +149,13 @@ The effects of the `AFTER_SYNC` wait point are:
 * However, if the primary crashes, then its [binary log](../../server-management/server-monitoring-logs/binary-log/) may also contain events for transactions that were prepared by the storage engine and written to the binary log, but that were never actually committed by the storage engine. As part of the server's [automatic crash recovery](../../server-management/server-monitoring-logs/transaction-coordinator-log/heuristic-recovery-with-the-transaction-coordinator-log.md) process, the server may recover these prepared transactions when the server is restarted. This could cause the "old" crashed primary to become inconsistent with its former replicas when they have\
   been reconfigured to replace the old primary with a new one.\
   The old primary in such a scenario can be re-introduced only as a [semisync replica](semisynchronous-replication.md#rpl_semi_sync_slave_enabled).\
-  The server post-crash recovery of the server configured with `rpl_semi_sync_slave_enabled = ON`\
-  ensures through [MDEV-21117](https://jira.mariadb.org/browse/MDEV-21117) that the server will not have extra transactions.\
-  The reconfigured as semisync replica server's binlog gets truncated to discard transactions proven\
+  To recover it safely, start the server with `--init-rpl-role=SLAVE`. This tells the server its\
+  role in the replication topology, so that post-crash recovery discards transactions proven not\
+  to be committed and the server will not have extra transactions ([MDEV-21117](https://jira.mariadb.org/browse/MDEV-21117),\
+  [MDEV-33465](https://jira.mariadb.org/browse/MDEV-33465)). Before MDEV-33465, this recovery was\
+  instead deduced from the semisync variables (`rpl_semi_sync_slave_enabled = ON`), which did not\
+  work reliably in mixed topologies; setting `--init-rpl-role=SLAVE` is now required.\
+  The server's binlog gets truncated to discard transactions proven\
   not to be committed, in any of their branches if they are multi-engine.\
   Truncation does not occur though when there exists a non-transactional group of events beyond the truncation position in which case recovery reports an error.\
   When the semisync replica recovery can't be carried out, the crashed primary may need to be rebuilt.

--- a/server/ha-and-performance/standard-replication/semisynchronous-replication.md
+++ b/server/ha-and-performance/standard-replication/semisynchronous-replication.md
@@ -146,18 +146,18 @@ The effects of the `AFTER_SYNC` wait point are:
 
 * All clients see the same data on the primary at the same time; after acknowledgement by the replica and after being committed to the storage engine on the primary.
 * If the primary crashes, then failover should be lossless, because all transactions committed on the primary would have been replicated to the replica.
-* However, if the primary crashes, then its [binary log](../../server-management/server-monitoring-logs/binary-log/) may also contain events for transactions that were prepared by the storage engine and written to the binary log, but that were never actually committed by the storage engine. As part of the server's [automatic crash recovery](../../server-management/server-monitoring-logs/transaction-coordinator-log/heuristic-recovery-with-the-transaction-coordinator-log.md) process, the server may recover these prepared transactions when the server is restarted. This could cause the "old" crashed primary to become inconsistent with its former replicas when they have\
-  been reconfigured to replace the old primary with a new one.\
-  The old primary in such a scenario can be re-introduced only as a [semisync replica](semisynchronous-replication.md#rpl_semi_sync_slave_enabled).\
-  To recover it safely, start the server with `--init-rpl-role=SLAVE`. This tells the server its\
-  role in the replication topology, so that post-crash recovery discards transactions proven not\
-  to be committed and the server will not have extra transactions ([MDEV-21117](https://jira.mariadb.org/browse/MDEV-21117),\
-  [MDEV-33465](https://jira.mariadb.org/browse/MDEV-33465)). Before MDEV-33465, this recovery was\
-  instead deduced from the semisync variables (`rpl_semi_sync_slave_enabled = ON`), which did not\
-  work reliably in mixed topologies; setting `--init-rpl-role=SLAVE` is now required.\
-  The server's binlog gets truncated to discard transactions proven\
-  not to be committed, in any of their branches if they are multi-engine.\
-  Truncation does not occur though when there exists a non-transactional group of events beyond the truncation position in which case recovery reports an error.\
+* However, if the primary crashes, then its [binary log](../../server-management/server-monitoring-logs/binary-log/) may also contain events for transactions that were prepared by the storage engine and written to the binary log, but that were never actually committed by the storage engine. As part of the server's [automatic crash recovery](../../server-management/server-monitoring-logs/transaction-coordinator-log/heuristic-recovery-with-the-transaction-coordinator-log.md) process, the server may recover these prepared transactions when the server is restarted. This could cause the "old" crashed primary to become inconsistent with its former replicas when they have
+  been reconfigured to replace the old primary with a new one.
+  The old primary in such a scenario can be re-introduced only as a [semisync replica](semisynchronous-replication.md#rpl_semi_sync_slave_enabled).
+  To recover it safely, start the server with `--init-rpl-role=SLAVE`. This tells the server its
+  role in the replication topology, so that post-crash recovery discards transactions proven not
+  to be committed and the server will not have extra transactions ([MDEV-21117](https://jira.mariadb.org/browse/MDEV-21117),
+  [MDEV-33465](https://jira.mariadb.org/browse/MDEV-33465)). Before MDEV-33465, this recovery was
+  instead deduced from the semisync variables (`rpl_semi_sync_slave_enabled = ON`), which did not
+  work reliably in mixed topologies; setting `--init-rpl-role=SLAVE` is now required.
+  The server's binlog gets truncated to discard transactions proven
+  not to be committed, in any of their branches if they are multi-engine.
+  Truncation does not occur though when there exists a non-transactional group of events beyond the truncation position in which case recovery reports an error.
   When the semisync replica recovery can't be carried out, the crashed primary may need to be rebuilt.
 
 When this variable is set to `AFTER_COMMIT`, the primary performs the following steps:


### PR DESCRIPTION
## What

Updates the recovery paragraph in the `AFTER_SYNC` wait-point section of the [Semisynchronous Replication](https://mariadb.com/docs/server/ha-and-performance/standard-replication/semisynchronous-replication) page.

The paragraph described the **pre-MDEV-33465** behavior: it said post-crash binlog truncation happens for a server "configured with `rpl_semi_sync_slave_enabled = ON`", ensuring through MDEV-21117 that the server will not have extra transactions.

## Why

**MDEV-33465** ("an option to enable semisync recovery"), fixed in **10.6.19, 10.11.9, 11.1.6, 11.2.5, 11.4.3** — every currently-maintained line — decoupled recovery from the semisync variables because the old approach broke in mixed topologies (a crashed primary restarting as an *async* replica couldn't deduce its role). Recovery-time binlog truncation is now triggered by the read-only startup option **`--init-rpl-role=SLAVE`** (system variable `init_rpl_role`, values `MASTER`/`SLAVE`, default `MASTER`), **not** by `rpl_semi_sync_slave_enabled=ON`.

Verified against `mariadb-server` source:
- `sql/sys_vars.cc` — `init_rpl_role` system variable
- `sql/mysqld.cc` — `rpl_status = init_rpl_role_val;`
- `sql/log.cc` — `do_truncate(rpl_status == RPL_IDLE_SLAVE)` (`RPL_IDLE_SLAVE` == started with `init-rpl-role=SLAVE`)

Flagged by Markus Mäkelä on Slack.

Ticket: DOCS-6341

🤖 Generated with [Claude Code](https://claude.com/claude-code)