### PR TITLE
DOCS-6345 Promote connector agent-skills draft -> pilot

### DIFF
--- a/agent-skills/.skills-manifest.json
+++ b/agent-skills/.skills-manifest.json
@@ -73,13 +73,13 @@
       "path": "granular/connectors",
       "author": "docs-team",
       "skills": [
-        { "name": "mariadb-connector-python", "path": "granular/connectors/mariadb-connector-python/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.1" },
-        { "name": "mariadb-connector-j", "path": "granular/connectors/mariadb-connector-j/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
-        { "name": "mariadb-connector-nodejs", "path": "granular/connectors/mariadb-connector-nodejs/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
-        { "name": "mariadb-connector-odbc", "path": "granular/connectors/mariadb-connector-odbc/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.2" },
-        { "name": "mariadb-connector-r2dbc", "path": "granular/connectors/mariadb-connector-r2dbc/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.4" },
-        { "name": "mariadb-connector-cpp", "path": "granular/connectors/mariadb-connector-cpp/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "1.0" },
-        { "name": "mariadb-connector-c", "path": "granular/connectors/mariadb-connector-c/SKILL.md", "status": "draft", "last_reviewed": "2026-07-21", "baseline_version": "3.4" }
+        { "name": "mariadb-connector-python", "path": "granular/connectors/mariadb-connector-python/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.1" },
+        { "name": "mariadb-connector-j", "path": "granular/connectors/mariadb-connector-j/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-nodejs", "path": "granular/connectors/mariadb-connector-nodejs/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.5" },
+        { "name": "mariadb-connector-odbc", "path": "granular/connectors/mariadb-connector-odbc/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.2" },
+        { "name": "mariadb-connector-r2dbc", "path": "granular/connectors/mariadb-connector-r2dbc/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.4" },
+        { "name": "mariadb-connector-cpp", "path": "granular/connectors/mariadb-connector-cpp/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "1.0" },
+        { "name": "mariadb-connector-c", "path": "granular/connectors/mariadb-connector-c/SKILL.md", "status": "pilot", "last_reviewed": "2026-07-21", "baseline_version": "3.4" }
       ]
     },
     "topical": {


### PR DESCRIPTION
Manifest-only follow-up to #767. Flips the seven `granular/connectors/` skills (`mariadb-connector-{python, j, nodejs, odbc, r2dbc, cpp, c}`) from `status: draft` to `status: pilot` now that they've been reviewed. No content changes; the other (Server-wave) draft entries are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)