### PR TITLE
DOCS-6287 Add access-control agent skills (batch 2)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -21,7 +21,12 @@
         { "name": "mariadb-load-data", "path": "granular/statements/mariadb-load-data/SKILL.md", "status": "pilot", "last_reviewed": "2026-06-24", "baseline_version": "11.8" },
         { "name": "mariadb-transactions", "path": "granular/statements/mariadb-transactions/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-set-transaction", "path": "granular/statements/mariadb-set-transaction/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
-        { "name": "mariadb-lock-tables", "path": "granular/statements/mariadb-lock-tables/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
+        { "name": "mariadb-lock-tables", "path": "granular/statements/mariadb-lock-tables/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-create-user", "path": "granular/statements/mariadb-create-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-grant", "path": "granular/statements/mariadb-grant/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-revoke", "path": "granular/statements/mariadb-revoke/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-alter-user", "path": "granular/statements/mariadb-alter-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-drop-user", "path": "granular/statements/mariadb-drop-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
       ]
     },
     "granular-functions": {

--- a/agent-skills/granular/statements/mariadb-alter-user/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-alter-user/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: mariadb-alter-user
+description: "MariaDB-specific syntax and behavior for ALTER USER and SET PASSWORD — IF EXISTS warning-not-error semantics, IDENTIFIED BY vs IDENTIFIED BY PASSWORD vs IDENTIFIED VIA/WITH multi-plugin auth, PASSWORD EXPIRE variants and default_password_lifetime interaction, ACCOUNT LOCK/UNLOCK, resource limits, TLS/REQUIRE options, and SET PASSWORD's three literal forms (PASSWORD(), OLD_PASSWORD(), pre-hashed string — there is no cleartext-string form). Use when writing, generating, or reviewing statements that create/change account credentials, expire or lock accounts, or set passwords on MariaDB."
+---
+
+# ALTER USER and SET PASSWORD in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between what an LLM tends to write for account/password management and MariaDB's actual behavior**. It assumes the agent already knows `CREATE USER` basics. Consolidates **ALTER USER** and **SET PASSWORD** into one lookup, since the two overlap heavily on password semantics.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `SET PASSWORD FOR 'u'@'h' = 'mynewpassword';` expecting a cleartext-password shortcut | **There is no cleartext bare-string form.** A bare string on the right of `SET PASSWORD =` is stored **as-is as an already-hashed value** (e.g. what `PASSWORD()` returns) — writing a plaintext string there sets the account's hash to that literal text, which will not match the real password on login. Use `SET PASSWORD FOR 'u'@'h' = PASSWORD('mynewpassword');` for a plaintext input |
+| `ALTER USER 'bob'@'%';` with no user, expecting "modify my own account" | `ALTER USER` always requires an explicit user (or `CURRENT_USER()`/`CURRENT_USER`) in the specification — there is no bare "no-user-means-me" shorthand. Write `ALTER USER CURRENT_USER() IDENTIFIED BY '...'` |
+| `ALTER USER foo IDENTIFIED VIA ed25519 USING 'newhash'` to add ed25519 alongside an existing plugin, expecting other auth methods to survive | `ALTER USER ... IDENTIFIED VIA ...` **replaces the account's entire authentication method list**. Any previously configured plugin not repeated in the new `IDENTIFIED VIA ... OR ...` clause is removed (since 10.4.13; earlier the removal was inconsistent — MDEV-21928) |
+| `ALTER USER 'bob'@'%' PASSWORD EXPIRE INTERVAL 90;` | Needs the `DAY` unit: `PASSWORD EXPIRE INTERVAL 90 DAY` — there is no bare-integer or other unit form |
+| Assuming a locked account still finishes login and just gets restricted | `ACCOUNT LOCK` blocks the connection attempt itself with `ER_ACCOUNT_HAS_BEEN_LOCKED` ("Access denied, this account is locked") — it is checked before password validation, not a post-login restriction. Existing open connections are unaffected |
+| Assuming an expired password blocks the connection outright | By default the client *is* allowed to connect (if it advertises `CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS`), but the session is put in "sandbox mode": every statement except `SET PASSWORD` fails with `ER_MUST_CHANGE_PASSWORD` ("You must SET PASSWORD before executing this statement") until the password is changed. Only if `disconnect_on_expired_password = ON` (and the client can't handle expired passwords) is the connection itself refused with `ER_MUST_CHANGE_PASSWORD_LOGIN` |
+| `ALTER USER foo` on a nonexistent user and expecting a hard failure to always block subsequent DDL | Without `IF EXISTS`, a nonexistent user is an error, but `ALTER USER` still applies to every account in the list that *does* exist and does *not* error — only one error is raised for the whole statement covering the accounts that failed. With `IF EXISTS`, a nonexistent user produces a **warning**, not an error, and the rest apply normally |
+| Assuming `default_password_lifetime` auto-expires passwords out of the box | Its default is **0 (disabled)** — passwords never auto-expire unless an admin sets this global variable to a positive day count, or expiry is set per-account with `PASSWORD EXPIRE INTERVAL n DAY` |
+
+## ALTER USER — Option Surface
+
+`ALTER USER` shares its option grammar with `CREATE USER` (see the **`mariadb-create-user`** skill for the full option catalog). The distinguishing pieces for `ALTER USER`:
+
+```sql
+ALTER USER [IF EXISTS] user_specification [, user_specification] ...
+  [REQUIRE {NONE | tls_option [[AND] tls_option] ...}]
+  [WITH resource_option [resource_option] ...]
+  [lock_option] [password_option]
+  -- or, since 10.5.8/10.4.7:
+  [password_option] [lock_option]   -- either order is accepted
+
+user_specification:
+  username [IDENTIFIED BY 'password'
+           |IDENTIFIED BY PASSWORD 'hash'
+           |IDENTIFIED {VIA|WITH} plugin [USING 'string' | USING PASSWORD('cleartext')]
+                                          [OR plugin ...] ]
+```
+
+- **Modifying the current session's own account:** there is no implicit "no user given" form. Use `CURRENT_USER()` (or `CURRENT_USER`) explicitly:
+  ```sql
+  ALTER USER CURRENT_USER() IDENTIFIED BY 'newpass';
+  ```
+- **`IDENTIFIED BY 'password'`** — cleartext input, hashed by the account's authentication plugin before storage. Only meaningful for `mysql_native_password` / `mysql_old_password`.
+- **`IDENTIFIED BY PASSWORD 'hash'`** — the value is stored verbatim as an already-computed hash (e.g. the output of `PASSWORD('...')`); no re-hashing occurs.
+- **`IDENTIFIED VIA|WITH plugin`** — sets/replaces the account's authentication method(s). Multiple methods can be chained with `OR` (since 10.4) to support a migration window (e.g. old + new plugin side by side). Re-running `ALTER USER ... IDENTIFIED VIA` **drops any method not re-listed** — this is a full replacement, not a merge.
+- **`REQUIRE`** — TLS/X.509 constraints (`SSL`, `X509`, `CIPHER`, `ISSUER`, `SUBJECT`); `X509`/`ISSUER`/`SUBJECT`/`CIPHER` all imply `SSL`. `SSL`/`X509` cannot combine with other TLS options; `ISSUER`/`SUBJECT`/`CIPHER` can combine with each other.
+- **`WITH` resource limits** — `MAX_QUERIES_PER_HOUR`, `MAX_UPDATES_PER_HOUR`, `MAX_CONNECTIONS_PER_HOUR`, `MAX_USER_CONNECTIONS`, `MAX_STATEMENT_TIME`. Tracked per `'user'@'host'` account, not per user name. `0` means unlimited for that resource.
+
+## `IF EXISTS`
+
+```sql
+ALTER USER IF EXISTS 'bob'@'%' PASSWORD EXPIRE;
+```
+
+Turns a "no such user" condition from a hard error into a **warning** for that account, letting the rest of a multi-user statement (or an idempotent provisioning script) proceed without erroring. Without `IF EXISTS`, MariaDB still applies the statement to every account that *does* exist — the error covers only the accounts that failed, not the whole batch — but the statement as a whole reports failure.
+
+## `PASSWORD EXPIRE` Options
+
+```sql
+ALTER USER 'monty'@'localhost' PASSWORD EXPIRE;                    -- expire immediately
+ALTER USER 'monty'@'localhost' PASSWORD EXPIRE INTERVAL 120 DAY;   -- expire in N days
+ALTER USER 'monty'@'localhost' PASSWORD EXPIRE NEVER;              -- opt out of auto-expiry
+ALTER USER 'monty'@'localhost' PASSWORD EXPIRE DEFAULT;            -- fall back to default_password_lifetime
+```
+
+- Bare `PASSWORD EXPIRE` (no modifier) expires the password **immediately** — the next login enters sandbox mode.
+- `default_password_lifetime` is the server-wide policy (days; `0` = disabled, which is the default); per-account `PASSWORD EXPIRE` options override it for that account.
+- Sandbox-mode behavior on an expired password: see "What LLMs Often Miss" above — the account can usually still authenticate, but only `SET PASSWORD` is permitted until the password is reset.
+
+## `ACCOUNT LOCK` / `ACCOUNT UNLOCK`
+
+```sql
+ALTER USER 'marijn'@'localhost' ACCOUNT LOCK;
+ALTER USER 'marijn'@'localhost' ACCOUNT UNLOCK;
+```
+
+Blocks (or re-permits) new connections for that account. Locking does **not** kill sessions already open at the time of the lock. A locked account's login attempt fails with `ER_ACCOUNT_HAS_BEEN_LOCKED`, checked before credentials are evaluated.
+
+## SET PASSWORD
+
+```sql
+SET PASSWORD [FOR user] = PASSWORD('cleartext');       -- hash a plaintext input
+SET PASSWORD [FOR user] = OLD_PASSWORD('cleartext');   -- pre-4.1 hash format; only for very old clients
+SET PASSWORD [FOR user] = 'already-hashed-value';      -- stored as-is, NO re-hashing
+```
+
+- **No `FOR` clause** targets the *current session's* account. Any non-anonymous user can change their own password this way.
+- **With `FOR user`**, the caller needs the `UPDATE` privilege on the `mysql` database; `user` must match the `User`/`Host` values exactly as recorded in `mysql.user`/`mysql.global_priv`.
+- The bare-string third form is **not** a cleartext shortcut — the exact text becomes the stored authentication hash. It exists so tooling can copy a hash from one account/server to another (e.g. `SELECT PASSWORD('x')` output, or a dump), not so a human can type a plaintext password directly. Getting this wrong (typing a real plaintext password without `PASSWORD()`) silently creates an account nobody can log into with that password.
+- Works for any plugin that stores its credential in `mysql.global_priv` (`mysql_native_password`, `mysql_old_password`, `ed25519`). Plugins that authenticate by other means (`unix_socket`, `named_pipe`, `gssapi`, `pam`) reject `SET PASSWORD` outright with an explicit "ignored" error, since there's no password to store.
+- Clearing a password: `SET PASSWORD FOR 'bob'@'localhost' = PASSWORD('');` — sets a blank password (the account can then connect with no password supplied). A blank password is not a wildcard that matches anything.
+- `ALTER USER ... IDENTIFIED BY '...'` and `SET PASSWORD ... = PASSWORD('...')` are functionally equivalent ways to change a password to a plaintext value; `ALTER USER` is the modern, more general statement and also accepts `IF EXISTS`, expiry, locking, and resource-limit clauses in the same statement.
+
+## See Also
+
+- **`mariadb-create-user`** — full option catalog (`IDENTIFIED VIA/WITH`, `DEFAULT ROLE`, resource limits, TLS) shared with `ALTER USER`
+- **`mariadb-grant`** — privilege grants, which also accept an inline `IDENTIFIED BY` that can create the account
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/alter-user>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/set-password>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-user>

--- a/agent-skills/granular/statements/mariadb-create-user/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-user/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: mariadb-create-user
+description: "MariaDB-specific syntax and behavior for CREATE USER — multiple authentication methods chained with OR, IDENTIFIED BY / IDENTIFIED BY PASSWORD / IDENTIFIED VIA|WITH plugin USING|AS 'string'|PASSWORD(...), the default authentication plugin, REQUIRE TLS options, WITH resource-limit options, PASSWORD EXPIRE variants, ACCOUNT LOCK/UNLOCK, OR REPLACE, IF NOT EXISTS, and account-name/host defaulting. Covers CREATE USER only (not GRANT's implicit user-creation path). Use when writing, generating, or reviewing CREATE USER statements that target MariaDB."
+---
+
+# CREATE USER in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between generic "create a database user" SQL and MariaDB's `CREATE USER`**. It assumes the agent already knows the basic shape (`CREATE USER name IDENTIFIED BY 'password'`). Everything below documents MariaDB-specific authentication chaining, default-plugin behavior, TLS/resource/expiry/lock options, and the most common LLM traps.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| Assuming the default auth plugin is a SHA-2/caching variant (a habit from other databases) | MariaDB's compiled-in default authentication plugin is **`mysql_native_password`** (`default_auth_plugin_name` in server source). Fresh installs additionally give the local root account `unix_socket` as an **`OR`**-ed fallback, so root can log in passwordless via the socket — don't assume root always needs a password |
+| `CREATE USER 'app'@'%' IDENTIFIED BY 'pw1', 'app'@'%' IDENTIFIED VIA pam` as two separate fallback mechanisms | Chain alternatives on **one** account with `OR`: `IDENTIFIED VIA ed25519 USING PASSWORD('pw1') OR unix_socket OR pam`. Mechanisms are tried in the order written; first success wins |
+| `IDENTIFIED BY PASSWORD 'mySecretPass'` thinking `BY PASSWORD` accepts plain text | `IDENTIFIED BY PASSWORD '...'` expects an **already-hashed** value (the output of `PASSWORD()`), not plain text. Plain text goes in plain `IDENTIFIED BY '...'` |
+| Not checking whether the account already exists before `CREATE USER` | Either `CREATE USER IF NOT EXISTS` (emits a **warning**, `Note 1973`, not an error, and skips creation) or `CREATE OR REPLACE USER` (drops and recreates unconditionally) |
+| `CREATE USER 'app'` assuming it matches only local connections | No host part defaults to **`'app'@'%'`** — matches from *any* host. If you want local-only, write `'app'@'localhost'` explicitly |
+| Relying on `GRANT ... TO newuser` to silently create the account | `NO_AUTO_CREATE_USER` is set in `sql_mode` **by default**, so `GRANT` to a non-existent user errors instead of creating one. Always issue an explicit `CREATE USER` first |
+| `REQUIRE X509 AND SSL` or stacking `SSL`/`X509` with other options | `SSL` and `X509` **cannot combine with other TLS options** (each implies the weaker one already). Only `CIPHER`/`ISSUER`/`SUBJECT` can be combined with each other via `AND` |
+| Assuming `ACCOUNT LOCK` kills the user's current session | It only blocks **new** connection attempts — existing connections are unaffected until they disconnect |
+| Assuming `IDENTIFIED VIA <plugin> USING 'x'` works for every plugin | `USING`/`AS` with a literal string is plugin-specific (e.g. `pam` takes a service name); to feed a plain-text password through `PASSWORD()` to a plugin, the plugin must implement that hook — `ed25519` does, most others don't |
+
+## Syntax at a Glance
+
+```sql
+CREATE [OR REPLACE] USER [IF NOT EXISTS]
+  user_spec [, user_spec ...]
+  [REQUIRE {NONE | tls_option [[AND] tls_option ...]}]
+  [WITH resource_option [resource_option ...]]
+  [[ACCOUNT {LOCK|UNLOCK}] [PASSWORD EXPIRE [DEFAULT|NEVER|INTERVAL N DAY]]]
+  -- lock_option and password_option may appear in either order
+
+user_spec:
+  'user'[@'host'] [ IDENTIFIED BY 'password'
+                   | IDENTIFIED BY PASSWORD 'hash'
+                   | IDENTIFIED {VIA|WITH} auth_rule [OR auth_rule ...] ]
+
+auth_rule:
+  plugin_name [ {USING|AS} 'auth_string' | {USING|AS} PASSWORD('plaintext') ]
+```
+
+## Authentication Options
+
+- **`IDENTIFIED BY 'password'`** — plain-text password, hashed on the server via `PASSWORD()` before storage. Supported only for the `mysql_native_password` and `mysql_old_password` plugins.
+- **`IDENTIFIED BY PASSWORD 'hash'`** — the value must already be a `PASSWORD()`-format hash; same two-plugin restriction.
+- **`IDENTIFIED {VIA|WITH} plugin [USING|AS ...] [OR plugin ...]`** — `VIA` and `WITH` are synonyms. Chain multiple plugins with `OR`; each is a full alternative authentication path, tried in declared order until one succeeds. Common pattern:
+
+  ```sql
+  CREATE USER safe@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret') OR unix_socket;
+  ```
+
+- **No auth clause at all** — the account has no password requirement; an empty password does **not** act as a wildcard, the client must connect with no password supplied.
+- The plugin must already be active (check `SHOW PLUGINS`); install with `INSTALL PLUGIN`/`INSTALL SONAME` first if it isn't loaded.
+
+## TLS — `REQUIRE`
+
+| Option | Effect |
+|---|---|
+| `REQUIRE NONE` | TLS not required (default) |
+| `REQUIRE SSL` | TLS required, no certificate check. Cannot combine with other TLS options |
+| `REQUIRE X509` | TLS + valid X.509 certificate required (implies `SSL`). Cannot combine with other TLS options |
+| `REQUIRE ISSUER 'x'` / `SUBJECT 'x'` / `CIPHER 'x'` | Each implies `X509`/`SSL` as needed; these three **can** be combined with each other via `AND` |
+
+## Resource Limits — `WITH`
+
+`MAX_QUERIES_PER_HOUR`, `MAX_UPDATES_PER_HOUR`, `MAX_CONNECTIONS_PER_HOUR`, `MAX_USER_CONNECTIONS`, `MAX_STATEMENT_TIME` (seconds). `0` means unlimited for that resource. Limits are tracked per **account** (`'user'@'host'`), not per session; reset with `FLUSH USER_RESOURCES` / `FLUSH PRIVILEGES`.
+
+## Password Expiry / Account Locking
+
+```sql
+PASSWORD EXPIRE                    -- expire immediately
+PASSWORD EXPIRE DEFAULT            -- fall back to default_password_lifetime
+PASSWORD EXPIRE NEVER              -- override global default, never expire
+PASSWORD EXPIRE INTERVAL N DAY     -- expire N days from now
+ACCOUNT LOCK | ACCOUNT UNLOCK
+```
+
+`lock_option` and `password_option` may be given in either order (both orderings are valid grammar productions). `ACCOUNT LOCK` prevents new connections only.
+
+## OR REPLACE / IF NOT EXISTS / Errors
+
+- Without either modifier, creating a user (or any of its permission rows) that already exists returns `ERROR 1396 (HY000)`; the statement still creates whichever listed accounts *don't* error.
+- `IF NOT EXISTS` downgrades the "exists" case to a warning (`Note 1973`) instead of an error, and leaves the existing account untouched.
+- `OR REPLACE` is shorthand for `DROP USER IF EXISTS name; CREATE USER name ...` — unconditionally recreates.
+
+## Account Names
+
+- Format: `'user_name'@'host_name'`. Omitted host defaults to `'%'` (any host), **not** `localhost`.
+- Host name supports `%`/`_` wildcards (LIKE-style matching) and CIDR-like `base_ip/netmask` forms; netmasks don't apply to IPv6.
+- An empty user name (`''@'host'`) is an anonymous, catch-all account for that host pattern.
+- When multiple accounts could match a connecting client, MariaDB picks the most specific: exact host beats wildcard host, narrower wildcards beat broader ones, and a non-empty user name beats an anonymous one. Only the matched account's own grants apply — not the union of everything that could have matched.
+
+## See Also
+
+- **`mariadb-grant`** — privilege assignment; also the implicit-user-creation interaction with `NO_AUTO_CREATE_USER`
+- **`mariadb-alter-user`** — modifying an existing account's auth/TLS/resource/expiry/lock settings in place
+- **`mariadb-drop-user`** — removing accounts; same `ERROR 1396` / `IF EXISTS` semantics
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-user>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/set-password>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-create-user>
+  - <https://mariadb.com/docs/server/reference/plugins/authentication-plugins>

--- a/agent-skills/granular/statements/mariadb-drop-user/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-drop-user/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: mariadb-drop-user
+description: "MariaDB-specific behavior for DROP USER and RENAME USER — multiple accounts per statement, IF EXISTS turning a missing-user error into a note, the active-connections warning (dropped users keep working until their session ends; new connections are blocked), no cascade onto objects owned or privileges granted by the dropped user, dangling DEFINER references left behind on views/routines/triggers, and RENAME USER preserving privileges across the rename with no active-session check. Use when writing, generating, or reviewing DROP USER or RENAME USER statements, or account-lifecycle cleanup scripts, that target MariaDB."
+---
+
+# DROP USER (and RENAME USER) in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the MariaDB-specific behavior of `DROP USER` and, briefly, the related `RENAME USER` statement. It assumes the agent already knows the standard-SQL notion of dropping/renaming a database principal. The traps here are almost all about what `DROP USER` *doesn't* do — it does not touch active sessions, owned objects, or privileges the dropped user granted to others.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Only newer-than-10.6 features carry a `*(since X.Y)*` annotation.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| Assuming `DROP USER` kills the user's open connections | It does **not**. A dropped account with an active session keeps working, with all its privileges, until that connection disconnects — MariaDB only blocks *new* connections and emits a note-level warning: `Dropped users '...' have active connections. Use KILL CONNECTION if they should not be used anymore.` To actually cut it off, run `KILL CONNECTION <id>` for each of the account's live sessions |
+| Writing a loop issuing one `DROP USER` per account | `DROP USER` takes a comma-separated list in a single statement: `DROP USER 'u1'@'%', 'u2'@'%', 'u3'@'%';` — one statement, one binlog event, one round trip |
+| `DROP USER 'bob'@'%';` in a script where the account might not exist | Add `IF EXISTS` — without it, a missing account raises `ERROR 1396 (HY000): Operation DROP USER failed for '...'`. With `IF EXISTS`, a missing account produces a **note**, not an error, so idempotent teardown scripts don't fail |
+| Expecting a dropped user's tables/views/procedures to disappear too | `DROP USER` never cascades onto objects the user owns — those objects are untouched and now ownerless. It only removes rows from the grant tables (`mysql.user`, `mysql.db`, `mysql.tables_priv`, etc.) |
+| Expecting revocation of privileges the dropped user had granted to *other* users | Not revoked. If `alice` ran `GRANT SELECT ON t TO bob`, dropping `alice` leaves `bob`'s `SELECT` on `t` intact — there is no cascade on grants made *by* the account |
+| Dropping a user that's the `DEFINER` of a view, stored routine, or trigger | The object is left behind with a now-nonexistent definer. It keeps working for `SELECT`/schema purposes in most cases, but **invoking** it (routine call, `SQL SECURITY DEFINER` context, etc.) fails with `The user specified as a definer ('user'@'host') does not exist`. Re-point the `DEFINER` (e.g. `ALTER VIEW ... DEFINER = ...`) *before* dropping the account, not after |
+| Renaming a user and assuming privileges need to be re-granted | `RENAME USER old TO new` preserves the account's existing privileges — they follow the renamed account; no re-`GRANT` needed |
+| Checking for active connections before `RENAME USER` | Not necessary and not done by the server — `RENAME USER`, unlike `DROP USER`, does not check for or warn about active sessions of the account being renamed |
+
+## `DROP USER` — Syntax and Behavior
+
+```sql
+DROP USER [IF EXISTS] user_name [, user_name] ...
+```
+
+- A connected account is still deleted from the grant tables, but a note-level warning is issued and the live session keeps its privileges until it disconnects on its own. Run `KILL CONNECTION <id>` against each of the account's sessions if you need to end them immediately.
+- In `sql_mode=ORACLE`, dropping a currently-connected user fails outright with `Operation DROP USER failed for '...'`, instead of the warn-and-proceed behavior used in the default mode.
+- Each `user_name` uses the same `'user'@'host'` form as `CREATE USER`; a bare user name implies `@'%'`.
+- Multiple accounts in one statement are processed together: if some fail (don't exist, and `IF EXISTS` wasn't given) while others succeed, the successful drops still commit, and a single `ERROR 1396` lists all the failed names together.
+- Privilege required: the global `CREATE USER` privilege, **or** the `DELETE` privilege on the `mysql` database.
+
+```sql
+-- Idempotent teardown:
+DROP USER IF EXISTS 'svc_batch'@'%', 'svc_report'@'%';
+```
+
+## `RENAME USER`
+
+```sql
+RENAME USER old_user TO new_user [, old_user TO new_user] ...
+```
+
+- Renames one or more accounts in place; privileges are attached to the same underlying account record, so they carry over to the new name automatically.
+- If any `old_user` doesn't exist, or any `new_user` already exists, `ERROR 1396 (HY000)` results — same partial-success semantics as `DROP USER`: pairs that don't error still get renamed.
+- Also usable to change just the host part: `RENAME USER 'foo'@'1.2.3.4' TO 'foo'@'10.20.30.40';`
+- Privilege required: the global `CREATE USER` privilege, **or** the `UPDATE` privilege on the `mysql` database.
+- For changing other account attributes (password, `REQUIRE`, resource limits) without changing the name, use `ALTER USER`, not `RENAME USER`.
+
+## See Also
+
+- **`mariadb-create-user`** — account creation, `IDENTIFIED BY`/auth plugins, resource limits
+- **`mariadb-grant`** — privilege levels, `GRANT ... TO`, `CREATE USER` vs. `DELETE`/`UPDATE` on `mysql`
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/drop-user>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/rename-user>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-user>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/grant>

--- a/agent-skills/granular/statements/mariadb-grant/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-grant/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: mariadb-grant
+description: "MariaDB-specific GRANT behavior — privilege scope levels (global/db/table/column/routine), implicit account creation interacting with the NO_AUTO_CREATE_USER sql_mode (on by default), MariaDB-only privileges LLMs won't know (BINLOG MONITOR, DELETE HISTORY, SET USER, FEDERATED ADMIN, READ_ONLY ADMIN, etc.) and the SUPER-privilege split, GRANT PROXY, resource limits, REQUIRE TLS options, and MariaDB roles (GRANT role TO user/role, WITH ADMIN OPTION, single-active-role semantics). Use when writing, generating, or reviewing GRANT statements or privilege/role designs that target MariaDB."
+---
+
+# GRANT in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between the privilege grammar an LLM tends to reach for and MariaDB's `GRANT`**. It assumes the agent already knows the basic shape (`GRANT priv ON object TO user`). Everything below documents MariaDB's privilege catalog quirks, implicit-user-creation rules, roles, proxy grants, and the traps most likely to trip up a coding agent.
+
+> **Default context:** Assume MariaDB **11.8 LTS** unless the user states another version. Privileges available in all current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 items carry one. Never mention versions below 10.6.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …the actual MariaDB behavior |
+|---|---|
+| Assuming `GRANT ... TO newuser` cannot create an account | In MariaDB, `GRANT ... TO newuser IDENTIFIED BY 'pw'` **still implicitly creates the account** if it doesn't exist — as long as authentication info is supplied. Verified in `sql/sql_acl.cc` (`replace_user_table`, ~line 5639) |
+| Assuming `GRANT` freely auto-creates passwordless users | The `NO_AUTO_CREATE_USER` `sql_mode` is **enabled by default** in current MariaDB (`sql/sys_vars.cc`: default `sql_mode` includes `MODE_NO_AUTO_CREATE_USER`). With it on (the default), `GRANT ... TO newuser` with **no** `IDENTIFIED BY`/`VIA` clause errors (`ER_PASSWORD_NO_MATCH`) instead of silently creating a passwordless account. `IDENTIFIED BY ''` (empty string) does **not** count as auth for this check — `LEX_USER::has_auth()` requires a non-empty `pwtext`/`auth_str`/plugin — so it still errors under the default mode |
+| `GRANT REPLICATION CLIENT ON *.* TO ...` for binlog-status monitoring | Still works (kept as a compatibility alias), but the current name is **`BINLOG MONITOR`** — `REPLICATION CLIENT` was renamed in 10.5.2. Confirmed in `sql/sql_yacc.yy`: `REPLICATION CLIENT_SYM { $$= BINLOG_MONITOR_ACL; /*Compatibility*/ }` |
+| Granting `SUPER` for anything beyond legacy compatibility | `SUPER` was split (MDEV-21743, 10.5.2+) into narrower privileges: `SET USER`, `FEDERATED ADMIN`, `CONNECTION ADMIN`, `REPLICATION SLAVE ADMIN`, `BINLOG ADMIN`, `BINLOG REPLAY`, `SLAVE MONITOR` (`REPLICA` is a lexer synonym for the `SLAVE` token, so `REPLICA MONITOR` also parses), `BINLOG MONITOR`, `REPLICATION MASTER ADMIN`. `READ_ONLY ADMIN` was later **removed from `SUPER`** entirely (so replicas can be locked down even for `SUPER` users). Prefer the narrow privilege over blanket `SUPER` |
+| A user's assigned roles are "active" as soon as they're granted | Granting a role (`GRANT rolename TO user`) does **not** confer its privileges. The user must activate it with `SET ROLE rolename` (or have it as a default role — see `SET DEFAULT ROLE`) before the privileges apply |
+| `SET ROLE r1, r2` to activate several roles at once | MariaDB has **only one active role per session** — `SET ROLE` replaces the current role, it does not add to a set. (A role can itself have other roles granted to it, which is how a session reaches a whole privilege tree through one active role.) |
+| A role name and a username never collide | They can, and MariaDB resolves the conflict **in favor of the role**: `CREATE USER alice; CREATE ROLE alice; GRANT SELECT ON db.* TO alice;` grants `SELECT` to the *role* `alice`, not the user |
+| `DELETE`-only privilege list for a table | MariaDB also has **`DELETE HISTORY`** — required to run `DELETE HISTORY` against a `SYSTEM VERSIONING` table's historical rows; it's distinct from plain `DELETE` |
+| `GRANT ... TO user@host` is the only grantee form | MariaDB also accepts `TO PUBLIC` *(since 10.11)* to grant to every account, present and future — `SHOW GRANTS` shows a user's `PUBLIC`-inherited grants; `SHOW GRANTS FOR PUBLIC` isolates just the `PUBLIC` grants |
+| Overlapping wildcard `db_name.*` grants resolve by grant order or wildcard-prefix length | MariaDB picks the **most specific pattern** (the one matching the fewest databases) regardless of grant order or literal prefix length |
+
+## Privilege Levels
+
+`priv_level` in the grammar selects scope; some privileges only make sense at certain scopes:
+
+| Scope | `priv_level` form | Notes |
+|---|---|---|
+| Global | `*.*` | Server administration + all DB/table/routine privileges everywhere, including objects created later. Stored in `mysql.global_priv`. Takes effect only for *new* connections |
+| Database | `db_name.*` (or bare `*` for current DB) | All table/routine privileges within that DB, including future objects. Stored in `mysql.db` |
+| Table | `db_name.tbl_name` (or bare `tbl_name`) | `TABLE` keyword optional |
+| Column | table-level `priv_level` + `priv_type (col1, col2, …)` | Only `SELECT`, `INSERT`, `UPDATE`, `REFERENCES` support column lists. `GRANT OPTION` cannot be column-scoped — `WITH GRANT OPTION` on a column grant promotes to table-level `GRANT OPTION` |
+| Routine | `FUNCTION db.name` / `PROCEDURE db.name` | Also `PACKAGE` / `PACKAGE BODY` object types |
+
+`ALL` / `ALL PRIVILEGES` grants everything **at the given level only** (table-level `ALL` doesn't touch DB or global scope) and never implies `GRANT OPTION`. `USAGE` grants nothing — it's the vehicle for changing resource limits or TLS options on an existing account without touching privileges.
+
+## Roles
+
+```sql
+GRANT role TO user_or_role [, user_or_role ...] [WITH ADMIN OPTION];
+GRANT role1 TO role2;   -- roles can be granted to other roles
+```
+
+- Requires the grantor to already have admin rights over the role (see `CREATE ROLE ... WITH ADMIN`, which defaults to `WITH ADMIN CURRENT_USER`).
+- `WITH ADMIN OPTION` lets the grantee re-grant the role onward.
+- Privileges attach to the role via ordinary `GRANT priv ON obj TO rolename`, then reach the user only when active (`SET ROLE rolename`).
+- Role-vs-username conflicts resolve to the role (see table above).
+
+## `GRANT PROXY`
+
+```sql
+GRANT PROXY ON user_or_role TO account_or_role [, ...] [WITH GRANT OPTION];
+```
+
+Lets one account impersonate another (`CURRENT_USER()` becomes the proxy target); requires an auth plugin that supports it (the default `mysql_native_password` does not — `pam` does). To grant `PROXY` for a *specific* target account, the granter needs `PROXY` on that exact account **with `GRANT OPTION`**. To grant `PROXY` for *any* account, the granter needs `PROXY ON ''@'%' WITH GRANT OPTION` (the anonymous-account form) — this is what default `root` accounts hold.
+
+## Resource Limits & TLS
+
+```sql
+GRANT USAGE ON *.* TO 'u'@'h' WITH
+    MAX_QUERIES_PER_HOUR n MAX_UPDATES_PER_HOUR n
+    MAX_CONNECTIONS_PER_HOUR n MAX_USER_CONNECTIONS n
+    MAX_STATEMENT_TIME t;
+
+GRANT USAGE ON *.* TO 'u'@'h' REQUIRE SSL;                 -- or X509
+GRANT USAGE ON *.* TO 'u'@'h' REQUIRE SUBJECT '...' AND ISSUER '...' AND CIPHER '...';
+```
+
+`0` on any resource limit means unlimited. Limits are tracked per `'user'@'host'` account, not per session. `CONNECTION ADMIN` (and legacy `SUPER`) accounts bypass `max_user_connections`/`max_password_errors` and get one extra slot past `max_connections`. `REQUIRE SSL`/`X509` cannot combine with other TLS options; `ISSUER`/`SUBJECT`/`CIPHER` imply and can combine with `X509`.
+
+## See Also
+
+- **`mariadb-revoke`** — the inverse statement; same privilege catalog and scope rules apply
+- **`mariadb-create-user`** — account-name syntax, authentication plugins, `IDENTIFIED VIA`
+- Canonical references on `mariadb.com/docs` (consult for the full ~50-entry privilege table and edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/grant>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-role>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/set-role>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/revoke>

--- a/agent-skills/granular/statements/mariadb-revoke/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-revoke/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: mariadb-revoke
+description: "MariaDB-specific syntax and behavior for REVOKE — the mirrored five-form grammar (privilege ON object, the special ALL PRIVILEGES/GRANT OPTION form with no ON clause, PROXY, role revocation, ADMIN OPTION FOR role), the USAGE-privilege gotcha, ER_NONEXISTING_GRANT on mismatched revoke level, and the absence of an IF EXISTS clause. Use when writing, generating, or reviewing REVOKE statements (privileges, roles, or proxy) against MariaDB."
+---
+
+# REVOKE in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between standard SQL `REVOKE` and MariaDB's**. It assumes the agent already knows the standard form (`REVOKE priv ON obj FROM grantee`). MariaDB's privilege model is symmetric with `GRANT` (see **`mariadb-grant`** for the full `priv_type`/`priv_level` catalog) but `REVOKE` has its own grammar quirks, error semantics, and a role-revocation path that has no standard-SQL equivalent.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `REVOKE ALL PRIVILEGES, GRANT OPTION FROM ON *.* user` or otherwise adding `ON *.*` to the all-privileges form | The all-privileges form **takes no `ON` clause at all** — `REVOKE ALL PRIVILEGES, GRANT OPTION FROM user;`. Adding `ON *.*` is a syntax error; the grammar simply has no `ON` slot in that production |
+| `REVOKE IF EXISTS priv ON obj FROM user` | **No `IF EXISTS` clause exists for `REVOKE`** — the grammar (`revoke:` rule) has no `IF EXISTS` token. Revoking a privilege/grant that doesn't exist at that exact level always errors (`ER_NONEXISTING_GRANT`, SQLSTATE 42000); there is no built-in idempotent form. Wrap in a stored routine with a handler, or check `SHOW GRANTS` first, if idempotency is needed |
+| Assuming `REVOKE ALL ON *.* FROM user` removes every privilege | It removes everything **except `USAGE`** — the user keeps the ability to connect. To fully lock the account out, `DROP USER` it instead. The second form (`REVOKE ALL PRIVILEGES, GRANT OPTION FROM user`) is the same story — `USAGE` always survives |
+| Revoking a table/column privilege at the wrong level (e.g. revoking a column-level grant with a table-level `REVOKE`) | The revoke's `ON` level must **match exactly** the level the privilege was granted at (global / db / table / column / routine). Mismatched levels raise `ER_NONEXISTING_GRANT`, not a silent no-op |
+| `REVOKE role FROM user` when checking whether it "cascades" | It does — MariaDB's role system computes effective privileges by propagation through the role graph. Revoking a privilege *from a role* (or revoking a role *from another role*) immediately changes the effective privileges of every user/role that inherits it, with no re-grant needed |
+| Forgetting `REVOKE role` needs the grantor to already hold `GRANT OPTION`-equivalent authority | Revoking privileges (form 1) requires `GRANT OPTION` on what's being revoked, same as `GRANT`; revoking the special ALL form requires the global `CREATE USER` privilege or `UPDATE` on the `mysql` database — a *different* requirement than form 1 |
+| `REVOKE PROXY FROM user` (omitting `ON`) | `PROXY` revocation always needs the target: `REVOKE PROXY ON proxied_user FROM user_who_can_proxy` — mirrors `GRANT PROXY ON ... TO ...` in reverse |
+
+## The Five Forms
+
+```sql
+-- 1. Revoke specific privileges at a given level
+REVOKE priv_type [(column_list)] [, priv_type [(column_list)]] ...
+    ON [object_type] priv_level
+    FROM account_or_role [, account_or_role] ...
+
+-- 2. Revoke everything (no ON clause — this is the special form)
+REVOKE ALL [PRIVILEGES], GRANT OPTION
+    FROM account_or_role [, account_or_role] ...
+
+-- 3. Revoke proxy privilege
+REVOKE PROXY ON user_or_role
+    FROM account_or_role [, account_or_role] ...
+
+-- 4. Revoke a role
+REVOKE role [, role] ...
+    FROM account_or_role [, account_or_role] ...
+
+-- 5. Revoke the ADMIN OPTION for a role (keeps the role itself)
+REVOKE ADMIN OPTION FOR role [, role] ...
+    FROM account_or_role [, account_or_role] ...
+```
+
+`priv_type`/`priv_level`/`object_type` are identical to `GRANT` — see **`mariadb-grant`** for the full catalog (this includes MariaDB-only privileges like `BINLOG ADMIN`, `CONNECTION ADMIN`, `READ ONLY ADMIN`, `SET USER`, `SLAVE MONITOR`). `account_or_role` accepts `username`, `role`, `PUBLIC`, `CURRENT_USER[()]`, or `CURRENT_ROLE[()]`.
+
+## Privilege Requirements — Two Different Bars
+
+- **Form 1** (targeted privilege revoke): the executing user needs the `GRANT OPTION` privilege **and** must actually hold the privileges being revoked.
+- **Form 2** (`REVOKE ALL PRIVILEGES, GRANT OPTION FROM ...`): needs the global `CREATE USER` privilege, *or* the `UPDATE` privilege on the `mysql` database — a distinct, broader requirement than form 1.
+
+## Errors and Mismatches
+
+- Revoking a privilege the grantee doesn't hold **at the specified level** raises `ER_NONEXISTING_GRANT` (SQLSTATE `42000`) — not a silent success. This applies to global/db/table/column/routine levels and to proxy revocation alike.
+- There is **no `IF EXISTS` variant** of `REVOKE` — confirmed against the grammar (`sql/sql_yacc.yy`, the `revoke:` production). If a script needs to revoke-if-present, catch the error explicitly (e.g. in a stored procedure with a `DECLARE ... HANDLER`) rather than assuming an `IF EXISTS` keyword is accepted.
+- `REVOKE ALL PRIVILEGES, GRANT OPTION FROM ...` never takes an `ON` clause; `ON *.*` there is a parse error because the production has no `ON` token, not a semantic restriction that can be worked around with different syntax.
+
+## Roles
+
+```sql
+REVOKE journalist FROM hulda;
+REVOKE ADMIN OPTION FOR journalist FROM hulda;
+```
+
+- Revoking a role from a user or another role removes the membership edge; privilege propagation recomputes effective privileges for every downstream grantee immediately — no separate refresh step.
+- Revoking a *privilege from a role* (via form 1, `ON ... FROM role_name`) similarly propagates: every user or role that has that role in its chain loses the privilege, without touching the role's other members' unrelated privileges.
+- If the role being revoked was previously set as a session's **default role** (`SET DEFAULT ROLE`), `REVOKE` does **not** clear that default-role record in `mysql.user`. Re-granting the same role later makes it the default again automatically. Use `SET DEFAULT ROLE NONE` to actually clear it.
+
+## Proxy Revocation
+
+```sql
+REVOKE PROXY ON 'dba_user'@'localhost' FROM 'app_user'@'localhost';
+```
+
+Removes `app_user`'s ability to connect and execute as `dba_user`. Always requires the `ON` target — there's no bare "revoke all proxy" shorthand.
+
+## See Also
+
+- **`mariadb-grant`** — the mirrored `GRANT` privilege model, full `priv_type`/`priv_level` catalog, `WITH GRANT OPTION`
+- **`mariadb-create-user`** — account creation/locking; `DROP USER` for fully removing an account (the only way to strip the residual `USAGE` privilege)
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/revoke>
+  - <https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/grant>


### PR DESCRIPTION
Batch 2 of the **DOCS-6287** agent-skills coverage wave — access control (the ticket's "B" group). Follows batch 1 (#758).

## What's here (5 new Tier 1 skills, `granular/statements/`)

| Skill | Covers |
|---|---|
| `mariadb-create-user` | `IDENTIFIED BY`/`BY PASSWORD`/`VIA\|WITH` multi-plugin auth chained with `OR`, default plugin, `REQUIRE` TLS, resource limits, `PASSWORD EXPIRE`, `ACCOUNT LOCK`, `OR REPLACE`, `IF NOT EXISTS`, host defaulting |
| `mariadb-grant` | privilege scope levels, implicit account creation + `NO_AUTO_CREATE_USER`, the `SUPER` split, renamed privileges (`BINLOG MONITOR`), `DELETE HISTORY`, roles, `GRANT PROXY`, `TO PUBLIC` |
| `mariadb-revoke` | the five REVOKE forms, the `USAGE`-survives gotcha, `ER_NONEXISTING_GRANT` on level mismatch, no `IF EXISTS` |
| `mariadb-alter-user` | shared option surface with CREATE USER, `PASSWORD EXPIRE` variants + `default_password_lifetime`, `ACCOUNT LOCK`/expired-password sandbox mode, and `SET PASSWORD` |
| `mariadb-drop-user` | multi-account drops, `IF EXISTS`, the active-connections warning, no cascade on owned objects / grants made, dangling `DEFINER`; plus `RENAME USER` |

## Method

Same as batch 1: parallel research agents source-verified every "What LLMs Often Miss" claim against `mariadb-server/sql/` (`sql_acl.cc`, `sql_yacc.yy`, `sys_vars.cc`, `privilege.h`) and the canonical docs. Hard confirmations included the `SUPER`-split privileges, the `REPLICATION CLIENT` → `BINLOG MONITOR` rename, and `DELETE HISTORY`.

**Two verification catches worth flagging for review:**
1. **`SET PASSWORD = 'string'` is NOT a cleartext form.** Source (`sql_yacc.yy` / `sql_acl.cc`, plus the `set_password` mtr test) shows a bare string is stored *as an already-computed hash*. The skill documents `SET PASSWORD = PASSWORD('cleartext')` for plaintext input and warns that typing a plaintext string bare silently locks the account out.
2. **`DROP USER ... FORCE` is not in the community server.** The public docs page shows `FORCE` (12.1+), but it is absent from the `DROP USER` grammar and `mysql_drop_user()` in the CS tree at 13.x (it appears to be Enterprise-only; the unified docs conflate the two). Since these skills target the 11.8 **community** baseline, the skill omits `FORCE` and documents `KILL CONNECTION` as the way to end a dropped user's live sessions. The warn-and-block-new-connections behavior itself *is* in CS (`sql_acl.cc:13092-13229`), as is the `sql_mode=ORACLE` error path. **Worth confirming whether the docs page should carry a CS-vs-ES tab for `FORCE`** — flagging separately.

House rule applied: no MySQL product name anywhere (verified by sweep); the `mysql` database and `mysql_native_password`/`mysql_old_password` plugin identifiers are kept as the real names.

## Status & checks

All five registered in `.skills-manifest.json` as **`status: "draft"`** (→ `pilot` after your review). codespell (CI-equivalent invocation) + lychee pass; all 11 canonical URLs verified live.

> Note: this branch was cut from `main` before #758 merged, so both PRs append to the `granular-statements` array in `.skills-manifest.json` — expect a trivial append-conflict when the second one merges; I'll rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)