### PR TITLE
DOCS-6345 Add agent-skills for the MariaDB Connectors

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -67,6 +67,21 @@
         { "name": "mariadb-binlog", "path": "granular/tools/mariadb-binlog/SKILL.md", "status": "draft", "last_reviewed": "2026-07-20", "baseline_version": "11.8" }
       ]
     },
+    "granular-connectors": {
+      "$comment": "Tier 1 (connectors) — one skill per client connector, focused on application-development usage (connect, query, params, transactions, pooling, error handling) rather than install/config. Consumed by the AI Plugin (DOCS-6345). baseline_version tracks the connector release line, which is independent of the MariaDB server version.",
+      "tier": 1,
+      "path": "granular/connectors",
+      "author": "docs-team",
+      "skills": [
+        { "name": "mariadb-connector-python", "path": "granular/connectors/mariadb-connector-python/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.1" },
+        { "name": "mariadb-connector-j", "path": "granular/connectors/mariadb-connector-j/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-nodejs", "path": "granular/connectors/mariadb-connector-nodejs/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-odbc", "path": "granular/connectors/mariadb-connector-odbc/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.2" },
+        { "name": "mariadb-connector-r2dbc", "path": "granular/connectors/mariadb-connector-r2dbc/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.4" },
+        { "name": "mariadb-connector-cpp", "path": "granular/connectors/mariadb-connector-cpp/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.0" },
+        { "name": "mariadb-connector-c", "path": "granular/connectors/mariadb-connector-c/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.4" }
+      ]
+    },
     "topical": {
       "path": "topical",
       "author": "mariadb-foundation",

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -22,6 +22,7 @@ nothing here depends on a submodule fetch or a separate repository.
 | `granular/statements/` | **Tier 1** — one skill per SQL statement family (`mariadb-create-table`, `mariadb-alter-table`, `mariadb-select`, …) | Docs team, hand-curated | Source of truth, here |
 | `granular/functions/` | **Tier 2** — one skill per function category (`mariadb-json-functions`, …); machine-extracted entries wrapped in a hand-written scaffold | Docs team + `extractor/` | Source of truth, here |
 | `granular/tools/` | **Tier 1 (tools)** — one skill per client utility (`mariadb-dump`, `mariadb-import`, …) | Docs team, hand-curated | Source of truth, here |
+| `granular/connectors/` | **Tier 1 (connectors)** — one skill per client connector (`mariadb-connector-python`, …), focused on application-development *usage* rather than install/config | Docs team, hand-curated | Source of truth, here |
 | `topical/` | **Topical** — feature-area deep dives (`mariadb-features`, `mariadb-vector`, …) | Robert Silen / MariaDB Foundation | **Vendored** from [`MariaDB/skills`](https://github.com/MariaDB/skills) — see `topical/VENDORED.md`; do not hand-edit |
 
 Each skill is a directory containing a `SKILL.md` (Claude Code skill convention),

--- a/agent-skills/granular/connectors/mariadb-connector-c/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-c/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: mariadb-connector-c
+description: "MariaDB-specific behavior of MariaDB Connector/C (the `libmariadb` client library implementing the MariaDB/MySQL client-server protocol in C) for application code — that the public API is still `mysql_`-prefixed (`mysql_init`, `mysql_real_connect`, `mysql_query`, `mysql_store_result`, ...) with only a handful of `mariadb_`-prefixed extensions; that `mysql_init()` must run before `mysql_real_connect()`; the buffered-vs-unbuffered split between `mysql_store_result()` and `mysql_use_result()` and the mandatory `mysql_free_result()`; that literal values must go through `mysql_real_escape_string()` when not using prepared statements (the classic SQL-injection trap); the `?`-placeholder prepared-statement API (`mysql_stmt_init`/`mysql_stmt_prepare`, `MYSQL_BIND` arrays, `mysql_stmt_bind_param`/`execute`/`bind_result`/`fetch`); that autocommit is on by default so transactions need `mysql_autocommit(conn,0)` + `mysql_commit()`/`mysql_rollback()`; separate connection-level (`mysql_errno`/`mysql_error`) vs statement-level (`mysql_stmt_errno`/`mysql_stmt_error`) error handling; that options (`mysql_optionsv()`) must be set after `mysql_init()` but before connecting; and that `mysql_real_query()` (with an explicit length) is the binary-safe alternative to `mysql_query()`. Use when writing or reviewing C code that talks to MariaDB via Connector/C (`libmariadb`) or via the connectors built on top of it."
+---
+
+# MariaDB Connector/C
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/C is the LGPL-licensed C client library (`libmariadb`) implementing the MariaDB/MySQL client-server protocol. It is the foundation other MariaDB connectors build on — Connector/Python's C extension, Connector/ODBC, and Connector/C++ all link against it — and it is API-compatible with the classic MySQL C client library, so `mysql.h` and the `mysql_*` function names carry over directly. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the library or configuring the server.
+
+> **Default context:** Assume the **3.4** stable release series (GA February 2025; `mariadb_config --cc_version` reports the exact patch, e.g. `3.4.10`) unless the user states otherwise. Connector/C is compatible with all MariaDB and MySQL server versions — its version is independent of the server version it connects to, and behavior below applies across the 3.x line unless annotated.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Calls `mysql_real_connect()` on a raw/stack `MYSQL` struct, or skips init | Call **`mysql_init(NULL)`** first (it allocates and returns a `MYSQL *`, or initializes a struct you pass in) — every other function except `mysql_options()` fails until `mysql_real_connect()` succeeds on that handle |
+| Reaches for `mariadb_connect()`, `mariadb_query()`, etc., assuming a `mariadb_`-prefixed API | The public API is still **`mysql_`-prefixed** — `mysql_init`, `mysql_real_connect`, `mysql_query`, `mysql_store_result`, `mysql_close`, and friends — for MySQL C API compatibility. Only a handful of *extension* functions use `mariadb_` (e.g. `mariadb_reconnect()`, `mariadb_get_info()`, `mariadb_stmt_execute_direct()`); `mariadb_connect()` itself is just a macro wrapping `mysql_real_connect()` |
+| Builds SQL by concatenating/`sprintf`-ing string values into the query text passed to `mysql_query()` | **SQL-injection trap.** Escape every literal string with **`mysql_real_escape_string(mysql, to, from, length)`** first (the `to` buffer must be `length*2+1` bytes), or — preferably — use the prepared-statement API with `?` placeholders instead of building SQL text at all |
+| Calls `mysql_query()`/`mysql_store_result()` and moves straight to the next query | A result-returning statement needs one of **`mysql_store_result()`** (buffered — pulls the whole set into client memory; enables `mysql_num_rows()`/`mysql_data_seek()`) or **`mysql_use_result()`** (unbuffered — row-by-row, blocks the connection until every row is fetched or the result is freed). One of the two **must** be called even for a query with no rows, and the result **must** be released with **`mysql_free_result()`** — otherwise the next query on that connection fails |
+| Calls `mysql_num_rows()` / `mysql_data_seek()` on an unbuffered result | Those require **`mysql_store_result()`**; `mysql_use_result()` sets don't support random access or a row count until fully consumed |
+| Interpolates `%d`/`%s`-style values into a query string instead of using placeholders | Use the **prepared-statement API** with `?` markers: `mysql_stmt_init()` → `mysql_stmt_prepare(stmt, "...WHERE id=?", length)` → build a `MYSQL_BIND` array → `mysql_stmt_bind_param(stmt, bind)` → `mysql_stmt_execute(stmt)`. For a result set, bind a second `MYSQL_BIND` array with `mysql_stmt_bind_result()` and loop `mysql_stmt_fetch(stmt)` until it returns `MYSQL_NO_DATA` |
+| Assumes autocommit is off, or that DML needs an explicit `START TRANSACTION` | **Autocommit is ON by default** — each statement is its own transaction. For multi-statement transactions, disable it once with **`mysql_autocommit(conn, 0)`**, then use **`mysql_commit()`**/**`mysql_rollback()`** (or the `COMMIT`/`ROLLBACK` SQL statements); a new transaction starts automatically after each commit/rollback — no manual `START TRANSACTION` needed |
+| Checks one error API for everything, or checks connection errors after a statement-handle call | Connection-level calls (`mysql_real_connect`, `mysql_query`, `mysql_store_result`, ...) report through **`mysql_errno()`**/**`mysql_error()`**; `MYSQL_STMT`-level calls (`mysql_stmt_prepare`, `mysql_stmt_execute`, ...) have their **own** error context: **`mysql_stmt_errno()`**/**`mysql_stmt_error()`**/`mysql_stmt_sqlstate()`. Checking the wrong one silently misses the real error |
+| Sets TLS/charset/timeout options after connecting, or via `mysql_real_connect()` args alone | Set options with **`mysql_optionsv()`** (or the older `mysql_options()`) **after `mysql_init()` but before `mysql_real_connect()`** — e.g. `MYSQL_OPT_SSL_CA`, `MYSQL_SET_CHARSET_NAME`, `MYSQL_OPT_CONNECT_TIMEOUT`. Options set post-connect are ignored until the next connect/reconnect |
+| Uses `mysql_query()` for statements that may carry binary data or embedded NUL bytes | `mysql_query()` takes a **NUL-terminated** string and is **not** binary-safe. Use **`mysql_real_query(mysql, query, length)`**, which takes an explicit length, for binary-safe execution |
+| Reads only the first result after `CALL`ing a stored procedure or a multi-statement query | Stored-procedure calls and multi-statement queries (`MARIADB_OPT_MULTI_STATEMENTS`) can return **multiple result sets** — loop with **`mysql_next_result()`** (or `mysql_stmt_next_result()` for prepared statements), calling `mysql_store_result()`/`mysql_use_result()` + `mysql_free_result()` each time, until no more results remain |
+| Passes `-1` as a length to `mysql_real_query()` or `mysql_real_escape_string()`, expecting auto-detection everywhere | Only **`mysql_stmt_prepare()`** treats `length == (unsigned long)-1` as "compute via `strlen()`". The binary-safe functions (`mysql_real_query()`, `mysql_real_escape_string()`) need the **actual** byte length — passing `-1` there is a bug, not a shortcut |
+| Calls `mysql_close()` while `MYSQL_STMT`/`MYSQL_RES` handles from that connection are still open | Free every result with `mysql_free_result()` and close every prepared statement with `mysql_stmt_close()` **before** `mysql_close()` on the connection |
+
+## Connect, Prepared Statement, and Transaction
+
+```c
+#include <mysql.h>
+#include <stdio.h>
+#include <string.h>
+
+MYSQL *conn = mysql_init(NULL);
+if (!mysql_real_connect(conn, "localhost", "app", "secret",
+                         "appdb", 3306, NULL, 0))
+{
+    fprintf(stderr, "connect failed: %s\n", mysql_error(conn));
+    mysql_close(conn);
+    return 1;
+}
+
+/* Prepared statement with a `?` placeholder */
+MYSQL_STMT *stmt = mysql_stmt_init(conn);
+const char *sql = "SELECT name, qty FROM t WHERE qty > ?";
+mysql_stmt_prepare(stmt, sql, strlen(sql));
+
+int min_qty = 0;
+MYSQL_BIND param[1];
+memset(param, 0, sizeof(param));
+param[0].buffer_type = MYSQL_TYPE_LONG;
+param[0].buffer      = &min_qty;
+mysql_stmt_bind_param(stmt, param);
+
+mysql_stmt_execute(stmt);
+
+char name[64];
+int qty;
+unsigned long name_len;
+my_bool is_null[2];
+
+MYSQL_BIND result[2];
+memset(result, 0, sizeof(result));
+result[0].buffer_type   = MYSQL_TYPE_STRING;
+result[0].buffer        = name;
+result[0].buffer_length = sizeof(name);
+result[0].length        = &name_len;
+result[0].is_null       = &is_null[0];
+result[1].buffer_type   = MYSQL_TYPE_LONG;
+result[1].buffer        = &qty;
+result[1].is_null       = &is_null[1];
+mysql_stmt_bind_result(stmt, result);
+
+while (mysql_stmt_fetch(stmt) == 0)
+    printf("%s: %d\n", name, qty);
+
+mysql_stmt_close(stmt);
+
+/* Transaction: autocommit is on by default, so turn it off explicitly */
+mysql_autocommit(conn, 0);
+if (mysql_query(conn, "UPDATE t SET qty = qty - 1 WHERE id = 1") != 0 ||
+    mysql_query(conn, "UPDATE t SET qty = qty + 1 WHERE id = 2") != 0)
+{
+    fprintf(stderr, "update failed: %s\n", mysql_error(conn));
+    mysql_rollback(conn);
+}
+else
+{
+    mysql_commit(conn);
+}
+
+mysql_close(conn);
+```
+
+## See Also
+
+- **`mariadb-connector-python`** — the `mariadb` module's C extension links against this library
+- **`mariadb-connector-odbc`** / **`mariadb-connector-cpp`** — also built on top of Connector/C
+- **`mariadb-transactions`** — the server-side semantics behind `mysql_commit()`/`mysql_rollback()`
+- **`mariadb-prepare`** — server-side prepared statements, what the `MYSQL_STMT` API drives
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-c>

--- a/agent-skills/granular/connectors/mariadb-connector-cpp/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-cpp/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: mariadb-connector-cpp
+description: "MariaDB-specific behavior of MariaDB Connector/C++ (the `sql::` namespace API, modeled on JDBC 4.0) for application code — that a driver is obtained once via `sql::mariadb::get_driver_instance()` and connections come from `driver->connect(url, props)` or `sql::DriverManager::getConnection(url, props)`, both returning a raw `Connection*` you must own; the connection URL is `jdbc:mariadb://host:port/database[?opt=val]` (a `tcp://`/`unix://`/`pipe://` compatibility syntax also exists, JDBC-only); that both `PreparedStatement` parameter indexes and `ResultSet` column indexes are **1-based**, not 0-based, and index 0 or out-of-range throws; that `?` is the only placeholder syntax; that `ResultSet::next()` must be called before the first read and returns `bool`; that `connect()`/`createStatement()`/`prepareStatement()`/`executeQuery()` all return raw pointers with no automatic cleanup — wrap them in `std::unique_ptr`/`std::shared_ptr` (the documented idiom) or call `close()` explicitly, and always in child-before-parent order; that `sql::SQLString` (not `std::string`) is the parameter/return type throughout the API, though it converts to/from both directions; that **autocommit defaults to true** (opposite of Connector/Python's `autocommit=False`), so multi-statement transactions need `conn->setAutoCommit(false)` + `commit()`/`rollback()`; that all errors surface as `sql::SQLException` (and its typed subclasses) carrying `getErrorCode()`/`getSQLState()`; that client-side prepared statements are the default (`useServerPrepStmts=false`) and enabling the statement cache (`cachePrepStmts=true`) currently throws `SQLFeatureNotImplementedException` on this line; and that it is built on top of MariaDB Connector/C. Use when writing or reviewing C++ code that talks to MariaDB via Connector/C++ (the `sql::` API)."
+---
+
+# MariaDB Connector/C++
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/C++ is the official C++ driver for MariaDB, exposing an API modeled on the **JDBC 4.0** object model (`sql::Driver`, `sql::Connection`, `sql::Statement`, `sql::PreparedStatement`, `sql::ResultSet` — the same shapes as MariaDB Connector/J) rather than a procedural C-style API. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the library or configuring the server. It is **built on top of MariaDB Connector/C** (`libmariadb`) for the wire protocol, but application code talks only to the `sql::` classes, never to `mysql_*` calls directly.
+
+> **Default context:** Assume the **cpp-1.0** line (`CMakeLists.txt` reports `MACPP_VERSION "1.00.0008"`, i.e. 1.0.8) unless the user states otherwise. Connector/C++ is compatible with current MariaDB and MySQL servers — its version is independent of the server version it connects to.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Constructs a `Connection` directly, or expects a constructor-based driver | Get the singleton driver via **`sql::Driver* driver = sql::mariadb::get_driver_instance();`**, then call `driver->connect(url, props)` (returns `nullptr` on error — check before use) or the static `sql::DriverManager::getConnection(url, props)` (throws instead) |
+| Uses a bare `host:port` string or an ad-hoc DSN | Connection URLs use **JDBC syntax**: `jdbc:mariadb://host[:port]/[database][?opt1=val1&opt2=val2]` (port defaults to 3306). A `tcp://`/`unix://`/`pipe://` compatibility syntax also exists but only for `sql::Driver::connect()`, not `DriverManager` |
+| Uses `%s`/`$1`/named placeholders in a `PreparedStatement` | The only placeholder is **positional `?`** — `"INSERT INTO t (a,b,c) VALUES (?, ?, ?)"`, bound with `setString(1, ...)`, `setInt(2, ...)`, etc. |
+| Binds/reads with a 0-based index (`setString(0, ...)`, `getString(0)`) | **Both `PreparedStatement` parameter indexes and `ResultSet` column indexes are 1-based.** Index 0 or an out-of-range index throws `sql::IllegalArgumentException` (a `sql::SQLException` subclass) — the classic off-by-one for anyone used to 0-based arrays |
+| Reads a column before calling `next()`, or ignores its return value | **`ResultSet::next()` must be called before any `getXxx()`** and returns `bool` — `false` means no more rows (or the set was empty); reading before the first `next()` or after it returns `false` throws |
+| Leaks or manually `delete`s the pointers from `connect()`/`createStatement()`/`prepareStatement()`/`executeQuery()` | These factory methods return **raw owning pointers** — the caller is responsible for cleanup. The documented idiom wraps them immediately: `std::unique_ptr<sql::Connection> conn(driver->connect(url, props));`, `std::shared_ptr<sql::PreparedStatement> stmt(conn->prepareStatement(sql));`. Destroy/close children (`Statement`/`ResultSet`) before the `Connection` they came from |
+| Passes `std::string` everywhere and expects implicit `sql::SQLString` transparency | API signatures use **`sql::SQLString`**, not `std::string`. It constructs implicitly from `std::string`/`const char*` and converts to `const char*`, but there is no implicit `operator std::string()` — construct `sql::SQLString url("jdbc:mariadb://...")` explicitly where needed |
+| Assumes autocommit is off and INSERT/UPDATE need an explicit commit | **Autocommit defaults to `true`** (matching the MariaDB server default) — the opposite of Connector/Python's `autocommit=False`. Single statements commit themselves; only disable it (`conn->setAutoCommit(false)`) for multi-statement transactions, then `commit()`/`rollback()` explicitly |
+| Catches `std::exception` generically, or checks a return code for errors | Catch **`sql::SQLException`** (derives from `std::runtime_error`) by reference — `catch (sql::SQLException &e)`. Read `e.getErrorCode()` / `e.getSQLState()` / `e.what()`. Typed subclasses exist for specific cases (`SQLIntegrityConstraintViolationException`, `SQLSyntaxErrorException`, `SQLTimeoutException`, `BatchUpdateException`, ...) |
+| Expects server-side prepared statements or a statement cache by default | **Client-side prepared statements are the default** (`useServerPrepStmts=false`); set it `true` to use server-side `PREPARE`/`EXECUTE`. Don't set `cachePrepStmts=true` — on this connector line it throws `sql::SQLFeatureNotImplementedException("Callable/Prepared statement caches are not supported yet")` at connect time |
+| Loops `executeUpdate()` for bulk insert | Use `PreparedStatement::addBatch()` + `executeBatch()`/`executeLargeBatch()`; the `rewriteBatchedStatements` and `useBulkStmts` connection options further optimize batched `INSERT`s (the two are mutually exclusive — `rewriteBatchedStatements` wins if both are set) |
+| Wants the last auto-increment value or a `ResultSetMetaData`/schema introspection call | `Statement::getGeneratedKeys()` returns a `ResultSet` of generated keys after an insert; `ResultSet::getMetaData()` gives column info (`ResultSetMetaData`); `Connection::getMetaData()` gives database/schema info (`DatabaseMetaData`) |
+| Shares one `Connection`/`Statement`/`ResultSet` across threads without synchronization | `get_driver_instance()` returns a **process-wide singleton** and is safe to call from multiple threads to obtain independent connections, but individual `Connection`/`Statement`/`ResultSet` objects are not documented as safe for concurrent multi-threaded use — give each thread (or task) its own connection |
+
+## Connect, prepare, iterate, and transact
+
+```c++
+#include <iostream>
+#include <mariadb/conncpp.hpp>
+
+int main() {
+  try {
+    // One process-wide driver singleton
+    sql::Driver* driver = sql::mariadb::get_driver_instance();
+
+    sql::SQLString url("jdbc:mariadb://192.0.2.1:3306/appdb");
+    sql::Properties properties({
+        {"user", "app"},
+        {"password", "secret"},
+      });
+
+    // connect() returns a raw pointer -- wrap it immediately
+    std::unique_ptr<sql::Connection> conn(driver->connect(url, properties));
+    if (!conn) {
+      std::cerr << "connection failed" << std::endl;
+      return 1;
+    }
+
+    // autocommit defaults to true; disable it for a multi-statement transaction
+    conn->setAutoCommit(false);
+    try {
+      std::unique_ptr<sql::PreparedStatement> ins(
+          conn->prepareStatement("INSERT INTO t (name, qty) VALUES (?, ?)"));
+      ins->setString(1, "widget");   // parameter index is 1-based
+      ins->setInt(2, 5);
+      ins->executeUpdate();
+
+      conn->commit();
+    }
+    catch (sql::SQLException& e) {
+      conn->rollback();
+      throw;
+    }
+
+    // SELECT + iterate the ResultSet
+    std::unique_ptr<sql::PreparedStatement> sel(
+        conn->prepareStatement("SELECT id, name FROM t WHERE qty > ?"));
+    sel->setInt(1, 0);
+    std::unique_ptr<sql::ResultSet> res(sel->executeQuery());
+
+    while (res->next()) {                     // must call next() before reading
+      int32_t id = res->getInt(1);             // column index is 1-based
+      sql::SQLString name = res->getString("name");  // or by column label
+      std::cout << id << ": " << name << std::endl;
+    }
+
+    conn->close();  // also happens implicitly when the unique_ptr goes out of scope
+  }
+  catch (sql::SQLException& e) {
+    std::cerr << "SQL error [" << e.getErrorCode() << " " << e.getSQLState()
+               << "]: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}
+```
+
+## See Also
+
+- **`mariadb-connector-c`** — the underlying C client library (`libmariadb`) this driver is built on
+- **`mariadb-transactions`** — the server-side semantics behind `commit()`/`rollback()` and isolation levels set via `setTransactionIsolation()`
+- **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-cpp>

--- a/agent-skills/granular/connectors/mariadb-connector-j/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-j/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: mariadb-connector-j
+description: "MariaDB-specific behavior of MariaDB Connector/J (the `org.mariadb.jdbc:mariadb-java-client` JDBC driver) for application code — that JDBC 4 auto-registers the driver so `Class.forName` is unneeded; that the URL scheme is `jdbc:mariadb://host:port/db?opts` (`jdbc:mysql:` only works with `permitMysqlScheme`); that `useServerPrepStmts` defaults to `false` so `PreparedStatement` uses client-side parameter substitution unless explicitly enabled; that batched `INSERT`s already use the `COM_STMT_BULK` protocol by default (`useBulkStmtsForInserts=true`) which changes `getGeneratedKeys()` to return the *last* id, not the first; that JDBC `autocommit` defaults to `true` (opposite of the Python/C connectors) so transactions need an explicit `setAutoCommit(false)`; that `setFetchSize(Integer.MIN_VALUE)` throws (fetch size must be `>= 0`) and even a positive fetch size doesn't stop the server sending all rows underneath; that pooling should go through `MariaDbPoolDataSource` (default `maxPoolSize` 8) or an external pool, not a hand-rolled one; and that failover/multi-host URLs use a comma-separated host list with an HA-mode prefix, not driver code. Use when writing or reviewing Java code that talks to MariaDB with the `mariadb-java-client` JDBC driver."
+---
+
+# MariaDB Connector/J
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/J is the official JDBC driver for MariaDB and MySQL — Maven coordinates `org.mariadb.jdbc:mariadb-java-client`, LGPL-licensed. This skill covers the connector-specific behavior and the traps that bite generated application code. It is **pure Java** — it implements the client/server protocol itself and does **not** depend on MariaDB Connector/C (unlike Connector/Python or Connector/ODBC).
+
+> **Default context:** Assume the **3.5.x** line (current release `3.5.9`) unless the user states otherwise. Behavior shared with the 2.7.x line is shown without annotation; where 3.x changed a default from 2.7.x (notably batch-insert bulk protocol) it's called out explicitly. Connector versions are independent of the MariaDB server version — a 3.x connector routinely talks to a 10.6/10.11/11.x server.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `Class.forName("org.mariadb.jdbc.Driver")` before connecting | **Not needed.** The driver self-registers via the JDBC 4 `META-INF/services/java.sql.Driver` mechanism — `DriverManager.getConnection(url)` alone finds it. The legacy call still works, but only add it if targeting JDBC 3-era containers |
+| A `jdbc:mysql://host:3306/db` URL | Use **`jdbc:mariadb://host:port/db?opts`**. The `jdbc:mysql:` prefix is only accepted when the `permitMysqlScheme` option is present in the URL — otherwise the driver won't claim it |
+| Builds SQL with string concat / `String.format()` / `+` | Never. Use **`PreparedStatement`** with `?` placeholders and `setX(index, value)` — the driver escapes/binds values, closing off SQL injection |
+| Expects server-side prepared statements (binary protocol) by default | **`useServerPrepStmts` defaults to `false`.** `PreparedStatement` parameter substitution happens **client-side** (text protocol) unless you set `useServerPrepStmts=true` on the URL. 3.x is markedly more aggressive about caching once it *is* enabled — watch `max_prepared_stmt_count` after upgrading from 2.7.x |
+| Loops single `executeUpdate()` calls for bulk insert/update | Use **`addBatch()` / `executeBatch()`**. For `INSERT` batches, 3.x already sends them via the `COM_STMT_BULK` protocol by default (`useBulkStmtsForInserts=true`, `useBulkStmts` itself stays `false` for non-insert statements) — no extra option needed for the common case |
+| Reads `getGeneratedKeys()` after a batch insert expecting the *first* row's id | With the default bulk-insert protocol, `getGeneratedKeys()` returns the **last** generated id, not the first — a behavior change from 2.7.x. Don't assume per-row id order without checking `useBulkStmtsForInserts` |
+| Assumes autocommit is off; wraps every statement in `setAutoCommit(false)` needlessly, or forgets to call it | **`autocommit` defaults to `true`** (standard JDBC, opposite of Connector/Python and Connector/C). For a transaction, call `conn.setAutoCommit(false)` once, then `conn.commit()` / `conn.rollback()` explicitly — don't rely on statement-level commit |
+| Streams a huge `ResultSet` with `setFetchSize(Integer.MIN_VALUE)` | **Throws `SQLException`** — MariaDB Connector/J requires `rows >= 0`. Use a **positive** value, e.g. `stmt.setFetchSize(1000)`, on a `TYPE_FORWARD_ONLY` statement to stream row-by-row. Even then, the fetch size is capped internally (16384) and **the server still sends all rows** to the client socket — running another statement on the same connection before the stream is fully read pulls the remainder into memory (OOM risk); use a separate connection for concurrent work |
+| Hand-rolls a pool, or opens a new `Connection` per request | Use **`MariaDbPoolDataSource`** (internal pool: `maxPoolSize` default **8**, `minPoolSize` defaults to `maxPoolSize`, `maxIdleTime` default **600s**) or wrap the plain `MariaDbDataSource`/driver URL with an external pool (HikariCP). `connection.close()` on a pooled connection returns it to the pool — it doesn't disconnect — and resets autocommit, isolation level, and any active transaction (rolled back) |
+| Builds a custom failover/round-robin loop over multiple hosts | Multi-host URLs are native: **`jdbc:mariadb:sequential://host1,host2,host3/db`** (also `replication:`, `loadbalance:`, `load-balance-read:` prefixes) — comma-separate hosts in one URL instead of driver-side retry code |
+| Enables TLS with `useSSL=true&verifyServerCertificate=true` (other-driver naming) | Use **`sslMode`**: `disable` (default) / `trust` / `verify-ca` / `verify-full`. Certificate/key material via `serverSslCert`, `trustStore`/`trustStorePassword`, `keyStore`/`keyStorePassword` — not `verifyServerCertificate` |
+| Catches a generic `Exception` or expects a MariaDB-specific exception class | The driver throws the **standard `java.sql.SQLException` hierarchy** mapped from the server's SQLSTATE: `SQLIntegrityConstraintViolationException`, `SQLSyntaxErrorException`, `SQLTransactionRollbackException`, `SQLTransientConnectionException`, `SQLNonTransientConnectionException`. Read `.getErrorCode()` / `.getSQLState()` for the MariaDB-specific code, don't string-match `.getMessage()` |
+| Sets `Statement.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS)` and assumes it "just works" for any statement | `getGeneratedKeys()` only returns rows when `RETURN_GENERATED_KEYS` was explicitly requested on that statement/`prepareStatement()` call — it's not implicit for a plain `INSERT` |
+
+## Connection, prepared statements, and a transaction
+
+```java
+import java.sql.*;
+
+// JDBC 4 auto-registers the driver — no Class.forName() needed
+try (Connection conn = DriverManager.getConnection(
+        "jdbc:mariadb://localhost:3306/appdb", "app", "secret")) {
+
+    conn.setAutoCommit(false);   // autocommit defaults to true — turn it off for a transaction
+
+    try (PreparedStatement ps = conn.prepareStatement(
+            "INSERT INTO t (name, qty) VALUES (?, ?)")) {
+        ps.setString(1, "widget");
+        ps.setInt(2, 5);
+        ps.executeUpdate();
+        conn.commit();
+    } catch (SQLException e) {
+        conn.rollback();
+        throw e;
+    }
+
+    try (PreparedStatement ps = conn.prepareStatement(
+            "SELECT id, name FROM t WHERE qty > ?")) {
+        ps.setInt(1, 0);
+        try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                System.out.println(rs.getInt("id") + " " + rs.getString("name"));
+            }
+        }
+    }
+}
+```
+
+## Pooling with `MariaDbPoolDataSource`
+
+```java
+import org.mariadb.jdbc.MariaDbPoolDataSource;
+import java.sql.*;
+
+try (MariaDbPoolDataSource pool = new MariaDbPoolDataSource(
+        "jdbc:mariadb://localhost:3306/appdb?user=app&password=secret&maxPoolSize=10")) {
+
+    try (Connection conn = pool.getConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet rs = stmt.executeQuery("SELECT 1")) {
+        rs.next();
+    } // conn.close() (implicit) returns the connection to the pool, it doesn't disconnect
+}
+```
+
+## See Also
+
+- **`mariadb-connector-r2dbc`** — the reactive, non-blocking sibling driver for Java (also pure Java, no Connector/C dependency)
+- **`mariadb-transactions`** / **`mariadb-set-transaction`** — the server-side semantics behind `conn.commit()` / `conn.rollback()` and isolation levels
+- **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-j>

--- a/agent-skills/granular/connectors/mariadb-connector-nodejs/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-nodejs/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: mariadb-connector-nodejs
+description: "MariaDB-specific behavior of MariaDB Connector/Node.js (the `mariadb` npm package, a non-blocking driver) for application code — that the Promise API (`require('mariadb')` / `import mariadb from 'mariadb'`) is the default and the Callback API lives under `require('mariadb/callback')`; that `?` positional placeholders are default and `namedPlaceholders` must be enabled for `:name` style; that `query()` resolves to an array of row objects (or a JSON object with `affectedRows`/`insertId`/`warningStatus` for DML) carrying a non-enumerable `meta` property, and that `rowsAsArray`/`metaAsArray` change that shape; that BIGINT columns and `insertId` come back as native BigInt by default unless `bigIntAsNumber`/`insertIdAsNumber`/`supportBigNumbers`/`decimalAsNumber` are set; that `batch()` uses the COM_STMT_BULK_EXECUTE protocol (MariaDB >= 10.2.7) instead of looping `query()`; that `queryStream()` (with `for await` or event listeners) is needed for large result sets since `query()` buffers the entire result in memory; that `pool.query()` auto-acquires/releases a connection while `pool.getConnection()` must be released with `conn.release()` in a `finally`; that autocommit is not managed by the driver and follows the server's own default (ON), so transactions need explicit `beginTransaction()`/`commit()`/`rollback()`; that `execute()` uses server-side prepared statements with an LRU cache (`prepareCacheLength`, default 256) while `query()` uses the text protocol; and that thrown errors carry `.code`/`.errno`/`.sqlState` (not `.sqlstate`). Use when writing or reviewing Node.js/JavaScript code that talks to MariaDB with the `mariadb` package."
+---
+
+# MariaDB Connector/Node.js
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/Node.js is the official Node.js driver for MariaDB — the `mariadb` package on npm (`npm install mariadb`), LGPL-licensed and non-blocking. This skill covers the connector-specific behavior and the traps that bite generated application code. It is **pure JavaScript** and does **not** depend on MariaDB Connector/C — no native build step, no C toolchain required.
+
+> **Default context:** Assume the **3.5.x** line (current: 3.5.3) unless the user states otherwise; it requires **Node.js >= 20**. Connector versions are independent of the MariaDB server version — a 3.5.x connector talks to any currently supported MariaDB server release.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `require('mysql')` / `require('mysql2')`, or expects a default export shaped like those drivers | The package is **`mariadb`**. Default export is the **Promise API**: `import mariadb from 'mariadb'` (or `const mariadb = require('mariadb')`). The **Callback API** is a separate entry point: `require('mariadb/callback')` |
+| Builds SQL with template literals / string concatenation | Never. Pass values as the second argument to `query()`/`execute()`/`batch()`; the connector escapes them. `conn.query("... WHERE id = ?", [id])` |
+| Uses `:name` named placeholders by default | `?` positional placeholders are the default. `:name` style only works with the **`namedPlaceholders`** connection/query option set `true`, and then `values` must be an object: `conn.query({ namedPlaceholders: true, sql: '... WHERE id = :id' }, { id })` |
+| Uses `??` to escape an identifier as a placeholder (a mysql/mysql2 habit) | **Not implemented.** Use `conn.escapeId(name)` explicitly: `` conn.query(`CALL ${conn.escapeId(proc)}(?)`, [val]) `` |
+| Expects a single result-set shape for every query | `query()` on `INSERT`/`UPDATE`/`DELETE` resolves to a JSON object (`affectedRows`, `insertId`, `warningStatus`); on `SELECT` it resolves to an **array of row objects** with a non-enumerable `meta` array attached. `rowsAsArray: true` returns rows as arrays instead; `metaAsArray: true` returns `[rows, meta]` instead of `rows.meta` (mysql2-compatibility shape) |
+| Treats `insertId` / BIGINT columns as a JS `Number` | Both default to native **BigInt** (`9007199254740993n`) so values above 2^53 stay exact. Set `insertIdAsNumber`/`bigIntAsNumber` (and `decimalAsNumber`/`supportBigNumbers` for DECIMAL) to get plain `Number`s back — only if the app is sure values stay in the safe integer range |
+| Loops `query()` calls for bulk insert | Use **`conn.batch(sql, arrayOfArrays)`** — one call, and on MariaDB **>= 10.2.7** it uses the `COM_STMT_BULK_EXECUTE` protocol (a single round trip); on older servers it falls back automatically. Far fewer round trips than looping |
+| Pulls a huge result set with plain `query()` | `query()` buffers the **entire** result-set in memory before resolving. For large results use **`conn.queryStream(sql, values)`** — a Readable/emitter consumable with `for await (const row of stream)` or `.on('data'/'error'/'end')`. If handling a row throws mid-stream, call `stream.close()` explicitly or the connection can hang |
+| Opens a new connection per request, or hand-rolls pooling | Use **`mariadb.createPool(options)`**. `pool.query()`/`pool.batch()` auto-acquire and auto-release a connection. For multi-statement work, `pool.getConnection()` returns a connection that **must** be given back with `conn.release()` (aliased to `.end()`/`.close()`) — always in a `finally`, or the pool exhausts. Default `connectionLimit` is **10**, `acquireTimeout` **10000 ms** |
+| Assumes autocommit is off by default (a habit from some other DB-API drivers) | The connector has **no `autocommit` option at all** — it never touches session autocommit, so behavior follows the **server default (ON)**. Wrap multi-statement work in `conn.beginTransaction()` … `conn.commit()` / `conn.rollback()` explicitly regardless of server default |
+| Expects `execute()` and `query()` to behave identically | `query()` always uses the **text protocol**. `execute()` uses **server-side prepared statements** (binary protocol) and caches the prepared statement in an LRU cache keyed by SQL text (`prepareCacheLength`, default **256**) — reusing the same SQL string across calls avoids re-preparing |
+| Catches `Exception`/generic `Error`, or reads `.sqlstate` (lowercase, a DB-API habit) | Thrown errors are `SqlError` instances with **`.code`** (e.g. `ER_PARSE_ERROR`), **`.errno`** (numeric), and **`.sqlState`** (camelCase, capital S) — not `.sqlstate` |
+| Assumes client and server share a timezone, or hand-converts dates | `timezone` defaults to `'local'` (no conversion — fine only if client and server timezones match). Set `timezone: 'auto'` to have the connector detect and align to the server's timezone, or pass an explicit IANA zone/offset |
+| Expects the driver to auto-reconnect after a dropped connection | No automatic reconnection on a plain `Connection`. Use a pool (which validates/replaces connections) rather than assuming a long-lived single connection survives indefinitely |
+
+## Connection essentials
+
+```javascript
+import mariadb from 'mariadb';
+
+const pool = mariadb.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PWD,
+  database: 'appdb',
+  connectionLimit: 10   // default shown for clarity
+});
+
+// pool.query() auto-acquires and auto-releases a connection
+async function getUser(id) {
+  const rows = await pool.query('SELECT id, name FROM users WHERE id = ?', [id]);
+  return rows[0]; // rows is an array; rows.meta holds column metadata
+}
+```
+
+```javascript
+// Transaction: explicit getConnection() + release() in finally
+async function transferFunds(fromId, toId, amount) {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    await conn.query('UPDATE accounts SET balance = balance - ? WHERE id = ?', [amount, fromId]);
+    await conn.query('UPDATE accounts SET balance = balance + ? WHERE id = ?', [amount, toId]);
+    await conn.commit();
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release(); // returns the connection to the pool
+  }
+}
+```
+
+```javascript
+// Bulk insert: batch(), not a query() loop
+async function insertItems(basketId, itemIds) {
+  await pool.batch(
+    'INSERT INTO basket_item(basketId, itemId) VALUES (?, ?)',
+    itemIds.map((itemId) => [basketId, itemId])
+  );
+}
+```
+
+## See Also
+
+- **`mariadb-transactions`** — the server-side semantics behind `beginTransaction()`/`commit()`/`rollback()` and isolation levels
+- **`mariadb-prepare`** — server-side prepared statements, what `execute()` uses under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-nodejs>

--- a/agent-skills/granular/connectors/mariadb-connector-odbc/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-odbc/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mariadb-connector-odbc
+description: "MariaDB-specific behavior of MariaDB Connector/ODBC (the ODBC 3.8-compliant driver built on MariaDB Connector/C) for application code — that the DSN-less connection string keyword is `DRIVER={MariaDB ODBC 3.2 Driver}` (Windows) or a registered driver name / `.so` path (unixODBC/iODBC on Linux and macOS); that parameter markers are always the positional `?` via `SQLBindParameter`, never named or `%s`; that a single Unicode (`SQLWCHAR`) driver binary serves both ANSI and Unicode apps via `SQL_ATTR_ANSI_APP`; that `SQLPrepare`+`SQLExecute` defaults to server-side prepared statements (binary protocol) while `SQLExecDirect` defaults to client-side (text protocol) unless `EDSERVER`/`SQL_ATTR_EXECDIRECT_ON_SERVER` is set; that autocommit is ON by default (the connector issues `SET autocommit=1` at connect) so transactional code needs an explicit `SQLSetConnectAttr(..., SQL_ATTR_AUTOCOMMIT, SQL_AUTOCOMMIT_OFF, ...)` or a `COMMIT`; that the legacy `OPTION`/`OPTIONS` bitmask (found-rows, compression, multi-statements, auto-reconnect, ...) coexists with named keywords like `AUTO_RECONNECT` and `NAMEDPIPE`; that TLS is enabled implicitly by setting any of `SSLCA`/`SSLCERT`/`SSLKEY`/`SSLCIPHER`/`SSLCAPATH` (or explicitly via `FORCETLS=1`); that native error codes returned via `SQLGetDiagRec` are the raw MariaDB server error numbers, not ODBC-defined codes; and that from Python, `pyodbc.connect(\"DRIVER={...};SERVER=...\")` is the idiomatic entry point, not a MariaDB-specific module. Use when writing or reviewing application code (C/C++, or via a wrapper like pyodbc) that talks to MariaDB through the ODBC API."
+---
+
+# MariaDB Connector/ODBC
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/ODBC is an ODBC 3.8-compliant driver for MariaDB and MySQL, built on top of **MariaDB Connector/C** (`libmariadb`) for the actual client-server protocol work. Applications never link against it directly — they go through the standard **ODBC API** (`SQLConnect`/`SQLDriverConnect`, `SQLExecDirect`, `SQLBindParameter`, ...) mediated by a **Driver Manager** (unixODBC on Linux, iODBC on macOS, the built-in ODBC Driver Manager on Windows), or through a language wrapper on top of that API — most commonly **pyodbc** from Python. This skill covers the connector-specific behavior and the traps that bite generated application code; it does not cover installing the driver or configuring the server.
+
+> **Default context:** Assume the **3.2** stable release series (currently 3.2.10 GA) unless the user states otherwise. Connector/ODBC's version is independent of the MariaDB server version it connects to — behavior below applies across the 3.x line unless annotated with a specific version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| Guesses the driver name, or copies one from another database's ODBC setup | On Windows the registered name is **`{MariaDB ODBC 3.2 Driver}`** (version number changes per series). On Linux/macOS with unixODBC/iODBC, `Driver=` is either a path to `libmaodbc.so`/`libmaodbc.dylib` or the driver name you registered in `odbcinst.ini` — there is no fixed string, it must match what `odbcinst -i -d` installed |
+| Named or `%s`/`:name` parameter placeholders | ODBC only has **positional `?` markers**, bound in order with `SQLBindParameter` (or passed positionally through a wrapper, e.g. `cursor.execute(sql, params)` in pyodbc). No named-parameter support |
+| Builds SQL with string formatting/concatenation | Never. Bind values through `SQLBindParameter`/the wrapper's parameter API — the driver sends them as protocol-level parameters, not as text spliced into the query |
+| Assumes a separate ANSI driver package is needed for legacy apps | MariaDB Connector/ODBC ships **one Unicode (`SQLWCHAR`) driver binary** that serves both ANSI and Unicode applications; the Driver Manager sets `SQL_ATTR_ANSI_APP` and the driver converts transparently — no separate ANSI-only driver package to install |
+| Expects `SQLExecDirect` to always use server-side prepared statements | `SQLExecDirect` defaults to **client-side prepare** (`SQL_ATTR_EXECDIRECT_ON_SERVER` = `SQL_FALSE` by default); set that attribute (or the `EDSERVER` connection-string option, *since 3.2.5*) to force server-side prepare/binary protocol for one-shot execution |
+| Expects `SQLPrepare`+`SQLExecute` to use the text protocol | The opposite default: `SQLPrepare` uses **server-side prepared statements** (binary protocol) unless `SQL_ATTR_PREPARE_ON_CLIENT` is `SQL_TRUE` (or the `PREPONCLIENT` connection-string option, *since 3.2.0*) forces client-side prepare |
+| Assumes autocommit is off until told otherwise | **Autocommit is ON by default** — the connector sends `SET autocommit=1` at connect time, matching the ODBC standard default (`SQL_AUTOCOMMIT_ON`). Turn it off with `SQLSetConnectAttr(dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_OFF, 0)` before starting manual transaction control, then call `SQLEndTran(SQL_HANDLE_DBC, dbc, SQL_COMMIT)` / `SQL_ROLLBACK` |
+| Ignores the legacy `OPTION`/`OPTIONS` bitmask connection parameter | It is still live and stacks with named keywords: bit 2 = return matched (not changed) rows, bit 2048 = compression, bit 4194304 = `AUTO_RECONNECT`, bit 67108864 = allow multiple statements per query (needed to run a batch of `;`-separated statements). Prefer the equivalent named keyword (`AUTO_RECONNECT=1`, etc.) when one exists — it is more readable than computing bit sums |
+| Assumes TLS needs an explicit "enable SSL" switch before certs matter | Setting **any** of `SSLCA`/`SSLCERT`/`SSLKEY`/`SSLCIPHER`/`SSLCAPATH` auto-enables TLS enforcement. Use **`FORCETLS=1`** to require TLS without supplying certificate material, and **`SSLVERIFY=1`** separately to verify the server certificate against `SSLCA` |
+| Treats `SQLGetDiagRec`'s native-error field as an ODBC-defined code | It is the raw **MariaDB server error number** (`mysql_errno()`), e.g. `1146` for "table doesn't exist" — cross-reference it against server error codes, not an ODBC error table. `SQLSTATE` is the server's mapped 5-character state |
+| Runs several statements at once on one connection without buffering results first | The MariaDB protocol allows only one command in flight per connection; fetch or discard a statement's result set before issuing another on the **same connection** (no MARS-style interleaving). Use separate statement handles sequentially, a connection pool, or `OPTION` bit 67108864 only for literal multi-statement *batches* (`stmt1; stmt2;`) in a single `SQLExecDirect` call, which has its own limitations for cross-statement dependencies |
+| Connects with `mariadb.connect(...)` (the Python `mariadb` module) when the app is ODBC-based | From Python via ODBC, use **pyodbc**: `pyodbc.connect("DRIVER={MariaDB ODBC 3.2 Driver};SERVER=...;...")`. pyodbc is a generic ODBC wrapper — it is not MariaDB-specific, but it inherits every behavior above (autocommit-on default, `?` markers, native error = server error number) |
+| Assumes pyodbc commits automatically after `execute()` | pyodbc's `Connection.autocommit` defaults to **`False`** at the *pyodbc* layer (distinct from the ODBC/server-level default above) — call `conn.commit()` explicitly, or construct with `pyodbc.connect(..., autocommit=True)` |
+
+## Connection essentials
+
+```c
+/* DSN-less connection string, C/C++ via SQLDriverConnect */
+SQLWCHAR *ConnStr = L"DRIVER={MariaDB ODBC 3.2 Driver};"
+                     L"SERVER=127.0.0.1;PORT=3306;"
+                     L"DATABASE=appdb;UID=app;PASSWORD=secret;"
+                     L"SSLCA=/etc/mysql/certs/ca.pem;SSLVERIFY=1";
+```
+
+```
+# Equivalent unixODBC/iODBC odbc.ini DSN entry
+[MariaDB-appdb]
+Driver   = MariaDB ODBC 3.2 Driver
+SERVER   = 127.0.0.1
+PORT     = 3306
+DATABASE = appdb
+UID      = app
+PASSWORD = secret
+SSLCA    = /etc/mysql/certs/ca.pem
+SSLVERIFY = 1
+```
+
+```python
+import pyodbc
+
+conn = pyodbc.connect(
+    "DRIVER={MariaDB ODBC 3.2 Driver};"
+    "SERVER=127.0.0.1;PORT=3306;DATABASE=appdb;UID=app;PWD=secret",
+    autocommit=False,   # pyodbc's own default; shown for clarity
+)
+cur = conn.cursor()
+cur.execute(
+    "INSERT INTO t (name, qty) VALUES (?, ?)",  # positional ? markers only
+    ("widget", 5),
+)
+conn.commit()   # required: neither pyodbc nor a manual OFF toggle auto-commits
+
+cur.execute("SELECT id, name FROM t WHERE qty > ?", (0,))
+for row in cur.fetchall():
+    print(row.id, row.name)
+
+cur.close()
+conn.close()
+```
+
+## See Also
+
+- **`mariadb-connector-c`** — the underlying `libmariadb` client library that does the actual protocol work
+- **`mariadb-transactions`** — server-side semantics behind `SQLEndTran`/`conn.commit()` and isolation levels (`SQL_ATTR_TXN_ISOLATION` maps directly to `SET SESSION TRANSACTION ISOLATION LEVEL`)
+- **`mariadb-prepare`** — server-side prepared statements, what `SQLPrepare`'s default (and `EDSERVER`) use under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-odbc>

--- a/agent-skills/granular/connectors/mariadb-connector-python/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-python/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mariadb-connector-python
+description: "MariaDB-specific behavior of MariaDB Connector/Python (the `mariadb` PyPI module, a PEP-249 / DB API 2.0 driver) for application code — that the default paramstyle is qmark (`?`), not format (`%s`), and styles must not be mixed; that string formatting must never build SQL; that autocommit is off by default so DML needs `conn.commit()`; that a single parameter needs a one-tuple `(v,)`; that the text protocol is default and `binary=True` switches to server-side prepared statements; that cursors are buffered by default; connection pooling via `ConnectionPool` (default size 5, max 64); `callproc()` for stored procedures; the DB API exception hierarchy under `mariadb.Error`; and that the module is a C extension built on Connector/C. Use when writing or reviewing Python code that talks to MariaDB with the `mariadb` module."
+---
+
+# MariaDB Connector/Python
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/Python is the official Python driver for MariaDB — the `mariadb` module on PyPI (`pip install mariadb`), implementing the Python DB API 2.0 ([PEP-249](https://peps.python.org/pep-249)). This skill covers the connector-specific behavior and the traps that bite generated application code. It is a **C extension built on MariaDB Connector/C**, so a build needs the C connector's development files (`mariadb_config` on the `PATH`) — it is not pure Python on the 1.1 line.
+
+> **Default context:** Assume the **1.1** stable line unless the user states otherwise. Behavior shared with older 1.x releases is shown without annotation; features added in the newer **2.0** line (`mariadb://` URI connection strings, async `asyncConnect`/`create_async_pool`, a pure-Python implementation) are marked *since 2.0*. Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| `%s` placeholders everywhere (`WHERE id = %s`) | The default **paramstyle is `qmark`** — use `?`: `cursor.execute("SELECT ... WHERE id = ?", (id,))`. `%s` (format) is accepted for compatibility, but **mixing `?` and `%s` in one statement raises**. Prefer `?` |
+| Builds SQL with f-strings / `%` / `.format()` / string concat | Never. Pass values as the second argument to `execute()`; the connector escapes them. `cursor.execute("... VALUES (?, ?)", (a, b))` |
+| Passes a single parameter as a scalar (`execute(sql, id)`) | Parameters must be a **tuple or list**; a single value needs a one-element tuple: `(id,)` — note the trailing comma. `executemany()` takes a **list of tuples** |
+| Assumes autocommit is on; INSERT/UPDATE "disappear" | **`autocommit` is `False` by default.** Call `conn.commit()` after DML, or open the connection with `autocommit=True`. On close without commit, the transaction rolls back |
+| Uses a libpq-style DSN (`"host=... dbname=..."`) or a MySQL URL | `connect()` takes **keyword args**: `mariadb.connect(host="localhost", port=3306, user=..., password=..., database=...)`. *Since 2.0* a `mariadb://user:pw@host/db` URI string is also accepted (kwargs override URI values) |
+| Imports `MySQLdb`, `pymysql`, or `mysql.connector` | The module is **`mariadb`** (`import mariadb`). API is DB API 2.0 but the module name, C-extension nature, and `?` paramstyle differ from those drivers |
+| Expects server-side prepared statements by default | The **text protocol is the default**. Set **`binary=True`** for the binary protocol (server-side prepared statements) — at the cursor (`conn.cursor(binary=True)`), or *since 2.0* at the connection. (`prepared=True` is deprecated in favor of `binary=True`) |
+| Expects the driver to auto-reconnect after a dropped connection | **No automatic reconnection.** (The `reconnect` parameter was removed in 2.0.) Use a connection pool, or call `conn.reconnect()` explicitly |
+| Streams a huge result set with a default cursor | Cursors are **buffered by default** — the whole result is pulled into memory. For large results use `conn.cursor(buffered=False)` and iterate row by row |
+| Loops `execute()` for bulk insert/update | Use **`executemany(sql, list_of_tuples)`** — far fewer round trips. All tuples must have the **same types**; signal NULL / column default with `mariadb.constants.INDICATOR` values, not `None`-as-default |
+| Hand-rolls a pool, or opens a new connection per request | Use **`mariadb.ConnectionPool(pool_name="app", pool_size=5)`**; borrow with `pool.get_connection()` and return it by `conn.close()`. `pool_size` defaults to 5, **max 64**; `pool_reset_connection=True` (default) resets each connection before reuse |
+| Calls a stored procedure by string-building `CALL ...` with OUT params | Use **`cursor.callproc("proc_name", (in1, in2))`**; read OUT/INOUT results from the returned sequence / a following result set |
+| Catches `Exception` or a MySQL driver's error class | Catch **`mariadb.Error`** (the DB API base). Subclasses: `OperationalError`, `IntegrityError`, `ProgrammingError`, `DataError`, `InterfaceError`, `InternalError`, `NotSupportedError`, `PoolError`. `.errno` / `.sqlstate` are on the exception |
+
+## Connection essentials
+
+```python
+import mariadb
+
+# Keyword-argument connection (works on all supported versions)
+conn = mariadb.connect(
+    host="localhost", port=3306,
+    user="app", password="secret",
+    database="appdb",
+    autocommit=False,          # the default; shown for clarity
+)
+
+# since 2.0 — URI connection string
+conn = mariadb.connect("mariadb://app:secret@localhost:3306/appdb")
+
+with conn.cursor() as cur:
+    cur.execute("INSERT INTO t (name, qty) VALUES (?, ?)", ("widget", 5))
+    conn.commit()                      # autocommit is off by default
+
+    cur.execute("SELECT id, name FROM t WHERE qty > ?", (0,))   # note (0,)
+    for row in cur:                    # buffered by default
+        print(row)
+```
+
+Common `connect()` keywords: `host` (default `localhost`; a comma-separated list gives simple failover), `port` (default `3306`), `user`/`username`, `password`/`passwd`, `database`/`db`, `unix_socket`, `autocommit`, and the SSL/TLS options. Result-shape options include `dictionary=True` (rows as dicts) and `named_tuple=True`. Some options apply only to the C extension — see the connection-class reference.
+
+## Pooling
+
+```python
+import mariadb
+
+pool = mariadb.ConnectionPool(
+    pool_name="app", pool_size=8,      # max 64; pool_reset_connection defaults to True
+    host="localhost", user="app", password="secret", database="appdb",
+)
+
+conn = pool.get_connection()
+try:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+        cur.fetchone()
+finally:
+    conn.close()                        # returns the connection to the pool (does not really close it)
+```
+
+## See Also
+
+- **`mariadb-connector-c`** — the underlying C client library this module wraps (build-time dependency)
+- **`mariadb-transactions`** / **`mariadb-set-transaction`** — the server-side semantics behind `conn.commit()` / `conn.rollback()` and isolation levels
+- **`mariadb-prepare`** — server-side prepared statements, what `binary=True` uses under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-python>

--- a/agent-skills/granular/connectors/mariadb-connector-r2dbc/SKILL.md
+++ b/agent-skills/granular/connectors/mariadb-connector-r2dbc/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: mariadb-connector-r2dbc
+description: "MariaDB-specific behavior of MariaDB Connector/R2DBC (the `org.mariadb:r2dbc-mariadb` reactive driver implementing the R2DBC SPI) for application code — that the connection URL scheme is `r2dbc:mariadb://user:pw@host:port/db` and factories come from `ConnectionFactories.get(url)` or a `MariadbConnectionConfiguration` builder + `MariadbConnectionFactory`; that placeholders are positional `?` (bound 0-indexed via `.bind(int, value)`) or named `:name` (via `.bind(String, value)`), never mixed with driver-side string interpolation; that NOTHING runs until the `Publisher` returned by `Statement.execute()` (a `Flux<MariadbResult>`) is subscribed, and a `Result` can be consumed exactly once via `.map()` or `getRowsUpdated()`; that `bindNull(index, Class)` needs an explicit type; that `autocommit` defaults to `true` and `useServerPrepStmts` (binary protocol) defaults to `false`; that transactions go through `beginTransaction()`/`commitTransaction()`/`rollbackTransaction()` returning `Mono<Void>` that must itself be subscribed; that connection pooling is not built in and needs `r2dbc-pool`'s `ConnectionPool`/`ConnectionPoolConfiguration`; that calling `.block()` inside a reactive pipeline defeats the whole point and errors surface as `onError` signals (`R2dbcException` subtypes) rather than thrown exceptions; and that `io.r2dbc.spi.Batch` groups distinct un-parameterized SQL strings while `Statement.add()` adds another bound parameter set to the same parameterized SQL. Use when writing or reviewing Java code that talks to MariaDB reactively via R2DBC."
+---
+
+# MariaDB Connector/R2DBC
+
+*Last updated: 2026-07-21*
+
+MariaDB Connector/R2DBC is the official reactive, non-blocking driver for MariaDB implementing the [R2DBC](https://r2dbc.io) SPI — Maven coordinates `org.mariadb:r2dbc-mariadb`. It is **100% pure Java** (Java 8+), built on Reactor and Netty, and does **not** depend on Connector/C. This skill covers the connector-specific behavior and the traps that bite generated application code. It is a separate, independently-versioned sibling of **MariaDB Connector/J** (the blocking JDBC driver, also pure Java) — same vendor, different API paradigm; do not assume JDBC idioms (blocking calls, `try`-with-resources returning a live `ResultSet`) carry over.
+
+> **Default context:** Assume the **1.4** line (`r2dbc-mariadb` 1.4.1) unless the user states otherwise; 1.0 and 1.1 have reached end of life. The connector follows the [R2DBC 1.0.0 spec](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/) (a legacy `r2dbc-mariadb-0.9.1-spec` artifact exists for the older spec). Connector versions are independent of the MariaDB server version.
+
+## What LLMs Often Miss
+
+| If the agent writes / assumes… | …prefer the MariaDB form |
+|---|---|
+| A JDBC-style URL (`jdbc:mariadb://...`) or a bare host string | The R2DBC URL scheme is **`r2dbc:mariadb://[user:pw@]host[:port][,host2...]/db[?opt=val]`** — the registered driver id is `mariadb`. Get a factory with `ConnectionFactories.get(url)`, or build one explicitly: `MariadbConnectionConfiguration.builder()...build()` + `new MariadbConnectionFactory(config)` |
+| `%s`/f-string/concat SQL, or assumes only `?` works | Two placeholder styles, never string-built SQL: positional **`?`** bound by **0-based** index (`.bind(0, val)`), and named **`:name`** bound by name (`.bind("name", val)`). Both are parsed from the same SQL text; pick one style per statement |
+| Expects `execute()` to run the query immediately | `Statement.execute()` returns a **`Flux<MariadbResult>`** (a cold `Publisher`) — **nothing hits the wire until it is subscribed** (`.subscribe()`, `Mono.from(...).block()`, a Reactor operator chain, etc.). Building the statement and calling `execute()` alone does nothing |
+| Reads a `Result` twice, or ignores it after `execute()` | A `Result` is **consume-once, forward-only**: call exactly one of `.map(BiFunction<Row,RowMetadata,T>)` or `.getRowsUpdated()`. Not fully consuming it can leave the corresponding statement incomplete |
+| Binds `null` as a plain value | `.bind(index, null)` is invalid — use **`bindNull(index, Class<?> type)`** (or the named overload) so the driver knows the SQL type to send |
+| Assumes DML needs an explicit commit, or that autocommit is off | **`autocommit` defaults to `true`** — new connections auto-commit each statement. To use transactions, call `setAutoCommit(false)` or explicitly `beginTransaction()` |
+| Expects server-side prepared statements (binary protocol) by default | **`useServerPrepStmts` defaults to `false`** — the text protocol is used (parameters substituted client-side) unless set to `true`, which switches to server-side prepare + a prepare-result LRU cache (`prepareCacheSize`, default 256) |
+| Calls `conn.commit()` / `conn.rollback()` (JDBC-style) | Transactions are reactive: **`beginTransaction()`**, **`commitTransaction()`**, **`rollbackTransaction()`** each return `Mono<Void>` — they are no-ops until subscribed, e.g. `Mono.from(connection.beginTransaction()).block()` or chained into the pipeline |
+| Calls `.block()` inside a reactive chain to "simplify" the code | Blocking a Netty event-loop thread inside the pipeline is the classic reactive anti-pattern — it defeats non-blocking I/O and can deadlock the loop. Compose with `Mono`/`Flux` operators end-to-end; only `.block()` at the outermost boundary (e.g. `main`, a test) |
+| Wraps calls in `try/catch (SQLException)` expecting a thrown exception | Errors are delivered as an **`onError` signal**, not a synchronous throw — subscribe with an error handler (`.doOnError()`, `.onErrorResume()`, etc.). Errors surface as typed `R2dbcException` subclasses (e.g. `R2dbcBadGrammarException`, `R2dbcDataIntegrityViolationException`, `R2dbcTransientResourceException`) derived from the server's SQLSTATE class |
+| Hand-rolls a pool or opens a new connection per request | No pooling is built in — add **`r2dbc-pool`** and wrap the `MariadbConnectionFactory` in `ConnectionPoolConfiguration.builder(factory).maxSize(...).build()` → `new ConnectionPool(poolConfig)`; borrow with `pool.create()`, return by `.close()` |
+| Loops single-row `execute()` calls for a bulk insert | Call **`Statement.add()`** between `.bind()` calls on the *same* parameterized statement to queue another parameter set, then `execute()` once — one round trip covers all bound rows |
+| Uses `io.r2dbc.spi.Batch` expecting parameter binding | `Batch` (`conn.createBatch().add(sql1).add(sql2)...`) groups **distinct, already-literal SQL strings with no parameter binding** — for parameterized bulk operations use `Statement.add()` instead (see above) |
+| Assumes TLS is on by default | `sslMode` defaults to **`DISABLE`** (no TLS) — set it explicitly (`TRUST`/`VERIFY_CA`/`VERIFY_FULL`) for anything beyond local development |
+
+## Connection, query, and result mapping
+
+```java
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.Result;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+ConnectionFactory factory =
+    ConnectionFactories.get("r2dbc:mariadb://app:secret@localhost:3306/appdb");
+
+Flux<String> names = Mono.from(factory.create())
+    .flatMapMany(conn ->
+        Flux.from(conn.createStatement("SELECT name FROM t WHERE qty > ?")
+                .bind(0, 0)          // positional, 0-based
+                .execute())
+            .flatMap(result -> result.map((row, meta) -> row.get("name", String.class)))
+            .concatWith(Mono.from(conn.close()).then(Mono.empty())));
+
+names.subscribe(System.out::println);   // nothing runs before this subscribe
+```
+
+Transactions (manual, reactive — no implicit commit/rollback):
+
+```java
+Mono<Void> work = Mono.from(factory.create())
+    .flatMap(conn -> Mono.from(conn.beginTransaction())
+        .then(Mono.from(conn.createStatement(
+                "INSERT INTO t (name) VALUES (:name)")
+            .bind("name", "widget")
+            .execute()))
+        .flatMap(res -> Mono.from(res.getRowsUpdated()))
+        .then(Mono.from(conn.commitTransaction()))
+        .onErrorResume(e -> Mono.from(conn.rollbackTransaction()).then(Mono.error(e)))
+        .then(Mono.from(conn.close())));
+
+work.block();   // only block at the outermost boundary
+```
+
+## See Also
+
+- **`mariadb-connector-j`** — the blocking JDBC sibling (also pure Java, no Connector/C); use it when the application isn't reactive
+- **`mariadb-transactions`** / **`mariadb-set-transaction`** — server-side semantics behind `beginTransaction()`/`commitTransaction()`/isolation levels
+- **`mariadb-prepare`** — server-side prepared statements, what `useServerPrepStmts=true` uses under the hood
+- Canonical reference on `mariadb.com/docs`, consult for edge cases not covered here: <https://mariadb.com/docs/connectors/mariadb-connector-r2dbc>


### PR DESCRIPTION
## What

Adds a new **`granular/connectors/`** Tier 1 layer to `agent-skills/` with one `SKILL.md` per MariaDB connector, for consumption by the **AI Plugin** — analogous to the existing Server statement/tool skills (DOCS-6206 / DOCS-6287). Registered in `.skills-manifest.json` (`status: draft`) with a per-connector `baseline_version`; README row added.

Focus is **connector *usage*** for building applications (connect, parameterized/prepared statements, result handling, transactions, pooling, batch, error handling, async/reactive) — not installation or server configuration.

## Skills (7)

| Skill | Baseline | Verified against |
|---|---|---|
| `mariadb-connector-python` | 1.1 | `mariadb-connector-python` (C ext / DB API 2.0) |
| `mariadb-connector-j` | 3.5 | `mariadb-connector-j` (pure-Java JDBC) |
| `mariadb-connector-nodejs` | 3.5 | `mariadb-connector-nodejs` (pure JS) |
| `mariadb-connector-odbc` | 3.2 | `mariadb-connector-odbc` (on Connector/C) |
| `mariadb-connector-r2dbc` | 1.4 | `mariadb-connector-r2dbc` (reactive Java) |
| `mariadb-connector-cpp` | 1.0 | `mariadb-connector-cpp` (on Connector/C) |
| `mariadb-connector-c` | 3.4 | `mariadb-connector-c` (`libmariadb`) |

## Method

Connector/Python authored as the pattern-setter, then six parallel source-verifying research agents (one per connector). Every "What LLMs Often Miss" row was checked against the connector's **own source clone** (defaults, option names, API surface, version-since facts), not just the published docs; load-bearing claims were re-verified by hand. All canonical `mariadb.com/docs/connectors/...` URLs return 200; codespell clean; connector versions pinned from each clone's `pom.xml`/`package.json`/`CMakeLists.txt`.

MySQL is named only where it is an unavoidable technical fact (Connector/C's API is literally `mysql_`-prefixed; Connector/J genuinely gates the `jdbc:mysql:` scheme behind `permitMysqlScheme`); rhetorical "unlike MySQL Connector/X" framing was removed per house convention.

## Docs discrepancies surfaced (source vs. published docs — candidates for a DOCS-6343-style accuracy sweep, not fixed here)

- **Node.js** — docs say `bigIntAsNumber` defaults `true`; source defaults it `false` (native BigInt returned by default). Docs also reference a `supportBigInt` option that does not exist in source.
- **Connector/C++** — docs list `cachePrepStmts` as a plain boolean option; on the `cpp-1.0` line, setting it `true` throws `SQLFeatureNotImplementedException` at connect.
- **ODBC** — docs say the driver "primarily uses the binary protocol"; in source that holds only for the `SQLPrepare` path — `SQLExecDirect` defaults to client-side/text.
- **Connector/J** — docs language can be read as implying `setFetchSize(Integer.MIN_VALUE)` is still accepted; current source throws for any negative value.

All skills are `status: draft` pending human verification → promotion to `pilot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)