### PR TITLE
DOCS-4583: note third-party status of AD-capable PAM modules

### DIFF
--- a/server/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md
+++ b/server/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/authentication-plugin-pam.md
@@ -340,7 +340,11 @@ Even when using the `pam` authentication plugin, the authenticating PAM user acc
 
 ## PAM Modules
 
-There are many PAM modules. The ones described below are the ones that have been seen most often by MariaDB.
+There are many PAM modules. The ones described below are the ones that have been seen most often by MariaDB. Several of them — including [pam\_sss](authentication-plugin-pam.md#pam_sss), [pam\_winbind](authentication-plugin-pam.md#pam_winbind), [pam\_lsass](authentication-plugin-pam.md#pam_lsass), [pam\_centrifydc](authentication-plugin-pam.md#pam_centrifydc), and [pam\_krb5](authentication-plugin-pam.md#pam_krb5) — can authenticate against Microsoft Active Directory.
+
+{% hint style="info" %}
+MariaDB supports the `pam` authentication plugin itself, not the individual PAM modules described below. These modules are third-party software, and the links to their documentation are provided for convenience only. MariaDB doesn't test, validate, or maintain them and can't list specific modules as officially supported. Consult each module's own documentation, and validate the configuration in your environment before relying on it in production.
+{% endhint %}
 
 ### pam\_unix
 


### PR DESCRIPTION
## What

Support asked (via DOCS-4583) which Active Directory–compatible PAM modules MariaDB officially supports, and for AD setup instructions.

Per Ralf Gebhardt's ruling on the ticket ([comment 1102156](https://mariadbcorp.atlassian.net/browse/DOCS-4583?focusedCommentId=1102156), backed by his 2023 comment): MariaDB covers only the `pam` authentication **plugin**, not the third-party PAM **modules**; listing "supported" modules would require an integration-QA effort to test them all. *"The maximum we should do is adding links to external resources with a note that we are not validating their content."*

## Change

One page — `authentication-plugin-pam.md`, the **PAM Modules** section:

- Added an intro pointer noting that several listed modules (`pam_sss`, `pam_winbind`, `pam_lsass`, `pam_centrifydc`, `pam_krb5`) can authenticate against Microsoft Active Directory (directly answering the ticket's AD framing; these modules and their external links were already documented).
- Added an `info` hint stating MariaDB supports the plugin itself, that the modules are third-party, that MariaDB doesn't test/validate/maintain them and can't list any as officially supported, and that the external links are for convenience only — enacting exactly what comment 1102156 authorizes.

No new external instructions written; no module claimed as supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)