### PR TITLE
DOCS-6287: agent skills batch 5 — session & introspection (SET, SHOW, EXPLAIN, PREPARE)

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -33,7 +33,11 @@
         { "name": "mariadb-call", "path": "granular/statements/mariadb-call/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-create-sequence", "path": "granular/statements/mariadb-create-sequence/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
         { "name": "mariadb-truncate-table", "path": "granular/statements/mariadb-truncate-table/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
-        { "name": "mariadb-rename-table", "path": "granular/statements/mariadb-rename-table/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
+        { "name": "mariadb-rename-table", "path": "granular/statements/mariadb-rename-table/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-set", "path": "granular/statements/mariadb-set/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-show", "path": "granular/statements/mariadb-show/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-explain", "path": "granular/statements/mariadb-explain/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" },
+        { "name": "mariadb-prepare", "path": "granular/statements/mariadb-prepare/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
       ]
     },
     "granular-functions": {

--- a/agent-skills/granular/statements/mariadb-explain/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-explain/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: mariadb-explain
+description: "MariaDB-specific behavior of EXPLAIN and its relatives (ANALYZE, EXPLAIN FORMAT=JSON, SHOW EXPLAIN/ANALYZE FOR) — MariaDB has no `EXPLAIN ANALYZE`; it uses a standalone `ANALYZE <statement>` that actually executes the query (and, for UPDATE/DELETE/INSERT, actually writes); plain EXPLAIN never runs anything; only FORMAT=JSON/TRADITIONAL exist (no TREE); and EXPLAIN covers INSERT/REPLACE directly. Use when writing, generating, or reviewing query-plan/EXPLAIN statements that target MariaDB."
+---
+
+# EXPLAIN in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the delta between the `EXPLAIN`/`ANALYZE`/query-plan family most LLMs default to and MariaDB's actual grammar and runtime behavior, verified against `sql/sql_yacc.yy`, `sql/sql_parse.cc`, `sql/sql_explain.cc`, `sql/sql_update.cc`, and `sql/sql_delete.cc` in the MariaDB server source.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `EXPLAIN ANALYZE SELECT …` | Drop the `EXPLAIN` keyword: **`ANALYZE SELECT …`**. `EXPLAIN ANALYZE` is not a valid production in MariaDB's grammar — `EXPLAIN` (lexed as the same token as `DESCRIBE`) only combines with `EXTENDED`, `PARTITIONS`, `FORMAT=JSON`, or `FOR CONNECTION`, never with `ANALYZE`. The syntax was replaced by the standalone `ANALYZE` statement back in MariaDB 10.1.0 |
+| `EXPLAIN SELECT …` to see "real" row counts | Plain `EXPLAIN` **never executes the query** — it only optimizes and reports estimates. To get real, executed-based numbers (`r_rows`, `r_filtered`), run **`ANALYZE SELECT …`** instead, which actually runs the statement (and discards the result set) |
+| Assuming `EXPLAIN` always shows a filtering percentage column | Plain tabular `EXPLAIN` omits the `filtered` column entirely. You need **`EXPLAIN EXTENDED`** (or `ANALYZE`, which always includes it) to get `filtered` — MariaDB never made `EXTENDED` the silent default |
+| `EXPLAIN` only for `SELECT` | MariaDB's `EXPLAIN`/`ANALYZE` grammar directly accepts `SELECT`, `INSERT`, `REPLACE`, `UPDATE`, and `DELETE` |
+| `ANALYZE UPDATE …` / `ANALYZE DELETE …` treated as a dry-run / read-only inspection | These statements **actually perform the update/delete** — `ANALYZE` only skips the write path when the plan proves the `WHERE` clause impossible; otherwise the modification commits normally, annotated with `r_rows`/`r_filtered`. Only `EXPLAIN` (not `ANALYZE`) is a true no-op for DML |
+| `EXPLAIN FORMAT=TREE` | MariaDB supports exactly two `FORMAT` values: **`JSON`** and **`TRADITIONAL`** (the default tabular form, explicitly nameable). There is no `TREE` format — using it raises `ER_UNKNOWN_EXPLAIN_FORMAT` |
+| `EXPLAIN tbl_name` treated as a query-plan request | `EXPLAIN tbl_name` is a synonym for **`DESCRIBE tbl_name`** / `SHOW COLUMNS FROM tbl_name` — it returns the column list, not an execution plan. Only `EXPLAIN` in front of `SELECT`/`INSERT`/`REPLACE`/`UPDATE`/`DELETE` produces a plan |
+| Confusing `ANALYZE TABLE tbl_name` with query-profiling `ANALYZE` | `ANALYZE TABLE tbl_name` is a completely different statement (recomputes engine index/table statistics for the optimizer). Query profiling is the MariaDB-specific extension `ANALYZE <explainable_statement>` (no `TABLE` keyword, no table name — a `SELECT`/`INSERT`/`REPLACE`/`UPDATE`/`DELETE` follows instead) — same leading keyword, disambiguated by what follows it |
+| Polling / re-running a slow query to "see" its plan while it's still running | Use **`SHOW EXPLAIN FOR <connection_id>`** or **`SHOW ANALYZE FOR <connection_id>`** to inspect a query that's still executing in another connection, found via `SHOW PROCESSLIST` — no need to wait for it to finish or kill it |
+
+## The Statement Family — Estimate vs. Actual
+
+MariaDB's plan-inspection surface has three tiers, all sharing the same tabular/JSON output shape:
+
+| Statement | Executes the query? | Extra columns | Notes |
+|---|---|---|---|
+| `EXPLAIN [EXTENDED\|PARTITIONS\|FORMAT=JSON] {SELECT\|INSERT\|REPLACE\|UPDATE\|DELETE}` | **No** — optimizes only, never runs | `filtered` (only with `EXTENDED`) | Pure estimate; safe against DML |
+| `ANALYZE [FORMAT=JSON] explainable_statement` | **Yes** — runs it for real | `r_rows`, `filtered`, `r_filtered` (tabular); much more in JSON | For `SELECT`, the result set is executed then discarded. For `INSERT`/`UPDATE`/`REPLACE`/`DELETE`, the write actually happens |
+| `SHOW EXPLAIN\|ANALYZE [FORMAT=JSON] FOR <connection_id>` | Inspects a query **already running** in another connection | Same columns as above, snapshotted mid-execution | MariaDB-specific; no standalone `EXPLAIN ANALYZE` needed since you inspect the live connection instead |
+
+`EXPLAIN ANALYZE` as its own two-keyword statement is retired: `EXPLAIN` and `ANALYZE` head two independent, non-combinable grammar productions. An agent asked to "profile this query" that reflexively emits `EXPLAIN ANALYZE …` will get a syntax error, not a plan. The correct rewrite is dropping the `EXPLAIN` and keeping only `ANALYZE`.
+
+## `FORMAT=JSON`
+
+```sql
+EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE col1 = 1;
+ANALYZE FORMAT=JSON SELECT * FROM t1 WHERE col1 = 1;
+```
+
+Both return a single row with a single column holding a JSON document describing the query block, tables, access types, and (for `ANALYZE FORMAT=JSON`) execution statistics. MariaDB's JSON shape is its own design — not a port of any other engine's `FORMAT=JSON`, and not interchangeable with it field-for-field.
+
+`ANALYZE FORMAT=JSON` adds, beyond the tabular `r_rows`/`filtered`/`r_filtered`:
+
+- **`r_loops`** — how many times a plan node executed.
+- **`r_total_time_ms`** — cumulative time spent in a node, including its subnodes. For `UPDATE`/`DELETE`, this includes making the row changes but excludes commit time.
+- **`r_buffer_size`** — size of any buffer the node used (e.g., join buffer).
+- **`r_engine_stats`** (InnoDB tables) — page-access counters; only non-zero members are printed.
+- *(since 11.5)* **`r_index_rows`** and **`r_icp_filtered`** — separate the count of index tuples enumerated (before any check) from post-Index-Condition-Pushdown selectivity; and **`r_total_filtered`** — combined selectivity across ICP, Rowid Filtering, and the attached condition.
+
+## `EXPLAIN EXTENDED` + `SHOW WARNINGS`
+
+```sql
+EXPLAIN EXTENDED SELECT * FROM employees WHERE last_name = 'Marx';
+SHOW WARNINGS;
+```
+
+`EXTENDED` is a live, non-deprecated modifier — it is not folded into the default tabular output. It does two things:
+
+1. Adds the `filtered` column (percentage estimate of rows surviving the attached condition) to the tabular result.
+2. Emits exactly one `Note`-level warning containing the query as the optimizer rewrote it (constant propagation, redundant-condition removal, etc.) — retrievable with a subsequent `SHOW WARNINGS`.
+
+Both behaviors fire only for the tabular path; `EXTENDED` and `FORMAT=JSON` are alternatives, not composable — the JSON output already carries the `filtered` and `attached_condition` fields unconditionally. `ANALYZE` always includes the `filtered` column (and `r_filtered`) with or without `EXTENDED`.
+
+## `SHOW EXPLAIN` / `SHOW ANALYZE` FOR `<connection_id>`
+
+```sql
+SHOW PROCESSLIST;                      -- find the connection id
+SHOW EXPLAIN FOR 7;                    -- what is connection 7 doing?
+SHOW ANALYZE FOR 7;                    -- ...with runtime stats so far
+SHOW EXPLAIN FORMAT=JSON FOR 7;        -- same, as JSON     (since 10.9)
+SHOW ANALYZE FORMAT=JSON FOR 7;        -- same, as JSON     (since 10.9)
+EXPLAIN FOR CONNECTION 7;              -- alias for SHOW EXPLAIN FOR 7 (since 10.9)
+```
+
+MariaDB-specific: there is no need to `KILL` and rerun a long query, or wait for it to finish, to see what it's doing. `SHOW EXPLAIN` snapshots the query plan of a statement actively running in another session; `SHOW ANALYZE` additionally reports the runtime statistics accumulated *so far*. Both require the same privilege as `SHOW PROCESSLIST`, and both error with `ER_TARGET_NOT_EXPLAINABLE` (*"Target is not running an EXPLAINable command"*, error 1932) if the target connection isn't currently mid-plan (e.g., still opening tables) or isn't running an explainable statement at all.
+
+`SHOW ANALYZE` picks up detailed timing (`r_..._time_ms` fields) only if the target connection is itself running `ANALYZE`; a plain `SELECT` being inspected this way reports row counts but not timings, since timing collection is opt-in via `ANALYZE`.
+
+## `EXPLAIN` for `INSERT` / `UPDATE` / `DELETE` / `REPLACE`
+
+```sql
+EXPLAIN UPDATE t1 SET c1 = c1 + 1 WHERE c2 > 100;
+EXPLAIN DELETE FROM t1 WHERE c2 > 100;
+EXPLAIN INSERT INTO t1 SELECT * FROM t2 WHERE c2 > 100;
+ANALYZE DELETE FROM t1 WHERE c2 > 100;   -- actually deletes
+```
+
+All four DML forms are directly explainable. As with `SELECT`, `EXPLAIN` on any of these is a pure dry run: the server derives and prints the plan, then stops before touching data. `ANALYZE` on any of these executes for real; the only exception the optimizer takes is bailing out early (before running the write) when it can already prove the `WHERE` clause matches nothing.
+
+## `EXPLAIN tbl_name` — the `DESCRIBE` Synonym
+
+```sql
+EXPLAIN employees;      -- same as: DESCRIBE employees;  /  SHOW COLUMNS FROM employees;
+```
+
+This form has nothing to do with query plans. `EXPLAIN`/`DESCRIBE`/`DESC` are three spellings of the same keyword at the lexer level; followed directly by a table name (no `SELECT`/`UPDATE`/etc.), it lists that table's columns, types, keys, and defaults — identical to `SHOW COLUMNS FROM`.
+
+## Examples
+
+```sql
+-- Estimate only: no usable index, so it's a full table scan
+EXPLAIN SELECT * FROM employees_example WHERE home_phone = '326-555-3492';
++------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
+| id   | select_type | table             | type | possible_keys | key  | key_len | ref  | rows | Extra       |
++------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
+|    1 | SIMPLE      | employees_example | ALL  | NULL          | NULL | NULL    | NULL |    6 | Using where |
++------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
+
+-- Estimate + actual: ANALYZE runs the query and adds r_rows / r_filtered
+ANALYZE SELECT * FROM tbl1 WHERE key1 BETWEEN 10 AND 200 AND col1 LIKE 'foo%';
+           id: 1
+  select_type: SIMPLE
+        table: tbl1
+         type: range
+possible_keys: key1
+          key: key1
+      key_len: 5
+          ref: NULL
+         rows: 181
+       r_rows: 181
+     filtered: 100.00
+   r_filtered: 10.50
+        Extra: Using index condition; Using where
+
+-- Inspecting a query already running in another session (no need to wait for it)
+SHOW PROCESSLIST;
+SHOW EXPLAIN FOR 1;
++------+-------------+-------+-------+---------------+------+---------+------+---------+-------------+
+| id   | select_type | table | type  | possible_keys | key  | key_len | ref  | rows    | Extra       |
++------+-------------+-------+-------+---------------+------+---------+------+---------+-------------+
+|    1 | SIMPLE      | tbl   | index | NULL          | a    | 5       | NULL | 1000107 | Using index |
++------+-------------+-------+-------+---------------+------+---------+------+---------+-------------+
+```
+
+## See Also
+
+- **`mariadb-select`** — the queries whose plans EXPLAIN describes.
+- **`mariadb-show`** — `SHOW EXPLAIN`/`SHOW ANALYZE FOR`, and other introspection statements.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain-format-json>

--- a/agent-skills/granular/statements/mariadb-prepare/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-prepare/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: mariadb-prepare
+description: "MariaDB-specific behavior of server-side prepared statements — PREPARE / EXECUTE / DEALLOCATE PREPARE and EXECUTE IMMEDIATE — covers the broad preparable-statement allow-list, EXECUTE..USING accepting arbitrary expressions (not just user variables), the stored-function/trigger ban on dynamic SQL, session-local statement lifetime, and EXECUTE IMMEDIATE's DEFAULT/IGNORE bind parameters. Use when writing, generating, or reviewing PREPARE/EXECUTE statements that target MariaDB."
+---
+
+# PREPARE / EXECUTE in MariaDB
+
+*Last updated: 2026-07-20*
+
+These are SQL-level ("text protocol") prepared statements: you PREPARE a statement from a string or expression, then EXECUTE it by name. This is a different mechanism from the binary-protocol prepared statements (`COM_STMT_PREPARE` / `COM_STMT_EXECUTE`) that connectors and drivers issue behind the scenes for parameterized queries — the SQL forms below are statements you write and run yourself, typically inside dynamic SQL or stored procedures.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `EXECUTE stmt USING 5` is invalid — "USING only accepts user variables" | In current MariaDB, `EXECUTE ... USING` binds any expression, not just `@variables` — literals, arithmetic, function calls all work. The user-variable-only restriction only applied before 10.2.3, well before the 10.6 baseline. |
+| Trying to bind an identifier or table name with `?`: `PREPARE s FROM 'SELECT * FROM ?'` | `?` (or Oracle-mode `:1`, `:name`) can only stand in for a data value, never identifiers/keywords. To parameterize table/column names, concatenate them into the `PREPARE`/`EXECUTE IMMEDIATE` source string itself (the standard "dynamic SQL" pattern). |
+| Using `PREPARE`/`EXECUTE`/`EXECUTE IMMEDIATE` inside a stored function or trigger | Not allowed there — MariaDB raises `Dynamic SQL is not allowed in stored function or trigger`. These statements only work inside stored **procedures**. |
+| Assuming most statement types can't be prepared (SELECT/DML only) | The allow-list is broad: essentially every SQL statement — DDL, `GRANT`/`REVOKE`, replication and admin commands, `SHOW` variants, compound statements — can be `PREPARE`d, except `PREPARE`, `EXECUTE`, and `DEALLOCATE`/`DROP PREPARE` themselves. |
+| Assuming a prepared statement is visible to other connections or survives a session | Prepared statements are strictly session-local (held in a per-thread statement map); they vanish when the session ends or on explicit `DEALLOCATE`. |
+| Re-`PREPARE`ing an existing name and expecting an "already exists" error | Re-issuing `PREPARE` with a name already in use implicitly deallocates the old statement first. If the new statement fails to parse, the old one is gone too — there is no rollback to the previous definition. |
+| `EXECUTE IMMEDIATE 'sql' USING <subquery-or-function-call>` | Neither the prepare source nor a `USING` parameter can be a subquery or a stored function call directly — bind the result into a user or SP variable first and pass that. |
+| Treating `max_prepared_stmt_count` as a per-connection limit | It's a single **global** counter (default 16382) shared across every session on the server — one connection's unclosed statements can starve another's. |
+| Only spelling it `DEALLOCATE PREPARE` | `DROP PREPARE` is an exact synonym for `DEALLOCATE PREPARE`. |
+
+## Syntax
+
+```sql
+PREPARE stmt_name FROM preparable_stmt;    -- preparable_stmt: a string literal or a user variable
+EXECUTE stmt_name [USING @var [, @var] ...];
+DEALLOCATE PREPARE stmt_name;   -- DROP PREPARE is a synonym
+EXECUTE IMMEDIATE preparable_stmt [USING ...];
+```
+
+- `preparable_stmt` / `statement` can be any expression that evaluates to the SQL text — a string literal, a user variable, or a `CONCAT(...)` expression — but it cannot itself be a subquery or a stored function call.
+- `stmt_name` is not case-sensitive.
+- `USING` arguments are matched positionally to the `?` placeholders in the prepared text; the count must match exactly.
+- `EXECUTE IMMEDIATE` additionally accepts `IGNORE` and `DEFAULT` as bind values in its `USING` list (see below).
+
+## Placeholders and the USING Clause
+
+- `?` is a positional data-value placeholder. In Oracle mode (`sql_mode=ORACLE`) MariaDB additionally accepts `:1`, `:2`, ... (or named `:label`) instead of `?`.
+- A placeholder can only appear where an expression is legal — never for identifiers, keywords, or clause structure.
+- `EXECUTE stmt USING expr [, expr] ...` binds each `USING` expression to the corresponding `?` in source order. In current MariaDB, those expressions can be user variables, literals, or arbitrary expressions — not just `@var_name`.
+- Because identifiers can't be bound as parameters, dynamic table/column names are handled by building the identifier into the SQL text before preparing it (classic *dynamic SQL*):
+
+```sql
+CREATE PROCEDURE test.count_rows(IN tab_name VARCHAR(64))
+BEGIN
+  SET @sql = CONCAT('SELECT COUNT(*) FROM ', tab_name);
+  PREPARE stmt FROM @sql;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+END;
+```
+
+## Session Scope and Lifetime
+
+- Prepared statements live in a per-session (thread-local) map. Other connections cannot see or execute them, and they disappear when the session ends.
+- `PREPARE`ing a name that's already in use implicitly deallocates the previous statement of that name before preparing the new one.
+- A statement `PREPARE`d inside a stored procedure is **not** automatically deallocated when the procedure returns — it stays live for the rest of the session. Calling such a procedure repeatedly (e.g., in a loop) without an explicit `DEALLOCATE PREPARE` accumulates statements and can hit `max_prepared_stmt_count`.
+- `max_prepared_stmt_count` (global, default `16382`) caps the total number of prepared statements open across *all* sessions on the server at once; setting it to `0` disables prepared statements entirely. Exceeding it raises `ERROR 1461: Can't create more than max_prepared_stmt_count statements`.
+- A prepared statement can reference user-defined `@variables`, but not stored-procedure local variables or IN/OUT parameters directly — pass those in via `USING` or via a session variable.
+- MariaDB may transparently re-prepare a statement (up to 3 attempts) if the table/view metadata it depends on changed between `PREPARE` and `EXECUTE` (for example, a DDL statement ran on another connection in between) — this is invisible to the caller unless the retry limit is exhausted.
+
+## What Can Be Prepared
+
+- Essentially every SQL statement can be `PREPARE`d and `EXECUTE`d — `SELECT`, DML, DDL (`CREATE`/`ALTER`/`DROP TABLE`, indexes, users, views, databases), `GRANT`/`REVOKE`, replication and administrative commands, most `SHOW` variants, `CALL`, and compound statements — **except** `PREPARE`, `EXECUTE`, and `DEALLOCATE`/`DROP PREPARE` themselves.
+- The prepare source cannot contain a subquery or a stored function call — MariaDB rejects it with `ER_SUBQUERIES_NOT_SUPPORTED` ("... does not support subqueries or stored functions") at parse time.
+- A statement that can't be directly prepared (e.g., `SIGNAL`) can still run indirectly: if a stored procedure body contains it, preparing and executing `CALL that_procedure()` works fine.
+
+## EXECUTE IMMEDIATE
+
+`EXECUTE IMMEDIATE` is a MariaDB extension that combines `PREPARE` + `EXECUTE` + `DEALLOCATE PREPARE` into a single statement — no name is assigned and nothing is left behind afterward:
+
+```sql
+EXECUTE IMMEDIATE 'SELECT 1';
+-- shorthand for:
+PREPARE stmt FROM 'SELECT 1';
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+```
+
+- It supports complex expressions as the prepare source and as bind parameters, e.g. `EXECUTE IMMEDIATE CONCAT('SELECT COUNT(*) FROM ', 't1', ' WHERE a=?') USING 5+5;`.
+- Same restriction as `PREPARE`: the source and `USING` parameters cannot be subqueries or stored function calls directly — assign to a variable first as a workaround.
+- `USING` parameters can additionally be the pseudo-values `DEFAULT` (bind as if the column's `DEFAULT` were used) or `IGNORE` (bind as if the value were omitted, subject to strict-mode handling), on top of ordinary expressions.
+- User and stored-procedure variables can be used as `OUT` parameters, e.g. `EXECUTE IMMEDIATE 'CALL p1(?)' USING @a;` writes the procedure's `OUT` value back into `@a`.
+- Allowed inside stored procedures, not inside stored functions or triggers (same rule as `PREPARE`/`EXECUTE`).
+- It increments `Com_execute_immediate` plus `Com_stmt_prepare`, `Com_stmt_execute`, and `Com_stmt_close`, but **not** `Com_execute_sql` — that counter is reserved for the explicit `PREPARE`..`EXECUTE` path. Useful for telling the two code paths apart in `SHOW STATUS`.
+
+## Prepared Statements Inside Stored Routines
+
+- `PREPARE`, `EXECUTE`, `EXECUTE IMMEDIATE`, and `DEALLOCATE PREPARE` are all allowed inside stored **procedures**.
+- None of them are allowed inside stored **functions** or **triggers** — MariaDB raises `Dynamic SQL is not allowed in stored function or trigger` for both.
+- `PREPARE` itself fails fast on a syntax error, so procedures sometimes use it purely as a validity check on caller-supplied SQL text (wrapped in a handler, then immediately `DEALLOCATE`d without ever `EXECUTE`ing).
+
+## Examples
+
+```sql
+-- Basic PREPARE / EXECUTE with a placeholder
+CREATE TABLE t1 (a INT, b CHAR(10));
+INSERT INTO t1 VALUES (1,'one'), (2,'two'), (3,'three');
+
+PREPARE test FROM 'SELECT * FROM t1 WHERE a=?';
+SET @param = 2;
+EXECUTE test USING @param;
+DEALLOCATE PREPARE test;
+
+-- Dynamic table name (identifiers must be concatenated, not bound)
+CREATE PROCEDURE test.stmt_test(IN tab_name VARCHAR(64))
+BEGIN
+  SET @sql = CONCAT('SELECT COUNT(*) FROM ', tab_name);
+  PREPARE stmt FROM @sql;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+END;
+
+-- EXECUTE IMMEDIATE with a DEFAULT bind parameter
+CREATE OR REPLACE TABLE t2 (a INT DEFAULT 10);
+EXECUTE IMMEDIATE 'INSERT INTO t2 VALUES (?)' USING DEFAULT;
+
+-- EXECUTE IMMEDIATE with an OUT parameter
+DELIMITER $$
+CREATE OR REPLACE PROCEDURE p1(OUT a INT)
+BEGIN
+  SET a := 10;
+END;
+$$
+DELIMITER ;
+SET @a = 2;
+EXECUTE IMMEDIATE 'CALL p1(?)' USING @a;
+SELECT @a;   -- 10
+```
+
+## See Also
+
+- **`mariadb-create-procedure`** — the routine context where dynamic SQL (`PREPARE`/`EXECUTE`) is allowed; it is banned in functions and triggers.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/prepared-statements/prepare-statement>
+  - <https://mariadb.com/docs/server/reference/sql-statements/prepared-statements/execute-statement>
+  - <https://mariadb.com/docs/server/reference/sql-statements/prepared-statements/deallocate-drop-prepare>
+  - <https://mariadb.com/docs/server/reference/sql-statements/prepared-statements/execute-immediate>

--- a/agent-skills/granular/statements/mariadb-set/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-set/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: mariadb-set
+description: "MariaDB-specific syntax and behavior for SET — GLOBAL/SESSION/LOCAL scope rules and their session-isolation semantics, the SET STATEMENT ... FOR extension (and its fixed list of 13 variables it cannot touch), `=`/`:=` equivalence for user variables inside SET (but not outside it), var = DEFAULT restore semantics, the SUPER privilege gate on SET GLOBAL, and the absence of SET PERSIST (MariaDB persists via config file, not SQL). Use when writing, generating, or reviewing SET statements (system/session/user variables, options, and SET STATEMENT ... FOR) that target MariaDB."
+---
+
+# SET in MariaDB
+
+*Last updated: 2026-07-20*
+
+This skill covers the delta between generic "assign a variable" SQL and MariaDB's `SET` — its scope keywords, the `SET STATEMENT ... FOR` per-query extension, and a persistence model that has no `SET PERSIST` equivalent.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `SET PERSIST var = value;` (or `SET PERSIST_ONLY`) to make a global setting survive a restart | **Does not exist in MariaDB** — there is no `PERSIST` keyword in the grammar at all. To persist a setting, write it to a config file (e.g. `/etc/mysql/mariadb.conf.d/`) or run `SET GLOBAL var=value` and separately update the config file for the next restart |
+| `GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'user'` before letting an app run `SET GLOBAL ...` | That privilege identifier doesn't exist in MariaDB. `SET GLOBAL` is gated by the **`SUPER`** privilege (some individual global variables — e.g. those touching binlogging or replication — instead check a narrower admin privilege such as `BINLOG ADMIN` or `REPLICATION MASTER ADMIN`, but the default check is `SUPER`) |
+| `SET GLOBAL max_connections=500;` then expecting the *current* session to see the new value immediately | A global change affects only **new** connections — not the session that issued it, and not any other already-open session. Reconnect (or read `@@global.var` explicitly) to see it take effect |
+| `SET x := 5;` inside a `SELECT` or other expression to assign a user variable | `:=` is required for user-variable assignment **outside** `SET` (e.g. `SELECT @x := 5`). Inside `SET`, both `SET @x = 5` and `SET @x := 5` work — `SET` is the one place plain `=` is accepted for a user variable |
+| A per-query tweak like `SET wait_timeout=5; SELECT ...; SET wait_timeout=@@global.wait_timeout;` to scope a setting to one statement | Use the MariaDB extension **`SET STATEMENT wait_timeout=5 FOR SELECT ...`** instead — except `wait_timeout` is one of a fixed list of variables `SET STATEMENT` cannot set (see below); for those, the manual save/restore pattern is still required |
+| `SET STATEMENT sql_mode='ANSI_QUOTES' FOR SELECT "col" FROM t;` and expecting `"col"` to be treated as an identifier | The whole statement is **parsed before** `SET STATEMENT` takes effect, so variables that affect parsing (charset settings, `sql_mode=ANSI_QUOTES`, etc.) don't retroactively change how the `FOR` statement itself was parsed |
+| `SET sql_mode = NULL;` or omitting a reset path entirely | Use `SET sql_mode = DEFAULT` (session → resets to the current global value) or `SET GLOBAL sql_mode = DEFAULT` (global → resets to the compiled-in server default) |
+| Writing `SET SESSION` when a variable turns out to be global-only, or vice versa | If a variable has a session value, omitting `GLOBAL`/`SESSION` behaves as `SESSION`; if it's global-only, omitting them applies to the global value. Setting the wrong scope explicitly is a hard error (`ERROR 1229` — variable is GLOBAL, use `SET GLOBAL`; `ERROR 1228` — variable is SESSION, can't use `SET GLOBAL`), not a silent no-op |
+| `SET LOCAL var = value;` assuming it differs from `SET SESSION` | `LOCAL` is a plain synonym for `SESSION` — identical parse action, no behavioral difference, use either |
+
+## Syntax
+
+```sql
+SET variable_assignment [, variable_assignment] ...
+
+variable_assignment:
+      user_var_name (= | :=) expr
+    | [GLOBAL | SESSION | LOCAL] system_var_name = expr
+    | [@@global. | @@session. | @@local. | @@] system_var_name = expr
+    | system_var_name = DEFAULT
+```
+
+- Multiple assignments in one statement are comma-separated and can mix scopes and variable kinds freely: `SET @x = 1, GLOBAL max_connections = 500, @@session.sql_mode = DEFAULT;`
+- `GLOBAL`, `SESSION`, and `LOCAL` are the keyword forms; `@@global.`, `@@session.`, `@@local.`, and bare `@@` are the equivalent variable-reference forms — `SET @@GLOBAL.max_connections = 500` and `SET GLOBAL max_connections = 500` are fully equivalent (same code path).
+- Omitting a scope keyword defaults to `SESSION` if the variable has a session value, otherwise to `GLOBAL`.
+- `SET @x = expr` and `SET @x := expr` are both accepted for user variables inside `SET` — but only `:=` is valid for a user-variable assignment anywhere else (e.g. inside a `SELECT` expression).
+
+## Variable Scopes — GLOBAL / SESSION / LOCAL
+
+- **`GLOBAL`** changes the server-wide default. It affects **new** sessions only — not the session that ran the `SET GLOBAL`, and not any session already connected.
+- **`SESSION`** (and its synonym **`LOCAL`**) changes the current connection only.
+- Setting a variable with the wrong scope is a hard error, not a fallback:
+
+```sql
+SET innodb_sync_spin_loops = 60;
+-- ERROR 1229 (HY000): Variable 'innodb_sync_spin_loops' is a GLOBAL variable
+--   and should be set with SET GLOBAL
+
+SET GLOBAL skip_parallel_replication = ON;
+-- ERROR 1228 (HY000): Variable 'skip_parallel_replication' is a SESSION variable
+--   and can't be used with SET GLOBAL
+```
+
+- Setting `GLOBAL` requires the **`SUPER`** privilege by default (a handful of individual global variables instead gate on a narrower privilege, such as replication/binlog admin variants — check the specific variable if `SUPER` alone doesn't work).
+- `SET` does **not** persist a global change across a server restart. There is no `SET PERSIST` in MariaDB — to survive a restart, also update the value in a configuration file.
+
+## `SET var = DEFAULT`
+
+```sql
+SET sql_mode = DEFAULT;         -- session var -> resets to the current GLOBAL value
+SET GLOBAL sql_mode = DEFAULT;  -- global var  -> resets to the compiled-in server default
+```
+
+`SET session_var = @@GLOBAL.session_var` achieves the same effect as `SET session_var = DEFAULT` by explicitly copying the current global value.
+
+## SET STATEMENT ... FOR (MariaDB Extension)
+
+```sql
+SET STATEMENT var1 = value1 [, var2 = value2, ...] FOR statement;
+```
+
+Sets one or more system variables for the duration of a single statement, then automatically restores the prior session value — roughly:
+
+```sql
+SET @save_value = @@var1;
+SET SESSION var1 = value1;
+statement;
+SET SESSION var1 = @save_value;
+```
+
+Notes and traps:
+
+- `value` must be a constant literal — it cannot reference a table or a stored routine (subqueries/table references in the `SET STATEMENT` clause itself are rejected).
+- The whole statement is parsed **before** `SET STATEMENT` variables take effect, so anything that influences parsing (client/connection charset variables, `sql_mode=ANSI_QUOTES`, etc.) won't retroactively change how the `FOR` statement was parsed.
+- It works with prepared statements — `SET STATEMENT var=val FOR PREPARE ...` and `SET STATEMENT var=val FOR EXECUTE stmt_name` are both valid targets.
+- Setting a `SESSION` variable *inside* the `FOR` statement (e.g. `SET STATEMENT x=1 FOR SET SESSION x=2`) is pointless: the inner `SET SESSION` takes effect, then gets reverted to the pre-`SET STATEMENT` value once the outer statement finishes.
+- A fixed set of 13 variables **cannot** be set via `SET STATEMENT` at all (attempting it raises `ER_SET_STATEMENT_NOT_SUPPORTED`) — `autocommit`, `character_set_client`, `character_set_connection`, `character_set_filesystem`, `collation_connection`, `debug_sync`, `interactive_timeout`, `profiling`, `profiling_history_size`, `query_cache_type`, `skip_replication`, `sql_log_off`, `wait_timeout`.
+
+```sql
+SET STATEMENT max_statement_time=1000 FOR SELECT ...;
+SET STATEMENT optimizer_switch='materialization=off' FOR SELECT ...;
+SET STATEMENT join_cache_level=6, optimizer_switch='mrr=on' FOR SELECT ...;
+```
+
+## Examples
+
+```sql
+-- multiple scopes and kinds in one statement
+SET @request_id = UUID(), SESSION sql_mode = 'STRICT_ALL_TABLES', GLOBAL max_connections = 500;
+
+-- inline user-variable assignment inside an expression (needs :=, not =)
+SELECT (@a := 1);
+SELECT @a;
+
+-- restore a session variable to the server default
+SET GLOBAL max_error_count = 256;
+SET SESSION max_error_count = DEFAULT;   -- picks up the new global value, 256
+
+-- bound a single query without touching session state
+SET STATEMENT max_statement_time=2 FOR SELECT SLEEP(10);
+```
+
+Read variable state back with `SHOW VARIABLES` or `INFORMATION_SCHEMA.SYSTEM_VARIABLES`, which exposes `SESSION_VALUE` and `GLOBAL_VALUE` side by side (a `NULL` in either column means the variable doesn't have that scope).
+
+## Related SET Forms (Separate Statements)
+
+These share the `SET` keyword but are documented — and should be reasoned about — separately:
+
+| Statement | Purpose |
+|---|---|
+| `SET NAMES` / `SET CHARACTER SET` | Set the client/connection/results character set (and collation) in one shot |
+| `SET PASSWORD` | Change an account's authentication credential |
+| `SET ROLE` / `SET DEFAULT ROLE` | Activate a role for the session, or set a user's default role |
+| `SET TRANSACTION` | Set isolation level / access mode for the next transaction or the whole session |
+| `SET sql_log_bin` | Session-only toggle for binary logging — no `GLOBAL` form, and it needs the `SUPER` privilege |
+| `SET PATH` *(since 12.3)* | Set the schema search path used to resolve unqualified stored-routine/package calls |
+
+## See Also
+
+- **`mariadb-set-transaction`** — isolation level and access mode assignment via `SET TRANSACTION`, a distinct statement from general `SET`.
+- **`mariadb-show`** — `SHOW VARIABLES` to read GLOBAL/SESSION variable values back.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/set-commands/set>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/set-commands/set-statement>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/set-commands/set-sql_log_bin>

--- a/agent-skills/granular/statements/mariadb-show/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-show/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: mariadb-show
+description: "MariaDB-specific behavior of the SHOW statement family — replication SHOW forms are spelled BINLOG STATUS/REPLICA STATUS/REPLICA HOSTS (REPLICA is a lexer-level synonym for SLAVE) while the underlying status counters still say slave/master; bare SHOW <name> is generic sugar for any plugin-registered INFORMATION_SCHEMA table (userstat, Galera, query-response-time); SHOW EXPLAIN/SHOW ANALYZE inspect another connection's live plan; only a fixed subset of SHOW forms accept LIKE/WHERE. Use when writing, generating, or reviewing SHOW statements that target MariaDB."
+---
+
+# SHOW in MariaDB
+
+*Last updated: 2026-07-20*
+
+`SHOW` is MariaDB's catch-all introspection statement — it is not standard SQL, and its surface has MariaDB-specific spellings, a generic plugin-table fallback, and diagnostic subcommands with no standard-SQL equivalent. Getting the terminology and filtering rules right matters more here than for most statement families, because an LLM's defaults skew toward older `MASTER`/`SLAVE` spellings and a narrower fixed-keyword mental model.
+
+> **Default context:** Assume MariaDB **11.8 LTS** (GA May 2025) unless the user states another version. Features available across current LTS branches (10.6, 10.11, 11.4, 11.8) are shown without a "since" annotation; only newer-than-10.6 features carry one.
+
+## What LLMs Often Miss
+
+| If the agent writes / suggests… | …prefer the MariaDB form |
+|---|---|
+| `SHOW MASTER STATUS` | `SHOW BINLOG STATUS` — same command (`SQLCOM_SHOW_BINLOG_STAT`), `MASTER STATUS` is kept only as a legacy alias. |
+| `SHOW SLAVE STATUS` | `SHOW REPLICA STATUS` — `REPLICA` is a **lexer-level synonym** for the `SLAVE` token (`sql/lex.h:541`), so every `SLAVE`-based rule (`STATUS`, `HOSTS`, `ALL SLAVES STATUS`) already accepts the `REPLICA` spelling; it is not a separate grammar branch. |
+| `SHOW SLAVE HOSTS` | `SHOW REPLICA HOSTS` — same alias relationship as above. |
+| Assuming the rename also touched status counters | It didn't: `Com_show_slave_status`, `Slave_running`, `Rpl_semi_sync_slave_status`, etc. are still spelled with `slave` in `SHOW STATUS` output, even when queried with `SHOW REPLICA STATUS`. Renaming would have broken every existing monitoring dashboard. |
+| Treating `SHOW <NAME>` as a fixed keyword list | Any identifier that doesn't match a hard-coded `SHOW` keyword falls through to a **generic rule**: MariaDB looks up `<NAME>` as a plugin-registered `INFORMATION_SCHEMA` table and, if found, runs it as a `SHOW`. This is how `SHOW USER_STATISTICS`, `SHOW WSREP_MEMBERSHIP`, and `SHOW QUERY_RESPONSE_TIME` work — they are not separate grammar productions. |
+| Assuming `SHOW TABLES` lists only tables | It also lists **sequences** and **views** — `SHOW FULL TABLES` reports `Table_type` as `BASE TABLE`, `VIEW`, or `SEQUENCE`. |
+| Assuming you can only `EXPLAIN` your own query | `SHOW EXPLAIN FOR <connection_id>` and `SHOW ANALYZE FOR <connection_id>` retrieve the plan (and, for `ANALYZE`, live runtime counters) of a query running in **another** connection — get the id from `SHOW PROCESSLIST`. |
+| Assuming `WHERE`/`LIKE` work on any `SHOW` statement | Only a documented subset ("Extended SHOW") accepts them — e.g. `SHOW REPLICA STATUS`, `SHOW ENGINE`, and `SHOW GRANTS` do not; `SHOW WARNINGS`/`SHOW ERRORS` use `LIMIT` instead. |
+| Assuming `SHOW GRANTS` has no "everyone" target | `SHOW GRANTS FOR PUBLIC` *(since 10.11)* lists grants issued with `GRANT ... TO PUBLIC`. |
+| Assuming `information_schema` is a drop-in replacement for every `SHOW` | Column sets, order, and availability can differ — e.g. `SHOW REPLICA STATUS` columns only became queryable via `information_schema.SLAVE_STATUS` *(since 11.6)*; before that, the replica status columns existed only in `SHOW` output. |
+
+## LIKE / WHERE Filtering
+
+General form:
+
+```sql
+SHOW ... LIKE 'pattern' | WHERE expr
+```
+
+`LIKE` matches against a fixed column (name depends on the statement, e.g. `Tables_in_<db>` for `SHOW TABLES`, `Variable_name` for `SHOW VARIABLES`/`SHOW STATUS`); `WHERE` can reference any output column with arbitrary expressions, the same way it works in `SELECT`.
+
+Only the following accept both clauses ("Extended SHOW"): `SHOW CHARACTER SET`, `SHOW COLLATION`, `SHOW COLUMNS`, `SHOW DATABASES`, `SHOW FUNCTION STATUS`, `SHOW INDEX`, `SHOW OPEN TABLES`, `SHOW PACKAGE STATUS`, `SHOW PACKAGE BODY STATUS`, `SHOW PROCEDURE STATUS`, `SHOW STATUS`, `SHOW TABLE STATUS`, `SHOW TABLES`, `SHOW TRIGGERS`, `SHOW VARIABLES`. Everything else either takes no filter at all (`SHOW ENGINE`, `SHOW GRANTS`, `SHOW REPLICA STATUS`) or a different clause entirely (`SHOW WARNINGS [LIMIT ...]`).
+
+```sql
+SHOW VARIABLES WHERE Variable_name LIKE 'aria%' AND Value > 8192;
+```
+
+## Replication SHOW Terminology
+
+MariaDB's replication vocabulary moved away from `MASTER`/`SLAVE` wording at the SQL-statement level; the table below gives the preferred spelling. Both spellings keep working — the old one is not deprecated, just not preferred:
+
+| Preferred | Legacy alias | Notes |
+|---|---|---|
+| `SHOW BINLOG STATUS` | `SHOW MASTER STATUS` | Same `SQLCOM_SHOW_BINLOG_STAT` command. From **12.3**, its output gains a `Gtid_Binlog_Pos` column, so a separate `SELECT @@global.gtid_binlog_pos` is no longer needed *(since 12.3)*. |
+| `SHOW REPLICA STATUS` | `SHOW SLAVE STATUS` | `REPLICA` lexes to the same token as `SLAVE`. Accepts `["connection_name"]` or `FOR CHANNEL "connection_name"` for multi-source setups. |
+| `SHOW ALL REPLICAS STATUS` | `SHOW ALL SLAVES STATUS` | Lists every configured connection (multi-source replication), sorted by `Connection_name`. |
+| `SHOW REPLICA HOSTS` | `SHOW SLAVE HOSTS` | Run on the primary; lists registered replicas (`Server_id`, `Host`, `Port`, `Master_id`). |
+
+Column-count caveat: the exact set of `SHOW REPLICA STATUS` columns is version-dependent (e.g. `Replicate_Rewrite_DB` *(since 10.11)*, `Master_last_event_time`/`Slave_last_event_time`/`Master_Slave_time_diff` *(since 11.6)*). Always match by column **name**, never by fixed offset.
+
+## SHOW vs INFORMATION_SCHEMA
+
+`SHOW` is MariaDB/traditional-SQL-dialect syntax; querying `INFORMATION_SCHEMA` (or `PERFORMANCE_SCHEMA`) with `SELECT` is the portable path and the one that composes with joins, computed columns, and prepared statements. Many `SHOW` statements are thin syntax over an `INFORMATION_SCHEMA` table lookup internally, but the two are **not guaranteed to return identical column sets or ordering**:
+
+| SHOW | INFORMATION_SCHEMA equivalent |
+|---|---|
+| `SHOW DATABASES` | `SCHEMATA` |
+| `SHOW TABLES` | `TABLES` |
+| `SHOW INDEX` | `STATISTICS` |
+| `SHOW VARIABLES` | `GLOBAL_VARIABLES` / `SESSION_VARIABLES` (or the unified `SYSTEM_VARIABLES`) |
+| `SHOW STATUS` | `GLOBAL_STATUS` / `SESSION_STATUS` |
+| `SHOW REPLICA STATUS` | `SLAVE_STATUS` *(since 11.6 — before that, no I_S equivalent existed)* |
+| `SHOW ENGINE INNODB MUTEX` | `INNODB_MUTEXES` |
+| `SHOW [TABLE\|INDEX\|CLIENT\|USER]_STATISTICS` | `TABLE_STATISTICS` / `INDEX_STATISTICS` / `CLIENT_STATISTICS` / `USER_STATISTICS` |
+
+## SHOW EXPLAIN / SHOW ANALYZE (MariaDB-Specific)
+
+```sql
+SHOW EXPLAIN [FORMAT=JSON] FOR <connection_id>;
+SHOW ANALYZE [FORMAT=JSON] FOR <connection_id>;
+```
+
+Both inspect a query **currently running in another session** (get `<connection_id>` from `SHOW PROCESSLIST`); requires the same privilege as `SHOW PROCESSLIST`. `SHOW EXPLAIN` returns the plan as it stands right now; `SHOW ANALYZE` additionally returns runtime counters (`r_rows`, `r_loops`, `r_filtered`, and — if the target is itself running `ANALYZE`— `r_*_time_ms` timings) without waiting for the query to finish. This is the tool for diagnosing a query that is "hung" or unexpectedly slow while it is still executing; regular `EXPLAIN`/`ANALYZE` can't observe a query that hasn't completed.
+
+`EXPLAIN FOR CONNECTION <connection_id>` (an alternate spelling of `SHOW EXPLAIN FOR`) and `FORMAT=JSON` support on `SHOW EXPLAIN` were both added *(since 10.9)*. `SHOW ANALYZE` as a whole statement was added *(since 10.9)*.
+
+If the target connection has no ready query plan yet, both fail with `ERROR 1932 (HY000): Target is not running an EXPLAINable command`.
+
+## MariaDB-Only SHOW Variants (Generic INFORMATION_SCHEMA Sugar)
+
+A bare `SHOW <identifier>` that isn't one of the hard-coded keywords is handled generically: MariaDB looks up `<identifier>` as a plugin-registered `INFORMATION_SCHEMA` table (`find_schema_table`, requiring `old_format` support) and runs it as a `SHOW`, optionally with `LIKE`/`WHERE` if the table supports it. This is why the following all "just work" without dedicated grammar rules:
+
+- **`SHOW TABLE_STATISTICS`**, **`SHOW INDEX_STATISTICS`**, **`SHOW CLIENT_STATISTICS`**, **`SHOW USER_STATISTICS`** — the userstat feature (per-table, per-index, per-client, and per-user activity counters: rows read/changed, bytes sent/received, busy/CPU time). Gated behind the `userstat` system variable, which **defaults to OFF**; nothing shows up until it's enabled.
+- **`SHOW WSREP_MEMBERSHIP`** / **`SHOW WSREP_STATUS`** — Galera Cluster node membership and status, from the `WSREP_INFO` plugin.
+- **`SHOW QUERY_RESPONSE_TIME`** — query-latency histogram buckets, from the `QUERY_RESPONSE_TIME` plugin.
+
+Two further MariaDB-only object types get dedicated (non-generic) `SHOW CREATE` keywords, because the object types themselves don't exist in standard SQL:
+
+- **`SHOW CREATE SEQUENCE seq_name`** — the `CREATE SEQUENCE` statement that would reproduce the sequence; `SHOW CREATE TABLE` on the same name shows the sequence's backing-table structure instead.
+- **`SHOW CREATE PACKAGE`** / **`SHOW CREATE PACKAGE BODY`** — only meaningful under Oracle-mode `sql_mode`, since packages are an Oracle-mode-only object type.
+
+## Examples
+
+Inspect a long-running query in another session:
+
+```sql
+SHOW PROCESSLIST;
+SHOW EXPLAIN FOR 3;
+SHOW ANALYZE FORMAT=JSON FOR 3;
+```
+
+Filter variables with a general expression, not just a name pattern:
+
+```sql
+SHOW VARIABLES WHERE Variable_name LIKE 'aria%' AND Value > 8192;
+```
+
+Binary-log position, MariaDB-preferred spelling:
+
+```sql
+SHOW BINLOG STATUS;
+```
+
+Replica status, MariaDB-preferred spelling, matched by column name:
+
+```sql
+SHOW REPLICA STATUS\G
+```
+
+Per-user activity counters (requires `userstat=1`):
+
+```sql
+SET GLOBAL userstat = 1;
+SHOW USER_STATISTICS;
+```
+
+## See Also
+
+- **`mariadb-set`** — set the variables `SHOW VARIABLES` reads back.
+- **`mariadb-explain`** — `SHOW EXPLAIN`/`SHOW ANALYZE FOR` in the context of the query-plan family.
+- Canonical references on `mariadb.com/docs`:
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/about-show>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/extended-show>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-binlog-status>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-explain>
+  - <https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-table-statistics>


### PR DESCRIPTION
Part of the **DOCS-6287** agent-skills coverage wave (follow-on to DOCS-6206). Batch 5 of 6: session and introspection statements.

## What's here — 4 new Tier 1 statement skills (all `status: "draft"`)

| Skill | Highest-value source-verified deltas |
|---|---|
| `mariadb-set` | `GLOBAL`/`SESSION`/`LOCAL` scope + new-sessions-only isolation; **no `SET PERSIST`** (grammar-verified; config-file persistence instead); `SET GLOBAL` gates on `SUPER` (no `SYSTEM_VARIABLES_ADMIN`); `=`/`:=` inside vs outside `SET`; `SET STATEMENT ... FOR` with the exact **13-variable** `NO_SET_STMT` blocklist; `SET PATH` *(since 12.3)* |
| `mariadb-show` | MariaDB replication spellings (`SHOW BINLOG STATUS`, `SHOW REPLICA STATUS/HOSTS`; `REPLICA` is a lexer synonym for `SLAVE`) while status counters stay `slave`/`master`; generic `SHOW <name>` → plugin `INFORMATION_SCHEMA` sugar (userstat, Galera, response-time); `SHOW EXPLAIN/ANALYZE FOR`; the Extended-SHOW `LIKE`/`WHERE` subset |
| `mariadb-explain` | MariaDB has **no `EXPLAIN ANALYZE`** — use standalone `ANALYZE <stmt>`, which actually executes (and, for UPDATE/DELETE/INSERT, **writes**); plain `EXPLAIN` never runs; only `FORMAT=JSON`/`TRADITIONAL` (no `TREE`); `EXPLAIN` covers INSERT/REPLACE; `SHOW EXPLAIN FOR <conn>` |
| `mariadb-prepare` | Broad preparable allow-list (all but PREPARE/EXECUTE/DEALLOCATE); `EXECUTE ... USING` binds **arbitrary expressions**, not just `@vars`; dynamic SQL banned in functions/triggers, allowed in procedures; global `max_prepared_stmt_count` (16382); `EXECUTE IMMEDIATE` with `DEFAULT`/`IGNORE` binds |

## Method
Four parallel research subagents, each source-verifying every "What LLMs Often Miss" row against `mariadb-server/sql/` (CS 13.0.1) and the canonical docs, returning file:line citations. Load-bearing / docs-contradicting claims were independently re-verified before landing — notably the **13-variable `SET STATEMENT` blocklist** (confirmed via the `NO_SET_STMT` macro count in `sys_vars.cc`, not the docs page's list of 24). All See Also URLs verified live (HTTP 200, no redirects); CI-exact codespell + lychee pass locally.

## Docs discrepancies surfaced (out of scope here — flagging for follow-up)
- `set-statement.md` lists ~24 variables as unsettable via `SET STATEMENT`; source (`NO_SET_STMT` flag) marks exactly **13** in 13.0.1. The skill documents the verified 13.
- Unreleased (not in the skill): an in-tree-but-untagged commit adds a `SHOW BINARY LOG STATUS` MySQL-compat alias and switches `mariadb-dump` to prefer `SHOW REPLICA STATUS` — worth documenting once it ships in a release.

## Notes for review
- `draft` status — promote to `pilot` after your review.
- Touches `.skills-manifest.json` (append) — trivial rebase against whichever DOCS-6287 PR merges first; I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)