### PR TITLE
DOCS-6287: agent skills batch 4 — remaining DDL (CREATE SEQUENCE, TRUNCATE TABLE, RENAME TABLE)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -30,7 +30,10 @@
         { "name": "mariadb-create-procedure", "path": "granular/statements/mariadb-create-procedure/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-create-function", "path": "granular/statements/mariadb-create-function/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-create-trigger", "path": "granular/statements/mariadb-create-trigger/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
-        { "name": "mariadb-call", "path": "granular/statements/mariadb-call/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
+        { "name": "mariadb-call", "path": "granular/statements/mariadb-call/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-create-sequence", "path": "granular/statements/mariadb-create-sequence/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-truncate-table", "path": "granular/statements/mariadb-truncate-table/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-rename-table", "path": "granular/statements/mariadb-rename-table/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
       ]
     },
     "granular-functions": {

--- a/agent-skills/granular/statements/mariadb-create-sequence/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-create-sequence/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: mariadb-create-sequence
+description: "MariaDB-specific syntax and behavior for CREATE SEQUENCE — sequences are ordinary tables (any transactional engine, default BIGINT SIGNED) wrapped with sequence semantics, support atomic CREATE OR REPLACE / IF NOT EXISTS, default to CACHE 1000, expose ANSI (NEXT VALUE FOR), PostgreSQL (NEXTVAL()), and Oracle-mode (seq.nextval) access forms, special-case INCREMENT BY 0 for multi-master/Galera replication, require row-based binlogging, and (since 11.5) truncate rather than reject out-of-range MINVALUE/MAXVALUE/START literals. Use when writing, generating, or reviewing CREATE SEQUENCE statements that target MariaDB."
+---
+
+# CREATE SEQUENCE in MariaDB
+
+*Last updated: 2026-07-20*
+
+This covers the delta between standard-SQL/Oracle-style sequence objects and MariaDB's `CREATE SEQUENCE`, which is implemented as a specially wrapped table rather than a standalone catalog object.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `DROP SEQUENCE IF EXISTS s; CREATE SEQUENCE s ...` to redefine a sequence | `CREATE OR REPLACE SEQUENCE s ...` — atomic, and `CREATE SEQUENCE ... IF NOT EXISTS` also exists for idempotent creation |
+| Assuming a sequence is stored by a storage engine literally named `SEQUENCE` | A sequence created by `CREATE SEQUENCE` is an ordinary table on whatever engine you name (InnoDB/Aria/MyISAM — anything supporting tables without rollback), wrapped by an internal handler. The storage engine literally called `SEQUENCE` is an unrelated feature: a virtual, on-the-fly row generator behind `seq_1_to_N`-style table names |
+| `NEXTVAL()` / `CURRVAL()` as the only forms | Three families are supported: ANSI `NEXT VALUE FOR seq` / `PREVIOUS VALUE FOR seq`, PostgreSQL-style `NEXTVAL(seq)` / `LASTVAL(seq)`, and Oracle-mode (`SQL_MODE=ORACLE`) `seq.nextval` / `seq.currval` |
+| Assuming no caching, or that caching is opt-in | `CACHE` defaults to **1000**, not 0. Values are reserved in blocks; `FLUSH TABLES`, a server restart, or dropping the connection discards the unused part of the cache (expect gaps). Dropping cache to `1` can roughly halve insert throughput and inflate binlog size several-fold |
+| Rejecting `INCREMENT BY 0` as meaningless | `INCREMENT BY 0` is special-cased: the sequence instead uses the session's `auto_increment_increment` / `auto_increment_offset`, which is MariaDB's documented way to run one sequence definition safely across multi-master or Galera nodes |
+| Assuming `SELECT NEXT VALUE FOR seq` is a safe read under any binlog format | It mutates the sequence's backing row and is always row-logged; under `BINLOG_FORMAT=STATEMENT` it raises an error (`impossible to write to binary log...limited to row-based logging`). Use `ROW` or `MIXED` |
+| `ALTER SEQUENCE s AS BIGINT INCREMENT BY 5` in one statement | The parser rejects combining `AS <type>` with any other clause in the same `ALTER SEQUENCE` — issue the type change alone. Internally it also runs as a full `ALTER TABLE` column-change, unlike every other `ALTER SEQUENCE` clause, which is a fast, single-row metadata update |
+| Expecting `CREATE SEQUENCE s MAXVALUE=99999999999999999999999999` to error immediately | *(since 11.5)* Oracle-style literals wider than the sequence's `AS` type are accepted by the parser and silently truncated to the type's bound, with a `Note`-level warning (`Truncated incorrect INTEGER value`) — not a hard error |
+| `UPDATE`/`DELETE` against a sequence's backing table to change its state | Not allowed on sequence tables. Use `ALTER SEQUENCE`, `SETVAL()`, or a full-row `INSERT` (the one legacy exception, kept for `mariadb-dump` compatibility) |
+
+## Syntax
+
+```sql
+CREATE [OR REPLACE] [TEMPORARY] SEQUENCE [IF NOT EXISTS] sequence_name
+    [AS {TINYINT | SMALLINT | MEDIUMINT | INT | INTEGER | BIGINT} [SIGNED | UNSIGNED]]
+    [INCREMENT [BY | =] number]
+    [MINVALUE [=] number | NO MINVALUE | NOMINVALUE]
+    [MAXVALUE [=] number | NO MAXVALUE | NOMAXVALUE]
+    [START [WITH | =] number]
+    [CACHE [=] number | NOCACHE]
+    [CYCLE | NOCYCLE]
+    [table_options]
+```
+
+- Clauses may be given in any order.
+- `table_options` accepts any normal `CREATE TABLE` option — most commonly `ENGINE = ...` and `COMMENT = '...'`. If `ENGINE` is omitted, the server's default storage engine is used, same as for a normal `CREATE TABLE`.
+- `NOMINVALUE` / `NOMAXVALUE` exist alongside the ANSI `NO MINVALUE` / `NO MAXVALUE` forms specifically for Oracle-syntax compatibility.
+- `AS <int type>` *(since 11.5)* sets the underlying integer storage type (any of `TINYINT`/`SMALLINT`/`MEDIUMINT`/`INT`/`INTEGER`/`BIGINT`, optionally `SIGNED`/`UNSIGNED`; `ZEROFILL` is rejected). Default is `BIGINT SIGNED`. Using `BIGINT UNSIGNED` extends the usable range up to `18446744073709551614`.
+- `CREATE SEQUENCE` requires the `CREATE` privilege on the target table/schema (it shares the exact privilege path used by `CREATE TABLE`); `CREATE OR REPLACE SEQUENCE` on a non-temporary sequence additionally requires `DROP`.
+- `CREATE SEQUENCE` is atomic DDL (as is all DDL since 10.6.1) — no partial-create state survives a crash.
+
+### Defaults (verified against source)
+
+| Clause | Default | Notes |
+|---|---|---|
+| `AS` type | `BIGINT SIGNED` | |
+| `INCREMENT` | `1` | May be negative. `0` defers to `auto_increment_increment` at first use (see gotcha table) |
+| `MINVALUE` | `1` if increment ≥ 0 and signed; the type's minimum + 1 if increment < 0 or unsigned. For default `BIGINT SIGNED` with a negative increment: `-9223372036854775807` | |
+| `MAXVALUE` | The type's maximum − 1 if increment ≥ 0 or unsigned; `-1` if increment < 0 (signed). For default `BIGINT SIGNED`: `9223372036854775806` | Sequences can never generate the true 64-bit min/max because of this ±1 reservation |
+| `START` | `MINVALUE` if increment ≥ 0, `MAXVALUE` if increment < 0 | |
+| `CACHE` | `1000` | `0` means "no cache" (every value written immediately) |
+| `CYCLE` | `NOCYCLE` (off) | |
+
+### Constraints on Create/Alter Arguments
+
+The following must hold, or the statement fails with `ER_SEQUENCE_INVALID_DATA` (error **4085**, `Sequence 'db.name' has out of range value for options`):
+
+- `MAXVALUE >= START >= MINVALUE`
+- `MAXVALUE > MINVALUE`
+- `MAXVALUE` / `MINVALUE` are truncated (with a warning), not rejected, if they exceed the `AS` type's bounds *(since 11.5)*.
+
+## Accessing and Modifying Values
+
+| Form | Standard | Notes |
+|---|---|---|
+| `NEXT VALUE FOR seq` | ANSI SQL | Also usable in a column `DEFAULT` |
+| `NEXTVAL(seq)` | PostgreSQL | |
+| `seq.nextval` | Oracle | Requires `SQL_MODE=ORACLE` |
+| `PREVIOUS VALUE FOR seq` | ANSI SQL | Last value generated *by the current connection* — not a global "last value" |
+| `LASTVAL(seq)` | PostgreSQL | |
+| `seq.currval` | Oracle | Requires `SQL_MODE=ORACLE` |
+| `SETVAL(seq, next_value [, is_used [, round]])` | PostgreSQL-compatible, extended with `round` | Only moves the sequence forward — attempting to set a lower `(round, next_value)` returns `NULL` and has no effect. Requires `INSERT` privilege. Used internally to propagate sequence state to replicas |
+
+`ALTER SEQUENCE ... RESTART [WITH n]` sets the next value directly (equivalent to `SETVAL(seq, n, 0)`); with no value it resets to the recorded `START` value. It takes a brief full-table lock, unlike `SETVAL()`, which is non-blocking.
+
+## Storage Engine and Table Structure
+
+- A sequence is a real table (visible in `SHOW TABLES`), created without rollback support even on transactional engines (InnoDB, Aria, MyISAM all qualify), then wrapped by an internal handler that intercepts reads/writes to implement sequence semantics.
+- The single row has 8 fixed columns: `next_not_cached_value`, `minimum_value`, `maximum_value`, `start_value`, `increment`, `cache_size`, `cycle_option`, `cycle_count`. `SHOW CREATE TABLE seq_name` shows this structure; `SHOW CREATE SEQUENCE seq_name` shows the equivalent `CREATE SEQUENCE` form with all defaults filled in.
+- Because sequences share the table namespace, `DROP TABLE`, `RENAME TABLE`, `ALTER TABLE ... RENAME`, and `SHOW CREATE TABLE` all work on a sequence; `LOCK TABLES` also affects it (unlike Oracle, where `LOCK TABLE` does not touch sequences). `CREATE TABLE ... SEQUENCE=1` is the table-option equivalent of `CREATE SEQUENCE`.
+- `DROP SEQUENCE` only removes sequences — pointing it at a plain table fails (or, with `IF EXISTS`, emits a note). `DROP TABLE` removes either kind.
+- Do not confuse this with the unrelated **SEQUENCE storage engine**, which powers virtual, read-only, disk-free row generators named by pattern (`seq_1_to_100`, `seq_1_to_15_step_3`, etc.) for row generation in queries — a completely different feature that happens to share the keyword.
+
+## Replication
+
+- `CREATE SEQUENCE` and `ALTER SEQUENCE` themselves replicate as their own DDL statement (row-based logging is explicitly disabled for the definition row they write).
+- Every cache-block refill triggered by `NEXT VALUE FOR` / `NEXTVAL()`, however, is logged as a row event (`Write_rows_log_event`) regardless of the session's binlog format. Because of this, statement-based logging cannot represent it: running `SELECT NEXT VALUE FOR seq` under `BINLOG_FORMAT=STATEMENT` raises an error. Use `ROW` or `MIXED`.
+- For master-master setups or Galera, set `INCREMENT=0` so the sequence defers to `auto_increment_increment` / `auto_increment_offset`, guaranteeing non-colliding values per node.
+- `SETVAL()` is the mechanism used to propagate a sequence's advanced state to replicas; out-of-order delivery is safe because only the highest `(round, next_value)` pair ever takes effect.
+
+## Errors
+
+| Code | Name | Message (current source text) |
+|---|---|---|
+| 4084 | `ER_SEQUENCE_RUN_OUT` | `Sequence 'db.name' has run out` — raised once bounds are exhausted and `CYCLE` was not specified |
+| 4085 | `ER_SEQUENCE_INVALID_DATA` | `Sequence 'db.name' has out of range value for options` — raised when `CREATE`/`ALTER SEQUENCE` arguments violate the ordering constraints above |
+
+## Examples
+
+```sql
+CREATE SEQUENCE s START WITH 100 INCREMENT BY 10;
+SELECT NEXTVAL(s);   -- 100
+SELECT NEXTVAL(s);   -- 110
+
+-- Idempotent redefinition, no drop/create race:
+CREATE OR REPLACE SEQUENCE s START WITH 1 MAXVALUE 10 CACHE 5;
+
+-- Multi-master / Galera friendly sequence:
+CREATE SEQUENCE s_mm INCREMENT BY 0;
+
+-- Explicit narrow type, since 11.5:
+CREATE SEQUENCE s3 AS SMALLINT UNSIGNED START WITH 1;
+
+-- Use as a DEFAULT instead of AUTO_INCREMENT:
+CREATE SEQUENCE s1;
+CREATE TABLE t1 (a INT PRIMARY KEY DEFAULT (NEXT VALUE FOR s1), b INT);
+INSERT INTO t1 (b) VALUES (1), (2);
+```
+
+## See Also
+
+- **`mariadb-create-table`** — the table-option surface (`ENGINE=`, atomic DDL, `CREATE OR REPLACE`) that `CREATE SEQUENCE` inherits, and the `SEQUENCE=1` table-option form
+- **`mariadb-alter-table`** — for changing a sequence's engine, comment, or name (via `ALTER TABLE`, not `ALTER SEQUENCE`)
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-structure/sequences/create-sequence>
+  - <https://mariadb.com/docs/server/reference/sql-structure/sequences/sequence-overview>
+  - <https://mariadb.com/docs/server/reference/sql-structure/sequences/alter-sequence>
+  - <https://mariadb.com/docs/server/reference/sql-structure/sequences/drop-sequence>

--- a/agent-skills/granular/statements/mariadb-rename-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-rename-table/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: mariadb-rename-table
+description: "MariaDB-specific syntax and behavior for RENAME TABLE — atomic multi-table renames executed left-to-right with full rollback on any failure (enabling the classic swap trick), works directly on TEMPORARY tables (no ALTER TABLE needed), refuses to run inside an active transaction or under LOCK TABLES, requires ALTER+DROP on the source and CREATE+INSERT on the target, supports IF EXISTS and WAIT/NOWAIT, and has specific cross-database move restrictions for views and tables with triggers. Use when writing, generating, or reviewing RENAME TABLE statements that target MariaDB."
+---
+
+# RENAME TABLE in MariaDB
+
+*Last updated: 2026-07-20*
+
+`RENAME TABLE` renames — and optionally moves — one or more tables or views in a single atomic statement. It is the primitive behind the well-known "instant" table-swap pattern, but it has sharper edges (transaction/lock restrictions, exact privilege set, temporary-table handling) than most LLMs assume by analogy with other systems.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| "Temporary tables can't be renamed with `RENAME TABLE`; use `ALTER TABLE ... RENAME TO` instead." | In MariaDB, `RENAME TABLE t1 TO t2;` works directly on a `TEMPORARY` table — no `ALTER TABLE` needed. |
+| `RENAME TABLE` inside a `BEGIN … COMMIT` block, assuming it just runs like other DDL. | MariaDB refuses outright: issuing `RENAME TABLE` inside an active transaction (or while `LOCK TABLES` is in effect) raises `ER_LOCK_OR_ACTIVE_TRANSACTION` ("Can't execute the given command because you have active locked tables or an active transaction") rather than implicitly committing and proceeding. |
+| Granting only `ALTER` (or only `DROP`) and assuming that covers a rename. | The full requirement is **`ALTER` + `DROP`** on the source table/database and **`CREATE` + `INSERT`** on the target table/database — all four privileges, split across both names. |
+| A multi-pair `RENAME TABLE t1 TO t2, t3 TO t4` where, if `t3` is missing, assuming `t1 TO t2` already "took" and only the failing pair errors. | The whole statement is atomic: renames are applied left-to-right, but if any pair fails, **every** rename in the statement is rolled back, including ones that already succeeded. |
+| Emulating a table swap with `DROP`/temp-name juggling across several separate statements. | Do it in one atomic statement: `RENAME TABLE t1 TO tmp, t2 TO t1, tmp TO t2;` — safe because the whole thing is one all-or-nothing operation. |
+| `RENAME TABLE db1.t TO db2.t;` assumed to always work for moving any object between databases. | It fails for **views** (`ER_FORBID_SCHEMA_CHANGE`, "Changing schema … is not allowed") and for tables that have **triggers** (`ER_TRG_IN_WRONG_SCHEMA`, "Trigger in wrong schema") — cross-database moves are blocked in both cases. |
+| Treating `IF EXISTS` as unsupported on `RENAME TABLE` (only assumed valid on `DROP TABLE`/`CREATE TABLE`). | `RENAME TABLE IF EXISTS t1 TO t2, ...` is valid — a missing source table becomes a note/warning instead of an error, and the statement continues with the remaining pairs. |
+| Assuming `RENAME TABLE` has no way to control metadata-lock waiting. | Each pair can carry `WAIT n` or `NOWAIT` (e.g. `RENAME TABLE t1 NOWAIT TO t2;`), which sets the lock-wait timeout for that statement's metadata-lock acquisition. |
+| Assuming `RENAME TABLES` (plural) is a different statement that must be used for multi-table renames, or that it behaves differently from `RENAME TABLE`. | `TABLE`/`TABLES` are interchangeable — the presence or absence of the `S` has zero effect on behavior, single or multi-table. |
+
+## Syntax
+
+```sql
+RENAME TABLE[S] [IF EXISTS] tbl_name
+  [WAIT n | NOWAIT]
+  TO new_tbl_name
+    [, tbl_name2 [WAIT n | NOWAIT] TO new_tbl_name2] ...
+```
+
+- `tbl_name` may be qualified as `db_name.tbl_name` on either side of `TO`, which moves the table to another database as part of the rename (subject to the view/trigger restrictions below).
+- Multiple `tbl_name TO new_tbl_name` pairs may be given, comma-separated, in one statement; they execute strictly left-to-right.
+- `IF EXISTS` suppresses the error (turning it into a warning) when a named source table does not exist.
+- `WAIT n | NOWAIT` sets the lock-wait timeout for acquiring the metadata lock needed for that pair's rename.
+- Do not confuse this with `RENAME USER old TO new [, ...]`, which shares the `RENAME` keyword but is a completely different statement (account management, not table DDL).
+
+## Atomicity, Ordering, and the Swap Trick
+
+`RENAME TABLE` with multiple pairs is one atomic operation: no other session can see any of the tables mid-rename, pairs are applied in the order written, and if any pair fails, all renames performed earlier in the same statement are reverted. This is what makes the classic swap safe:
+
+```sql
+CREATE TABLE new_table (...);
+-- populate new_table --
+RENAME TABLE old_table TO backup_table, new_table TO old_table;
+```
+
+or, to swap two existing tables' names outright:
+
+```sql
+RENAME TABLE t1 TO tmp_table,
+             t2 TO t1,
+             tmp_table TO t2;
+```
+
+For most storage engines (including InnoDB, MyRocks, MyISAM, and Aria) this atomicity extends to crash safety: if the server crashes mid-statement, all tables — and any trigger files touched — revert to their pre-statement names on recovery.
+
+## Restrictions on When RENAME TABLE Can Run
+
+`RENAME TABLE` cannot be issued:
+- inside an active (explicit or already-started) transaction, or
+- while the session holds tables via `LOCK TABLES`.
+
+Both cases raise `ER_LOCK_OR_ACTIVE_TRANSACTION` immediately, before any table is touched — there is no implicit commit-and-continue behavior here, unlike some other DDL statements.
+
+## Moving Tables Between Databases
+
+Qualifying either side with a database name moves the table:
+
+```sql
+RENAME TABLE db1.t TO db2.t;
+```
+
+This requires the databases to be reachable by the storage engine (effectively, the same filesystem/tablespace for file-based engines). Two cases are explicitly blocked:
+
+- **Tables with triggers** cannot be moved to another database — MariaDB raises `ER_TRG_IN_WRONG_SCHEMA` ("Trigger in wrong schema", error 1435). Triggers on a table that stays within the same database are automatically updated to reference the new table name.
+- **Views** cannot be moved to another database at all — MariaDB raises `ER_FORBID_SCHEMA_CHANGE` ("Changing schema from 'old_db' to 'new_db' is not allowed", error 1450). Renaming a view within the same database works normally.
+
+## Temporary Tables
+
+`RENAME TABLE` works directly on `TEMPORARY` tables — there is no need to fall back to `ALTER TABLE ... RENAME TO`. Temporary-table renames are handled separately from permanent-table renames internally (they are not written to the DDL recovery log, since temporary tables disappear on crash anyway) but use identical syntax.
+
+## Privileges
+
+Executing `RENAME TABLE` requires:
+- **`ALTER`** and **`DROP`** on the source table (or its database), and
+- **`CREATE`** and **`INSERT`** on the target table (or its database).
+
+All four privileges are checked, split across the two names — granting only a subset of them is a common under-provisioning mistake.
+
+## Contrast With ALTER TABLE ... RENAME TO
+
+`ALTER TABLE tbl_name RENAME TO new_name` renames a single table as one clause of a (possibly larger) `ALTER TABLE` statement, and can also move a table between databases. It does not offer the multi-pair, all-or-nothing semantics of `RENAME TABLE` — there is no equivalent to the comma-separated swap trick. Use `RENAME TABLE` when the goal is purely renaming/swapping one or more tables atomically; use `ALTER TABLE ... RENAME TO` when the rename is one of several changes being made to a table in the same statement.
+
+## See Also
+
+- **`mariadb-alter-table`** — the single-table `RENAME TO` alternative, and the only way to rename columns/indexes in the same statement.
+- **`mariadb-create-trigger`** — why a table with triggers can't be moved across databases with `RENAME TABLE`.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/rename-table>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-definition/atomic-ddl>

--- a/agent-skills/granular/statements/mariadb-truncate-table/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-truncate-table/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: mariadb-truncate-table
+description: "MariaDB-specific syntax and behavior for TRUNCATE TABLE — DROP privilege (not DELETE), implicit commit with no rollback, unconditional AUTO_INCREMENT reset, no ON DELETE triggers, FK-parent tables rejected unless self-referencing, system-versioned tables and SEQUENCEs reject TRUNCATE outright, always '0 rows affected', and the WAIT n | NOWAIT extension. Use when writing, generating, or reviewing TRUNCATE TABLE statements that target MariaDB."
+---
+
+# TRUNCATE TABLE in MariaDB
+
+*Last updated: 2026-07-20*
+
+`TRUNCATE TABLE` looks like a fast `DELETE FROM tbl_name` with no `WHERE` clause, but MariaDB implements it as a DDL-like operation with its own privilege model, transaction semantics, and object-type restrictions. This skill covers where that behavior diverges from standard SQL and from what an LLM typically assumes.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one. (None of the behaviors below are newer than 10.6 — TRUNCATE's DDL semantics, the FK check, and the `WAIT`/`NOWAIT` clause all predate it.)
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `GRANT DELETE ON db.tbl TO user` is enough to let `user` run `TRUNCATE TABLE tbl` | `TRUNCATE TABLE` checks the `DROP` privilege, not `DELETE` — grant `DROP` instead. |
+| "`TRUNCATE` resets `AUTO_INCREMENT` just like `DELETE FROM tbl` with no `WHERE` does" | `DELETE` **never** resets the counter, even when it removes every row. Only `TRUNCATE TABLE` resets `AUTO_INCREMENT` to the table's starting value, unconditionally — including on MyISAM and InnoDB, which normally never reuse values. |
+| Wrapping `TRUNCATE TABLE` in a transaction so it can be rolled back on error | `TRUNCATE TABLE` causes an implicit commit (like other DDL) and cannot be rolled back. Any prior uncommitted work in the same transaction is committed too. Use `DELETE` inside the transaction if rollback must remain possible. |
+| Assuming an `AFTER DELETE`/`BEFORE DELETE` trigger (e.g., an audit-log trigger) fires when a table is truncated | `TRUNCATE TABLE` does not delete rows one by one and does **not** invoke `ON DELETE` triggers at all. If trigger-based side effects must run, use `DELETE`. |
+| `TRUNCATE TABLE parent_tbl` to quickly empty a table that other tables reference via `FOREIGN KEY` | InnoDB refuses this with `ER_TRUNCATE_ILLEGAL_FK` (`Cannot truncate a table referenced in a foreign key constraint`), unless the only FK is self-referencing, or the session has `SET FOREIGN_KEY_CHECKS=0`. Plain `DELETE` enforces FKs row-by-row instead of rejecting the whole statement. |
+| `TRUNCATE TABLE t` to wipe current data from a `WITH SYSTEM VERSIONING` table while keeping (or "dropping") its history | MariaDB **rejects** `TRUNCATE TABLE` on a system-versioned table outright with `System-versioned tables do not support TRUNCATE TABLE` (`ER_VERS_NOT_SUPPORTED`). Use `DELETE HISTORY` to purge history, or `DELETE`/`DROP`+`CREATE` to clear current rows. |
+| `TRUNCATE TABLE seq` to reset a `SEQUENCE` back to its start value | Sequences reject `TRUNCATE` with `ER_ILLEGAL_HA` ("doesn't have this option"). Use `ALTER SEQUENCE seq RESTART` or `DROP SEQUENCE` + `CREATE SEQUENCE` instead. |
+| Reading the "rows affected" count from `TRUNCATE TABLE` to log how many rows were removed | `TRUNCATE TABLE` always reports **0 rows affected**, regardless of how many rows actually existed — treat it as "no information," not "zero rows removed." |
+| Adding `IF EXISTS` to `TRUNCATE TABLE`, or assuming it silently no-ops on a missing table | Not supported. `TRUNCATE TABLE` on a nonexistent table errors `ER_NO_SUCH_TABLE` (`Table '...' doesn't exist`, SQLSTATE `42S02`) just like referencing it in most other statements. |
+
+## Syntax
+
+```sql
+TRUNCATE [TABLE] tbl_name
+  [WAIT n | NOWAIT]
+```
+
+* The `TABLE` keyword is optional — `TRUNCATE tbl_name` and `TRUNCATE TABLE tbl_name` are equivalent.
+* `tbl_name` may be schema-qualified as `db_name.tbl_name`.
+* `WAIT n | NOWAIT` is a MariaDB extension: it overrides `lock_wait_timeout` (and `innodb_lock_wait_timeout`) for this statement only — `WAIT n` sets both to `n` seconds, `NOWAIT` sets both to `0`. This clause is shared with several other DDL statements (`ALTER TABLE`, `RENAME TABLE`, `LOCK TABLES`, `DROP TRIGGER`, …), not unique to `TRUNCATE`.
+* In `sql_mode=ORACLE`, the optional keywords `DROP STORAGE` / `REUSE STORAGE` are additionally accepted after the table name — they parse but have no effect (no-ops). Outside Oracle mode, that syntax is a parse error.
+* No `IF EXISTS` form exists.
+
+## DELETE vs TRUNCATE
+
+| Aspect | `DELETE FROM tbl` (no `WHERE`) | `TRUNCATE TABLE tbl` |
+|---|---|---|
+| Privilege required | `DELETE` | `DROP` |
+| Transaction | Normal DML; can be rolled back | Implicit commit; cannot be rolled back |
+| `AUTO_INCREMENT` | Left untouched | Reset to the table's starting value |
+| `ON DELETE` triggers | Fire once per row | Never fire |
+| Rows-affected count | Accurate | Always reported as 0 |
+| Row removal mechanism | Row-by-row | Drop-and-recreate (InnoDB, when unconstrained) or a mechanical "delete all" via the handler for other engines/cases |
+| Binary logging / replication | Logged as DML (row or statement, per `binlog_format`) | Always logged in **statement** format, treated like `DROP TABLE` + `CREATE TABLE` for replication purposes |
+
+## Foreign Keys
+
+* A table that is the **parent** in a non-self-referencing `FOREIGN KEY` (i.e., some other table's FK references it) cannot be truncated: MariaDB raises `ER_TRUNCATE_ILLEGAL_FK` (SQLSTATE `42000`), naming the offending constraint.
+* Self-referencing foreign keys (a table referencing its own columns) do **not** block `TRUNCATE`.
+* Setting `SET FOREIGN_KEY_CHECKS=0` for the session bypasses this check entirely, allowing the truncate to proceed even though the table is FK-referenced.
+
+## System-Versioned Tables and Sequences
+
+* `TRUNCATE TABLE` on a table created `WITH SYSTEM VERSIONING` is rejected with `ER_VERS_NOT_SUPPORTED` ("System-versioned tables do not support TRUNCATE TABLE"), whether or not the session holds `LOCK TABLES`. To clear such a table, use `DELETE` (optionally followed by `DELETE HISTORY`), or drop and recreate it.
+* `TRUNCATE TABLE` on a `SEQUENCE` object is rejected with `ER_ILLEGAL_HA`. Sequences support `RENAME` but not `TRUNCATE`; use `ALTER SEQUENCE ... RESTART` to reset one.
+* `TRUNCATE TABLE` on a `VIEW` fails with `ER_NO_SUCH_TABLE` — views were never valid targets.
+
+## Auto-Increment and Transaction Semantics
+
+* `TRUNCATE TABLE` unconditionally resets the table's `AUTO_INCREMENT` counter to its starting value (the value from `AUTO_INCREMENT=N` at `CREATE TABLE` time, or 1 by default) — even for engines like InnoDB and MyISAM that otherwise never reuse a used `AUTO_INCREMENT` value. `DELETE` never resets it, even when every row is removed.
+* `TRUNCATE TABLE` causes an implicit commit and cannot itself be rolled back; issuing it mid-transaction also commits everything else done earlier in that transaction.
+* `TRUNCATE TABLE` **can** be run on a table the session already holds under `LOCK TABLES ... WRITE` (it upgrades that lock internally) — but it fails with `ER_TABLE_NOT_LOCKED` if the session holds `LOCK TABLES` on a *different* table and tries to truncate one it didn't lock, and with `ER_TABLE_NOT_LOCKED_FOR_WRITE` if it only holds a `READ` lock.
+
+## Examples
+
+```sql
+-- Requires DROP privilege, not DELETE
+GRANT DROP ON reporting.staging_import TO 'etl_user'@'%';
+
+-- Empty a table and confirm AUTO_INCREMENT restarts at 1
+CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO t1 (a) VALUES (NULL), (NULL);   -- a = 1, 2
+TRUNCATE TABLE t1;
+INSERT INTO t1 (a) VALUES (NULL), (NULL);   -- a = 1, 2 again
+
+-- Bypass the FK-parent restriction deliberately
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE parent_tbl;
+SET FOREIGN_KEY_CHECKS=1;
+
+-- Cap how long the statement waits for its metadata lock
+TRUNCATE TABLE big_table WAIT 5;
+TRUNCATE TABLE big_table NOWAIT;
+```
+
+## See Also
+
+- **`mariadb-delete`** — the row-by-row, rollback-able, trigger-firing alternative when `TRUNCATE`'s restrictions (privilege, FK, versioning, sequences) get in the way.
+- **`mariadb-system-versioned-tables`** — why `TRUNCATE` is rejected on these tables and what `DELETE HISTORY` does instead.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/table-statements/truncate-table>
+  - <https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete>
+  - <https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/system-versioned-tables>


### PR DESCRIPTION
Part of the **DOCS-6287** agent-skills coverage wave (follow-on to DOCS-6206). Batch 4 of 6: the remaining core DDL statements.

## What's here — 3 new Tier 1 statement skills (all `status: "draft"`)

| Skill | Highest-value source-verified deltas |
|---|---|
| `mariadb-create-sequence` | Sequences are wrapped tables (any transactional engine, default `BIGINT SIGNED`); `CACHE` defaults to **1000**; ANSI / PostgreSQL / Oracle-mode access forms; `INCREMENT BY 0` → `auto_increment_increment` for multi-master/Galera; `NEXT VALUE FOR` requires row-based binlog; `AS <type>` *(since 11.5)*; distinct from the unrelated SEQUENCE storage engine |
| `mariadb-truncate-table` | Requires `DROP` (not `DELETE`); implicit commit, no rollback; unconditional `AUTO_INCREMENT` reset; no `ON DELETE` triggers; FK-parent tables rejected unless self-referencing; system-versioned tables & SEQUENCEs reject `TRUNCATE`; always "0 rows affected"; `WAIT n`/`NOWAIT` |
| `mariadb-rename-table` | Atomic multi-pair rename + swap trick with full rollback; works directly on `TEMPORARY` tables; refuses inside an active transaction / under `LOCK TABLES`; needs `ALTER`+`DROP` on source and `CREATE`+`INSERT` on target; cross-database moves blocked for views and tables with triggers |

## Method
Three parallel research subagents, each source-verifying every "What LLMs Often Miss" row against `mariadb-server/sql/` (CS 13.0.1) and the canonical docs, returning file:line citations. Synthesized here with load-bearing claims independently spot-checked; all See Also URLs verified live (HTTP 200, no redirects); CI-exact codespell + lychee pass locally.

## Docs discrepancies surfaced (out of scope here — flagging for follow-up)
- `rename-table.md` lists only DROP/CREATE/INSERT privileges; source (`sql_parse.cc` `check_rename_table`) also requires **ALTER** on the source.
- `truncate-table.md` says `TRUNCATE` "drops all historical records from a system-versioned table"; source rejects it with `ER_VERS_NOT_SUPPORTED` (MDEV-15966). The skill documents the verified behavior.
- `e4085` error-code page / `create-sequence.md` show stale text ("values are conflicting", code 4082); source is code **4085**, "has out of range value for options".

## Notes for review
- `draft` status — promote to `pilot` after your review.
- Touches `.skills-manifest.json` (append), so whichever of the open DOCS-6287 PRs merges after the first needs a trivial append-rebase — I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)