### PR TITLE
DOCS-6343: fix source-verified docs-accuracy discrepancies

### DIFF
--- a/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4085.md
+++ b/server/reference/error-codes/mariadb-error-codes-4000-to-4099/e4085.md
@@ -1,8 +1,8 @@
-# Error 4085: Sequence values are conflicting
+# Error 4085: Sequence Has Out of Range Value for Options
 
-| Error Code | SQLSTATE | Error                       | Description                                     |
-| ---------- | -------- | --------------------------- | ----------------------------------------------- |
-| 4085       |          | ER\_SEQUENCE\_INVALID\_DATA | Sequence '%-.64s.%-.64s' values are conflicting |
+| Error Code | SQLSTATE | Error                       | Description                                               |
+| ---------- | -------- | --------------------------- | -------------------------------------------------------- |
+| 4085       |          | ER\_SEQUENCE\_INVALID\_DATA | Sequence '%-.64s.%-.64s' has out of range value for options |
 
 ## Possible Causes and Solutions
 

--- a/server/reference/sql-statements/account-management-sql-statements/drop-user.md
+++ b/server/reference/sql-statements/account-management-sql-statements/drop-user.md
@@ -46,6 +46,10 @@ Operation DROP USER failed for 'foo'@'localhost'.
 ```
 
 Again, use the `FORCE` clause to prevent that error.
+
+{% hint style="warning" %}
+The `FORCE` clause is not available in MariaDB Community Server. In Community Server, use a `KILL CONNECTION` statement to end the live sessions of a dropped account.
+{% endhint %}
 {% endtab %}
 
 {% tab title="< 12.1" %}

--- a/server/reference/sql-statements/administrative-sql-statements/set-commands/set-statement.md
+++ b/server/reference/sql-statements/administrative-sql-statements/set-commands/set-statement.md
@@ -69,25 +69,13 @@ There are a number of variables that cannot be set on per-query basis. These inc
 * `character_set_connection`
 * `character_set_filesystem`
 * `collation_connection`
-* `default_master_connection`
 * `debug_sync`
 * `interactive_timeout`
-* `gtid_domain_id`
-* `last_insert_id`
-* `log_slow_filter`
-* `log_slow_rate_limit`
-* `log_slow_verbosity`
-* `long_query_time`
-* `min_examined_row_limit`
 * `profiling`
 * `profiling_history_size`
 * `query_cache_type`
-* `rand_seed1`
-* `rand_seed2`
 * `skip_replication`
-* `slow_query_log`
 * `sql_log_off`
-* `tx_isolation`
 * `wait_timeout`
 
 ## Source

--- a/server/reference/sql-statements/data-definition/rename-table.md
+++ b/server/reference/sql-statements/data-definition/rename-table.md
@@ -86,7 +86,7 @@ Set the lock wait timeout. See [WAIT and NOWAIT](../transactions/wait-and-nowait
 
 ### Privileges
 
-Executing the `RENAME TABLE` statement requires the [DROP](../account-management-sql-statements/grant.md#table-privileges), [CREATE](../account-management-sql-statements/grant.md#table-privileges) and [INSERT](../account-management-sql-statements/grant.md#table-privileges) privileges for the table or the database.
+Executing the `RENAME TABLE` statement requires the [ALTER](../account-management-sql-statements/grant.md#table-privileges) and [DROP](../account-management-sql-statements/grant.md#table-privileges) privileges on the original table, and the [CREATE](../account-management-sql-statements/grant.md#table-privileges) and [INSERT](../account-management-sql-statements/grant.md#table-privileges) privileges on the new table.
 
 ### Atomic RENAME TABLE
 

--- a/server/reference/sql-statements/table-statements/truncate-table.md
+++ b/server/reference/sql-statements/table-statements/truncate-table.md
@@ -51,7 +51,13 @@ For other storage engines, `TRUNCATE TABLE` differs from`DELETE` in the followin
 
 For the purposes of binary logging and [replication](../../../server-usage/storage-engines/myrocks/myrocks-and-replication.md), `TRUNCATE TABLE` is treated as [DROP TABLE](../data-definition/drop/drop-table.md) followed by [CREATE TABLE](../data-definition/create/create-table.md) (DDL rather than DML).
 
-`TRUNCATE TABLE` does not work on [views](../../../server-usage/views/). Currently, `TRUNCATE TABLE` drops all historical records from a [system-versioned table](../../sql-structure/temporal-tables/system-versioned-tables.md).
+`TRUNCATE TABLE` does not work on [views](../../../server-usage/views/). It also cannot be used on a [system-versioned table](../../sql-structure/temporal-tables/system-versioned-tables.md), returning the error:
+
+```sql
+ERROR 4137 (HY000): System-versioned tables do not support TRUNCATE TABLE
+```
+
+To remove historical records from a system-versioned table, use [DELETE HISTORY](../data-manipulation/changing-deleting-data/delete.md#delete-history) instead.
 
 #### WAIT/NOWAIT
 

--- a/server/reference/sql-structure/sequences/create-sequence.md
+++ b/server/reference/sql-structure/sequences/create-sequence.md
@@ -132,7 +132,7 @@ The following statement fails, as the increment conflicts with the defaults:
 
 ```sql
 CREATE SEQUENCE s3 START WITH -100 INCREMENT BY 10;
-ERROR 4082 (HY000): Sequence 'test.s3' values are conflicting
+ERROR 4085 (HY000): Sequence 'test.s3' has out of range value for options
 ```
 
 The sequence can be created by specifying workable minimum and maximum values:


### PR DESCRIPTION
Fixes five page/source mismatches found while source-verifying reference pages during the DOCS-6287 agent-skills wave. All claims verified against **Community Server `main` @ `934108aab5c` (VERSION 13.1.0)**.

| Page | Fix | Source |
|------|-----|--------|
| `rename-table` | Add **`ALTER`** to the required privileges (`ALTER` + `DROP` on the original table, `CREATE` + `INSERT` on the new). Page had omitted `ALTER`. | `check_rename_table()`, `sql/sql_parse.cc` |
| `truncate-table` | `TRUNCATE` on a **system-versioned** table is **rejected** with `ERROR 4137 … System-versioned tables do not support TRUNCATE TABLE` — it does **not** drop history. Point to `DELETE HISTORY`. | `sql/sql_truncate.cc` (`ER_VERS_NOT_SUPPORTED`) |
| `e4085` + `create-sequence` | `ER_SEQUENCE_INVALID_DATA` is code **4085**, text *"has out of range value for options"* (page showed **4082** / *"values are conflicting"*; 4082 is the unrelated `ER_ROW_VARIABLE_DOES_NOT_HAVE_FIELD`). | `sql/share/errmsg-utf8.txt`, `mysqld_error.h` |
| `set-statement` | Trim the unsettable-variable list from ~24 to the **13** that actually carry the `NO_SET_STMT` flag. | `sql/sys_vars.cc` |
| `drop-user` | Add a note that the **`FORCE`** clause is **not available in Community Server** (use `KILL CONNECTION`). No Enterprise/version claim — `FORCE` left in the syntax. | `sql/sql_yacc.yy`, `sql/sql_acl.cc` |

**Open item (not in this PR):** whether `DROP USER … FORCE` is an Enterprise Server feature (and since which version) could not be confirmed from the source trees available — the ES clone here is 10.6. The edit asserts only the verified fact (absent from Community Server). Engineering confirmation of the edition/version is needed before adding any ES-specific statement.

Ticket: DOCS-6343

🤖 Generated with [Claude Code](https://claude.com/claude-code)