### PR TITLE
DOCS-6287 Add stored-routine & trigger agent skills (batch 3)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -26,7 +26,11 @@
         { "name": "mariadb-grant", "path": "granular/statements/mariadb-grant/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-revoke", "path": "granular/statements/mariadb-revoke/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-alter-user", "path": "granular/statements/mariadb-alter-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
-        { "name": "mariadb-drop-user", "path": "granular/statements/mariadb-drop-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
+        { "name": "mariadb-drop-user", "path": "granular/statements/mariadb-drop-user/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-create-procedure", "path": "granular/statements/mariadb-create-procedure/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-create-function", "path": "granular/statements/mariadb-create-function/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-create-trigger", "path": "granular/statements/mariadb-create-trigger/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-call", "path": "granular/statements/mariadb-call/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
       ]
     },
     "granular-functions": {

--- a/agent-skills/granular/statements/mariadb-call/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-call/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: mariadb-call
+description: "MariaDB-specific syntax and behavior for CALL — optional parentheses when a procedure takes no arguments, OUT/INOUT parameters that must bind to user-defined variables, procedures returning result sets directly to the client (unlike stored functions), the EXECUTE privilege requirement, CALL as a prepared statement, and max_sp_recursion_depth for recursive procedures. Use when writing, generating, or reviewing CALL statements that invoke MariaDB stored procedures."
+---
+
+# CALL in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between invoking a routine in standard SQL and MariaDB's `CALL`**. It assumes the agent already knows that `CALL` invokes a previously defined stored procedure. Everything below documents MariaDB-specific parameter passing, result-set semantics, privileges, prepared-statement support, and recursion — plus the most common LLM traps.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `CALL sp_name();` for every invocation, even with zero parameters | Parentheses are optional when there are no arguments: `CALL sp_name;` and `CALL sp_name();` are equivalent. Don't assume the parens are mandatory |
+| `CALL sp_name('literal_out_placeholder', ...)` for an `OUT`/`INOUT` parameter | `OUT` and `INOUT` parameters must be bound to a **user-defined variable** (`@var`), not a literal — the server writes the returned value back into that variable. Read it with a follow-up `SELECT @var;` |
+| Treating a called procedure's `SELECT` output like a function's return value | A stored procedure can send **one or more result sets straight to the client** (each `SELECT` in its body produces one) — a stored function cannot do this at all, it only returns a scalar via `RETURN`. Don't conflate the two |
+| Assuming `CALL` always needs `EXECUTE`-plus-`SELECT` privilege on referenced tables | The caller needs the **`EXECUTE`** privilege on the procedure itself (or a broader routine/DB-level grant); the procedure's own body statements run with the privileges implied by `SQL SECURITY DEFINER`/`INVOKER`, not the caller's table grants |
+| Writing a recursive procedure and expecting it to just work | Recursion is **disabled by default**. Set the session variable `max_sp_recursion_depth` (default `0`, range `0`–`255`) to a nonzero value before calling a self-recursive procedure, or it fails immediately |
+| Calling a result-set-returning procedure from inside a stored function or trigger | Not allowed — a procedure that contains a `SELECT` (or dynamic SQL) cannot be invoked from a function or trigger context; the server raises an error rather than silently discarding the extra result set |
+
+## Syntax
+
+```sql
+CALL sp_name([parameter[, ...]]);
+CALL sp_name;          -- parens optional with no arguments
+CALL db_name.sp_name(parameter[, ...]);
+```
+
+- Parentheses may be omitted entirely when the procedure takes no parameters — `CALL p` and `CALL p()` are equivalent.
+- The procedure name can be schema-qualified (`db_name.sp_name`); back-tick either identifier if it's a reserved word or contains special characters.
+- Any amount of whitespace (spaces, tabs, newlines) is allowed between the procedure name and the opening `(`.
+
+## `OUT` / `INOUT` Parameters
+
+```sql
+CALL total_orders(@customer_id, @total);   -- @total is OUT or INOUT
+SELECT @total;                             -- read the value back
+```
+
+- Values passed for `OUT` and `INOUT` parameters must be **user-defined variables** (`@var`) at the top SQL level — not literals or expressions. Inside another stored program, a local variable or the enclosing routine's own parameter can also be used.
+- If the procedure body never assigns a value to an `OUT` parameter, the bound variable is set to `NULL` (its prior value is lost) when `CALL` returns.
+- `CALL` supports placeholders (`?`) for `OUT`/`INOUT` parameters in prepared statements, not just `IN` parameters.
+
+## Result Sets
+
+A stored procedure can return result sets directly to the client — each top-level `SELECT` executed in the procedure body produces one:
+
+```sql
+CALL report_summary();   -- may emit one SELECT's worth of rows, or several
+```
+
+- Whether the client can receive more than one result set from a single `CALL` depends on the client capability flag `CLIENT_MULTI_RESULTS`. Modern client libraries (including the MariaDB Connectors) set this by default; without it, only a single result set may come back, and prepared statements cannot be used inside the called procedure.
+- Consuming multiple result sets is a client-API concern (a "more results" loop in the connector) rather than `CALL` syntax.
+- After the procedure returns, `ROW_COUNT()` reports the affected-rows count of the **last** statement executed inside the routine.
+
+## Privileges
+
+Calling a procedure requires the **`EXECUTE`** privilege on that routine (granted directly, via a routine-level `GRANT EXECUTE ON PROCEDURE`, or implied by ownership/broader grants). This is independent of whatever table privileges the procedure's body statements need — those are evaluated against the definer or invoker per the routine's `SQL SECURITY` clause.
+
+## Prepared Statements
+
+```sql
+PREPARE stmt FROM 'CALL sp_name(?, ?, ?)';
+SET @a = 1, @out_val = NULL;
+EXECUTE stmt USING @a, @out_val, @out_val;
+```
+
+`CALL` can be executed as a prepared statement, with placeholders for `IN`, `OUT`, and `INOUT` parameters alike.
+
+## Recursion
+
+Stored procedures may call themselves (or each other, mutually) recursively. This is governed by the session variable `max_sp_recursion_depth`:
+
+- **Default: `0`** — recursion is disabled.
+- Range: `0`–`255`.
+- Set it before the call: `SET max_sp_recursion_depth = 10;`
+
+## See Also
+
+- **`mariadb-create-procedure`** — defining the stored procedure that `CALL` invokes, including parameter modes (`IN`/`OUT`/`INOUT`) and `SQL SECURITY`
+- Canonical reference on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/stored-routine-statements/call>

--- a/agent-skills/granular/statements/mariadb-create-function/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-function/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: mariadb-create-function
+description: "MariaDB-specific syntax and behavior for CREATE FUNCTION across its three distinct forms — stored functions (RETURNS + RETURN, IN/OUT/INOUT parameters, DETERMINISTIC/binlog interaction), stored aggregate functions (CREATE AGGREGATE FUNCTION with FETCH GROUP NEXT ROW), and loadable user-defined functions (CREATE FUNCTION ... SONAME 'lib.so', a plugin_dir-loaded shared library unrelated to stored routines). Use when writing, generating, or reviewing any CREATE FUNCTION statement, a custom aggregate, or a UDF registration targeting MariaDB."
+---
+
+# CREATE FUNCTION in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between standard SQL stored functions and MariaDB's three CREATE FUNCTION forms**: (1) ordinary **stored functions**, (2) **stored aggregate functions** (`CREATE AGGREGATE FUNCTION`), and (3) **loadable UDFs** (`CREATE FUNCTION ... SONAME`) — a mechanism unrelated to stored routines that loads a compiled shared library. These three share a keyword but almost nothing else; do not conflate them.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| Assuming stored function parameters are `IN`-only, like standard SQL | MariaDB allows `OUT` and `INOUT` (`IN OUT` is the same thing) on function parameters *(since 10.8)* — but they can only be supplied when the function is called from a `SET` assignment, not from a `SELECT`. Calling with an `OUT`/`INOUT` arg from `SELECT` raises error 4186, "OUT or INOUT argument N for function X is not allowed here" |
+| Omitting `DETERMINISTIC`/`NOT DETERMINISTIC` and assuming a sensible default | The characteristic defaults to **`NOT DETERMINISTIC`** if omitted — the pessimistic default, not the optimistic one |
+| Creating a non-deterministic function on a server with binary logging on and being surprised by an error | With `--log-bin` on and `log_bin_trust_function_creators=OFF` (the default), creating **any** stored function requires a `SUPER`-class privilege (`LOG BIN TRUSTED SP CREATOR`); a **non-deterministic** function whose data-access characteristic is `CONTAINS SQL` or `MODIFIES SQL DATA` is rejected outright regardless of privilege. Set `log_bin_trust_function_creators=ON` (session/global) for dev/test convenience, or mark the function `DETERMINISTIC`+`READS SQL DATA` if that's actually true |
+| Writing an aggregate as a regular scalar function plus a `GROUP BY` hack | Use `CREATE AGGREGATE FUNCTION` with a loop containing `FETCH GROUP NEXT ROW` — the MariaDB-specific mechanism for custom aggregates, callable in `GROUP BY` queries and as a window function |
+| Writing `CREATE FUNCTION foo RETURNS INT SONAME 'lib.so'` and expecting it to behave like a stored function | It's a completely different object — a **UDF**, backed by a compiled shared library the server loads from `plugin_dir`, recorded in `mysql.func`. No SQL body, no `BEGIN...END`, no `RETURN` statement — `RETURNS` here is restricted to `STRING`\|`INTEGER`\|`REAL`\|`DECIMAL` only |
+| Assuming a stored function silently shadows or is shadowed consistently by a same-named UDF | Unqualified function-call resolution order is: native built-ins, then **UDFs**, then type constructors, then **stored functions** last. A UDF named `foo` always wins over a stored function named `foo` for unqualified calls |
+| Writing a regular `SELECT ...` inside a stored function body to fetch a value | Not permitted — any statement returning a result set is disallowed in a stored function. Use `SELECT ... INTO var` (or a subselect in the `RETURN` expression) instead |
+| Forgetting a `RETURN` in the function body | Compile-time error (`ER_SP_NORETURN`) if no `RETURN` appears anywhere in the body; if execution reaches the end without having *executed* one at runtime, error `ER_SP_NORETURNEND` ("FUNCTION x ended without RETURN") |
+
+## Stored Functions
+
+```sql
+CREATE [OR REPLACE]
+    [DEFINER = {user | CURRENT_USER | role | CURRENT_ROLE}]
+    FUNCTION [IF NOT EXISTS] func_name ([func_parameter[,...]])
+    RETURNS type
+    [characteristic ...]
+    RETURN expr | func_body   -- func_body: BEGIN...END containing a RETURN
+```
+
+- `func_parameter`: `[IN | OUT | INOUT | IN OUT] param_name type [DEFAULT value]`. `IN` is the default direction. `DEFAULT` on a parameter is a MariaDB extension, not standard SQL.
+- **`RETURNS` is the declaration** (the type, stated once, in the header); **`RETURN`** is the *statement* that produces a value and exits — either a bare expression (`RETURN expr;`) or inside a `BEGIN...END` compound body, which must contain at least one `RETURN`.
+- `characteristic`: `LANGUAGE SQL` (accepted, no effect — SQL is the only language) | `[NOT] DETERMINISTIC` | `{CONTAINS SQL | NO SQL | READS SQL DATA | MODIFIES SQL DATA}` (informational only, unchecked; defaults to `CONTAINS SQL` if omitted) | `SQL SECURITY {DEFINER | INVOKER}` (defaults to `DEFINER`) | `COMMENT 'string'`.
+- Requires the `CREATE ROUTINE` privilege to create, `EXECUTE` to call; creation auto-grants `EXECUTE`/`ALTER ROUTINE` to the creator even when `DEFINER` names someone else.
+- Stored-function-only restrictions (beyond the general stored-routine limitations): no statement that returns a result set (use `SELECT ... INTO`), no `FLUSH`, no explicit/implicit commit or rollback, no recursion, cannot modify a table already in use by the invoking statement, no prepared statements (`PREPARE`/`EXECUTE`/dynamic SQL).
+
+```sql
+CREATE FUNCTION hello(s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC
+  RETURN CONCAT('Hello, ', s, '!');
+```
+
+## Stored Aggregate Functions
+
+```sql
+CREATE [OR REPLACE] [DEFINER = ...] AGGREGATE FUNCTION [IF NOT EXISTS]
+    func_name ([func_parameter[,...]]) RETURNS type
+BEGIN
+    -- declarations
+    DECLARE CONTINUE HANDLER FOR NOT FOUND RETURN return_val;
+    LOOP
+        FETCH GROUP NEXT ROW;   -- pulls the next row of the current group
+        -- accumulate into local state
+    END LOOP;
+END;
+```
+
+- Everything about a plain stored function applies, plus: the `AGGREGATE` keyword, and `FETCH GROUP NEXT ROW` inside the loop — MariaDB's mechanism for driving the row-by-row accumulation. There is no separate "initialize/iterate/terminate" API to implement (unlike UDF aggregates below); it's one loop with a `NOT FOUND` handler that fires when the group is exhausted, from which you `RETURN` the accumulated result.
+- Callable in `GROUP BY` queries and as a window function, exactly like a built-in aggregate.
+- Oracle-mode (`sql_mode=ORACLE`) syntax is also supported, using `RETURN` (not `RETURNS`) in the header and an `EXCEPTION WHEN NO_DATA_FOUND` block instead of a `CONTINUE HANDLER`.
+
+## User-Defined (Loadable) Functions — `CREATE FUNCTION ... SONAME`
+
+```sql
+CREATE [OR REPLACE] [AGGREGATE] FUNCTION [IF NOT EXISTS] function_name
+    RETURNS {STRING | INTEGER | REAL | DECIMAL}
+    SONAME 'shared_library_name';
+```
+
+This is **not** a stored function — no body, no `BEGIN...END`, no `RETURN`. It registers a function implemented in a compiled shared library (`.so`/`.dll`), loaded from the `plugin_dir` directory. `shared_library_name` is a **basename**, not a path.
+
+- Requires the `INSERT` privilege on the `mysql` database (`INSERT` + `DELETE` if `OR REPLACE` is used) — a different privilege model from stored routines' `CREATE ROUTINE`. Registration adds a row to `mysql.func`.
+- `RETURNS` here is limited to four keywords: `STRING`, `INTEGER`, `REAL`, `DECIMAL`. `DECIMAL` UDFs are implemented at the C level the same way as `STRING` UDFs (no native C decimal type in the calling convention).
+- `AGGREGATE` marks the UDF as an aggregate (summary) function, implemented via the UDF aggregate C API rather than `FETCH GROUP NEXT ROW`. Aggregate UDFs can also be used as window functions.
+- Statements using UDFs are **not safe for statement-based replication**.
+- **Name-collision precedence**: for an unqualified call, MariaDB resolves native built-ins first, then UDFs, then type constructors, then stored functions last — a UDF shadows a same-named stored function, not the other way around.
+- To upgrade a UDF's library, `DROP FUNCTION` first, replace the library file, then `CREATE FUNCTION` again — swapping the library in place under a loaded UDF can crash the server.
+
+## See Also
+
+- **`mariadb-create-procedure`** — shared stored-routine surface (parameters, characteristics, privileges) without the `RETURNS`/`RETURN` requirement
+- **`mariadb-create-trigger`** — another routine body context governed by the same `log_bin_trust_function_creators` binlog-safety gate
+- Canonical references on `mariadb.com/docs` (consult for edge cases not covered here):
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-function>
+  - <https://mariadb.com/docs/server/server-usage/stored-routines/stored-functions/stored-aggregate-functions>
+  - <https://mariadb.com/docs/server/server-usage/user-defined-functions/create-function-udf>

--- a/agent-skills/granular/statements/mariadb-create-procedure/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-procedure/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: mariadb-create-procedure
+description: "MariaDB-specific syntax and behavior for CREATE PROCEDURE — OR REPLACE / IF NOT EXISTS (mutually exclusive), DEFINER and SQL SECURITY DEFINER/INVOKER, parameter modes IN/OUT/INOUT (plus IN OUT and NOCOPY in Oracle mode only), parameter DEFAULT values (11.8+), the CONTAINS SQL/NO SQL/READS SQL DATA/MODIFIES SQL DATA characteristics (advisory, default CONTAINS SQL), DETERMINISTIC being a no-op on procedures, required CREATE ROUTINE privilege plus automatic ALTER ROUTINE/EXECUTE grants, and the client-side DELIMITER convention. Use when writing, generating, or reviewing CREATE PROCEDURE statements or stored-procedure bodies that target MariaDB."
+---
+
+# CREATE PROCEDURE in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between what an LLM tends to write for a "stored procedure" and MariaDB's actual `CREATE PROCEDURE`**. It assumes the agent already knows the general concept (parameters, a procedural body, `CALL` to invoke). Everything below documents MariaDB-specific clauses, privilege behavior, parameter semantics, and the most common LLM traps.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `CREATE OR REPLACE PROCEDURE ... IF NOT EXISTS` | **Illegal combination** — `OR REPLACE` and `IF NOT EXISTS` cannot be used together (`ER_WRONG_USAGE`). Pick one: `OR REPLACE` to unconditionally drop-and-recreate, or `IF NOT EXISTS` to no-op with a warning if the procedure already exists |
+| `DETERMINISTIC` / `NOT DETERMINISTIC` on a procedure, expecting it to affect execution | These characteristics are **parsed but ignored for procedures** — they apply only to stored functions. Don't rely on them for procedure caching/replication decisions |
+| Assuming `CONTAINS SQL`/`READS SQL DATA`/etc. is enforced | All four data-access characteristics are **purely advisory/informational** — MariaDB does not verify the body matches the declared clause. Default if omitted is `CONTAINS SQL` |
+| A single semicolon-terminated body pasted straight into a script/ORM call | The body's internal `;` terminators need a **client-side** `DELIMITER` change (e.g. `DELIMITER //`) when run through the `mariadb` CLI — this is a client convenience, not server syntax. Sending the CREATE statement over the wire via an API/driver (prepared statement, one string) needs no delimiter juggling at all |
+| `IN OUT param_name TYPE` in default (non-Oracle) SQL syntax | `IN OUT` (two words) is valid **only under `sql_mode=ORACLE`**. In default MariaDB mode, only `IN`, `OUT`, and `INOUT` (one word) are valid parameter modes, and `IN` is the default when a mode is omitted |
+| `OUT`/`INOUT` params without a session variable at call time | The caller must pass a **user-defined variable** (`@var`) — or, from inside another routine, a local variable/parameter — for each `OUT`/`INOUT` argument, so the returned value has somewhere to land |
+| Omitting `DEFINER`, assuming it's NULL/anonymous | Defaults to **`CURRENT_USER`** at creation time (the account that ran `CREATE PROCEDURE`), not left unset. Setting a *different* `DEFINER` requires the `SET USER` (superuser-class) privilege |
+| Expecting the procedure creator to always be able to run/alter it | `EXECUTE` and `ALTER ROUTINE` are **auto-granted to the creator** at creation time — but only while `automatic_sp_privileges` (default `1`) is enabled |
+| Using `ALTER PROCEDURE` to change parameters or the body | `ALTER PROCEDURE` can only touch **characteristics** (`SQL SECURITY`, data-access clause, `COMMENT`) — never the parameter list or body. To change those, use `CREATE OR REPLACE PROCEDURE` (preserves existing grants) or drop-and-recreate |
+
+## Syntax
+
+```sql
+CREATE
+    [OR REPLACE]
+    [DEFINER = { user | CURRENT_USER | role | CURRENT_ROLE }]
+    PROCEDURE [IF NOT EXISTS] sp_name ([proc_parameter[,...]])
+    [characteristic ...] routine_body
+
+proc_parameter:
+    [ OUT | INOUT | IN OUT ] param_name type |
+    [ IN ] param_name type [DEFAULT value_or_expression]
+
+characteristic:
+    LANGUAGE SQL
+  | [NOT] DETERMINISTIC
+  | { CONTAINS SQL | NO SQL | READS SQL DATA | MODIFIES SQL DATA }
+  | SQL SECURITY { DEFINER | INVOKER }
+  | COMMENT 'string'
+```
+
+`OR REPLACE` and `IF NOT EXISTS` are mutually exclusive. `IN OUT` (as two words) and the `NOCOPY` parameter hint are Oracle-mode-only syntax; default-mode MariaDB uses `INOUT` (one word). Parameter `DEFAULT` values/expressions are available on any parameter regardless of mode *(since 11.8)*.
+
+## Parameter Modes
+
+- **`IN`** (default when omitted) — passes a value in; the caller never sees changes made inside the procedure.
+- **`OUT`** — starts as `NULL` inside the procedure; its final value is visible to the caller. Must be called with a variable (`@v`, or a routine-local variable/parameter when called from another routine).
+- **`INOUT`** — caller-supplied initial value, modifiable, changes visible on return.
+
+```sql
+CREATE PROCEDURE simpleproc (OUT param1 INT, IN threshold INT DEFAULT 100)
+BEGIN
+  SELECT COUNT(*) INTO param1 FROM t WHERE val > threshold;
+END;
+```
+
+## Characteristics
+
+- **`LANGUAGE SQL`** — the only language currently supported; documentation-only clause.
+- **`DETERMINISTIC` / `NOT DETERMINISTIC`** — no effect on procedures (functions only). Default `NOT DETERMINISTIC`.
+- **Data-access clauses** (`CONTAINS SQL` / `NO SQL` / `READS SQL DATA` / `MODIFIES SQL DATA`) — advisory only, never validated against the body. Default `CONTAINS SQL` if none given.
+- **`SQL SECURITY { DEFINER | INVOKER }`** — controls whose privileges are checked at call time. Default **`DEFINER`**. With `DEFINER`, the routine runs with the definer account's privileges regardless of who calls it; with `INVOKER`, the caller's own privileges are checked.
+- **`COMMENT 'string'`** — free-text, shown in `SHOW PROCEDURE STATUS` / `INFORMATION_SCHEMA.ROUTINES`.
+
+## Privileges
+
+- Creating a procedure requires **`CREATE ROUTINE`**.
+- Specifying a `DEFINER` other than the calling account requires the `SET USER` privilege.
+- The creator is auto-granted **`ALTER ROUTINE`** and **`EXECUTE`** on the new routine (governed by `automatic_sp_privileges`, default on).
+- `CREATE OR REPLACE PROCEDURE` preserves existing routine-specific privileges; a plain `DROP PROCEDURE` + `CREATE PROCEDURE` does not.
+- `DROP PROCEDURE`/`ALTER PROCEDURE` require `ALTER ROUTINE` on the routine.
+
+## Body and Invocation Notes
+
+- `routine_body` is any valid SQL procedure statement — a single statement, or a `BEGIN ... END` compound block with declarations, handlers, loops, etc.
+- Unlike stored functions, **procedures may contain transaction-control statements** (`COMMIT`, `START TRANSACTION`, ...) and DDL (`CREATE`, `DROP`, ...).
+- Invoke with `CALL sp_name(...)` — never `SELECT`.
+- If the procedure name collides with a built-in SQL function name, a space is required between the name and `(` both when defining and calling it.
+- The procedure's effective `sql_mode` is captured **at creation time** and used on every execution afterward, independent of the session's `sql_mode` when it's called.
+- Oracle-mode PL/SQL-style procedure bodies are supported under `sql_mode=ORACLE` (a subset of PL/SQL syntax, including `IN OUT` and `NOCOPY` parameters) — a distinct body-syntax mode, not a separate statement.
+- `DELIMITER` (e.g. `DELIMITER //`) is a **client convenience** (`mariadb` CLI only) for feeding a multi-statement body containing `;` as one block — it is not server syntax and irrelevant when the `CREATE PROCEDURE` text is sent as a single prepared statement over the protocol.
+
+## See Also
+
+- **`mariadb-create-function`** — stored functions: `DETERMINISTIC` actually matters, single `RETURNS` value, no transaction/DDL statements
+- **`mariadb-create-trigger`** — trigger-specific `FOR EACH ROW`, timing, and `OLD`/`NEW` row access
+- **`mariadb-call`** — invoking procedures, passing `OUT`/`INOUT` arguments
+- Canonical references on `mariadb.com/docs` (consult only for edge cases not covered here):
+  - <https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures/create-procedure>
+  - <https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures/stored-procedure-overview>
+  - <https://mariadb.com/docs/server/server-usage/stored-routines/stored-procedures/alter-procedure>
+  - <https://mariadb.com/docs/server/server-usage/stored-routines/stored-functions/stored-routine-privileges>

--- a/agent-skills/granular/statements/mariadb-create-trigger/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-trigger/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: mariadb-create-trigger
+description: "MariaDB-specific syntax and behavior for CREATE TRIGGER — OR REPLACE, DEFINER, IF NOT EXISTS, multiple trigger_events in one statement with INSERTING/UPDATING/DELETING predicates (since 12.0), multiple triggers per action-time/event ordered with FOLLOWS/PRECEDES, OLD/NEW row-reference rules, the no-ALTER-TRIGGER gotcha, and restrictions on modifying tables already touched by the firing statement. Use when writing, generating, or reviewing CREATE TRIGGER statements that target MariaDB."
+---
+
+# CREATE TRIGGER in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the **delta between standard SQL triggers and MariaDB's**. It assumes the agent already knows the standard trigger model (fires `BEFORE`/`AFTER` a row-level DML event, `OLD`/`NEW` row aliases). Everything below documents MariaDB-specific grammar, ordering of multiple triggers, restrictions, and the most common LLM traps.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Anything available in current LTS branches (10.6, 10.11, 11.4, 11.8) is shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `ALTER TRIGGER … RENAME TO …` or any `ALTER TRIGGER` | **There is no `ALTER TRIGGER` statement in MariaDB.** To change a trigger, use `CREATE OR REPLACE TRIGGER` (if only the body/options change) or `DROP TRIGGER` + `CREATE TRIGGER` (to rename — trigger names can't be renamed in place) |
+| Assuming a table can only have one `BEFORE INSERT` trigger | MariaDB has always allowed **multiple triggers for the same action time + event** on one table, ordered with `FOLLOWS`/`PRECEDES`. If neither is given, the new trigger is appended last for that action/event |
+| One `CREATE TRIGGER` per event, e.g. three separate triggers for `INSERT`, `UPDATE`, `DELETE` doing the same thing | *(since 12.0)* A single trigger can fire on multiple events: `BEFORE INSERT OR UPDATE OR DELETE ON t FOR EACH ROW …`, using `INSERTING`/`UPDATING`/`DELETING` predicates in the body to branch. Older versions (all current LTS lines) require one event per trigger |
+| `NEW.col` in a `DELETE` trigger, or `OLD.col` in an `INSERT` trigger | Only `NEW.col` exists in `INSERT` (no old row); only `OLD.col` exists in `DELETE` (no new row); `UPDATE` triggers have both |
+| `SET NEW.col = value` inside an `AFTER` trigger to change the row | Has **no effect** in `AFTER` — the row change already happened. Move the assignment to a `BEFORE` trigger |
+| `CREATE DEFINER=... SQL SECURITY DEFINER TRIGGER …` | `SQL SECURITY` is **not valid trigger syntax** (unlike views/procedures/functions) — triggers always execute with the `DEFINER`'s privileges. Just omit it |
+| A trigger body that does `COMMIT;`, `ROLLBACK;`, or `START TRANSACTION;` | **Not permitted** — triggers can't perform explicit or implicit commits/rollbacks; they always run inside the invoking statement's transaction |
+| A trigger on one table that writes back to a table the firing statement is already reading/writing | Raises `ER_CANT_UPDATE_USED_TABLE_IN_SF_OR_TRG` — a trigger cannot modify a table the outer statement has already opened. Design around it (e.g. use a different table, or restructure the statement) |
+| `CREATE TRIGGER … ON some_view FOR EACH ROW …` or `ON temp_table` | Triggers can only be attached to **permanent base tables** — not views, not `TEMPORARY` tables |
+| Multi-statement trigger body pasted straight into the client without changing the delimiter | The body's own `;` terminates the statement early in the CLI client. Wrap with `DELIMITER //` … `END; //` … `DELIMITER ;` |
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE]
+    [DEFINER = { user | CURRENT_USER | role | CURRENT_ROLE }]
+    TRIGGER [IF NOT EXISTS]
+            trigger_name trigger_time {trigger_event [OR trigger_event] ...}
+    ON tbl_name FOR EACH ROW
+    [{ FOLLOWS | PRECEDES } other_trigger_name]
+    trigger_stmt
+
+trigger_time: BEFORE | AFTER
+trigger_event: INSERT | UPDATE [OF column_name [, column_name] ...] | DELETE
+```
+
+- `tbl_name` must be a permanent base table — not a view, not a `TEMPORARY` table.
+- Requires the **`TRIGGER`** privilege on `tbl_name` (plus `SET USER`/`SUPER` to use a `DEFINER` other than the current user).
+- `DEFINER` defaults to `CURRENT_USER` when omitted.
+- Multi-statement bodies need `BEGIN … END`; use the `DELIMITER` client command to type them interactively.
+- There is **no `ALTER TRIGGER`**. Modify via `CREATE OR REPLACE TRIGGER`, or `DROP TRIGGER` + recreate.
+
+## Multiple Trigger Events in One Statement *(since 12.0)*
+
+A single `CREATE TRIGGER` can react to more than one DML event by chaining `trigger_event` with `OR`:
+
+```sql
+CREATE TRIGGER t1_b_any BEFORE INSERT OR UPDATE OR DELETE ON t1 FOR EACH ROW
+BEGIN
+  IF INSERTING THEN
+    INSERT INTO t2 VALUES (NEW.a, 'INSERTING');
+  ELSEIF UPDATING THEN
+    INSERT INTO t2 VALUES (NEW.a, 'UPDATING');
+  ELSEIF DELETING THEN
+    INSERT INTO t2 VALUES (OLD.a, 'DELETING');
+  END IF;
+END;
+```
+
+`INSERTING`, `UPDATING`, `DELETING` are boolean predicates usable inside the body to branch on which event fired. On MariaDB versions before 12.0 (including all current 10.x/11.x LTS lines), only a single `trigger_event` is allowed per trigger — write three separate triggers instead, one per event.
+
+## Multiple Triggers per Action Time + Event — `FOLLOWS`/`PRECEDES`
+
+Unlike the single-event-per-trigger constraint above, **having more than one trigger for the same `trigger_time` + `trigger_event` combination on a table has always been supported** in MariaDB (this predates the 10.6 baseline — no version gate applies). Use `FOLLOWS`/`PRECEDES` to control firing order:
+
+```sql
+CREATE TRIGGER tr1_bi BEFORE INSERT ON t1 FOR EACH ROW SET @a := 1;
+CREATE TRIGGER tr2_bi BEFORE INSERT ON t1 FOR EACH ROW FOLLOWS tr1_bi SET @a := 2;
+CREATE TRIGGER tr0_bi BEFORE INSERT ON t1 FOR EACH ROW PRECEDES tr1_bi SET @a := 0;
+```
+
+- `FOLLOWS other_trigger` places the new trigger immediately after `other_trigger` in the firing order.
+- `PRECEDES other_trigger` places it immediately before.
+- Omitting both appends the new trigger last for that action time + event.
+- Verify the actual order via `ACTION_ORDER` in `INFORMATION_SCHEMA.TRIGGERS`:
+
+  ```sql
+  SELECT trigger_name, action_order FROM information_schema.triggers
+    WHERE event_object_table = 't1';
+  ```
+
+## `OLD` / `NEW` Row References
+
+| Event | Available references |
+|---|---|
+| `INSERT` | `NEW.col` only (no prior row) |
+| `UPDATE` | Both `OLD.col` (pre-update) and `NEW.col` (post-update) |
+| `DELETE` | `OLD.col` only (row is gone after) |
+
+- `OLD.col` is always **read-only**.
+- `NEW.col` is readable everywhere, and in a **`BEFORE`** trigger it can be assigned with `SET NEW.col = value` to change what actually gets written. In an `AFTER` trigger, assigning `NEW.col` is a no-op — the row is already committed to storage.
+- Neither `OLD` nor `NEW` can reference **generated columns**.
+- `OLD`/`NEW` are MariaDB extensions to standard SQL trigger syntax, and are not case-sensitive.
+
+## Restrictions
+
+Triggers inherit **both** the stored-routine and stored-function limitation sets, plus their own:
+
+- Cannot be defined on a `TEMPORARY` table or a view — permanent base tables only.
+- Cannot return a result set (a bare `SELECT` is rejected; `SELECT ... INTO` is fine).
+- No explicit or implicit `COMMIT`/`ROLLBACK`/`START TRANSACTION` inside the body.
+- Cannot modify a table that the invoking statement has already opened for read or write (`ER_CANT_UPDATE_USED_TABLE_IN_SF_OR_TRG`).
+- No `PREPARE`/`EXECUTE`/`DEALLOCATE PREPARE` (no dynamic SQL).
+- Not activated by foreign-key cascade actions (`ON DELETE CASCADE`, etc.) or by `TRUNCATE TABLE`.
+- Standard `FOR EACH STATEMENT` triggers are not supported — MariaDB triggers are always row-level (`FOR EACH ROW` is mandatory in the grammar).
+- If called indirectly (a trigger calling a stored procedure via `CALL`), the called routine inherits the trigger's restrictions — e.g. it still can't `COMMIT` or return a result set.
+
+## Trigger Firing on Compound Statements
+
+- `LOAD DATA INFILE` / `LOAD XML` fire `INSERT` triggers per row.
+- `REPLACE` fires, in order: `BEFORE INSERT`, then (only if a row is actually deleted) `BEFORE DELETE`/`AFTER DELETE`, then `AFTER INSERT`.
+- `INSERT ... ON DUPLICATE KEY UPDATE` fires `BEFORE INSERT`, then (if the row already exists) `BEFORE UPDATE`/`AFTER UPDATE` instead of the insert path.
+- `DROP TABLE`, `TRUNCATE TABLE`, and dropping a partition do **not** fire `DELETE` triggers.
+
+## Examples
+
+```sql
+-- OR REPLACE avoids the "trigger already exists" error on redeploy
+CREATE OR REPLACE DEFINER=`app_user`@`%` TRIGGER trg_limit_population
+  BEFORE UPDATE ON country_stats FOR EACH ROW
+BEGIN
+  IF NEW.population < 1 THEN
+    SET NEW.population = 1;
+  ELSEIF NEW.population > 2000000000 THEN
+    SET NEW.population = 2000000000;
+  END IF;
+END;
+```
+
+```sql
+-- IF NOT EXISTS: idempotent create, warns instead of erroring if present
+CREATE TRIGGER IF NOT EXISTS increment_animal
+  AFTER INSERT ON animals FOR EACH ROW
+  UPDATE animal_count SET animal_count.animals = animal_count.animals + 1;
+```
+
+## See Also
+
+- **`mariadb-create-procedure`** / **`mariadb-create-function`** — shared stored-routine restriction surface (no result sets from functions, no dynamic SQL, `DELIMITER` gotcha)
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/server-usage/triggers-events/triggers/create-trigger>
+  - <https://mariadb.com/docs/server/server-usage/triggers-events/triggers/trigger-overview>
+  - <https://mariadb.com/docs/server/server-usage/triggers-events/triggers/trigger-limitations>
+  - <https://mariadb.com/docs/server/server-usage/triggers-events/triggers/triggers-and-implicit-locks>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/drop/drop-trigger>


### PR DESCRIPTION
Batch 3 of the **DOCS-6287** agent-skills coverage wave — stored routines & triggers (the ticket's "C" group). Follows #758 (batch 1) and #759 (batch 2).

## What's here (4 new Tier 1 skills, `granular/statements/`)

| Skill | Covers |
|---|---|
| `mariadb-create-procedure` | `OR REPLACE`/`IF NOT EXISTS` (mutually exclusive), `DEFINER`/`SQL SECURITY`, `IN`/`OUT`/`INOUT` (+ Oracle-mode `IN OUT`/`NOCOPY`), param `DEFAULT` (11.8+), advisory data-access characteristics, `automatic_sp_privileges`, `DELIMITER` gotcha |
| `mariadb-create-function` | all three forms — stored functions (`RETURNS`/`RETURN`, `DETERMINISTIC` + binlog gate), stored **aggregate** functions (`FETCH GROUP NEXT ROW`), and loadable **UDFs** (`... SONAME`) |
| `mariadb-create-trigger` | `FOR EACH ROW`, `OLD`/`NEW` rules, multiple triggers per event (`FOLLOWS`/`PRECEDES`), multi-event triggers (12.0+), no `ALTER TRIGGER`, restrictions |
| `mariadb-call` | optional parens, `OUT`/`INOUT` via `@vars`, result sets, `EXECUTE` privilege, `max_sp_recursion_depth` |

## Method

Same source-verified pipeline: parallel research agents checked every "What LLMs Often Miss" claim against `mariadb-server/sql/` (`sql_yacc.yy`, `sp_head.cc`, `sql_trigger.cc`, `sql_acl.cc`, `sys_vars.cc`) and the canonical docs. Notable confirmations:

- **`CREATE PROCEDURE`**: `OR REPLACE` + `IF NOT EXISTS` is `ER_WRONG_USAGE`; `DETERMINISTIC` is a no-op on procedures; `IN OUT`/`NOCOPY` are Oracle-mode-only.
- **`CREATE FUNCTION`**: stored-function `OUT`/`INOUT` params (since 10.8) error 4186 from `SELECT`; `NOT DETERMINISTIC` is the default; `log_bin_trust_function_creators` defaults OFF (`sys_vars.cc`), gating function creation under `--log-bin`; UDF-vs-stored-function name-collision precedence (native → UDF → constructor → stored function).
- **`CREATE TRIGGER`**: multi-event triggers (`INSERT OR UPDATE OR DELETE` + `INSERTING`/`UPDATING`/`DELETING`) are **since 12.0** — verified against the grammar *and* `git tag --contains` (MDEV-10164, `mariadb-12.0.1`), so it's correctly gated and the skill tells the agent to use one-trigger-per-event by default on current LTS. `FOLLOWS`/`PRECEDES` multi-trigger ordering is long-standing (no gate).
- **`CALL`**: `max_sp_recursion_depth` default 0 (recursion off); parens optional with no args.

## Status & checks

All four registered in `.skills-manifest.json` as **`status: "draft"`** (→ `pilot` after review). codespell (CI-equivalent) + lychee pass; all canonical URLs verified live; no MySQL product name (sweep clean).

> Note: like #759, this branch was cut from `main` before the earlier batch PRs merged, so all three append to the `granular-statements` array in `.skills-manifest.json` — expect a trivial append-conflict on whichever merges after the first; I'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)