### PR TITLE
DOCS-6351 Convert Galera PNG diagrams to inline Mermaid (pilot)

### DIFF
--- a/galera-cluster/high-availability/monitoring-mariadb-galera-cluster.md
+++ b/galera-cluster/high-availability/monitoring-mariadb-galera-cluster.md
@@ -37,7 +37,29 @@ You can monitor the status of individual nodes to ensure they are in working ord
 
 ## Understanding Galera Node States
 
-<div align="left"><figure><img src="../.gitbook/assets/galerafsm.png" alt=""><figcaption></figcaption></figure></div>
+```mermaid
+stateDiagram-v2
+    accTitle: Galera Cluster node state machine
+    accDescr {
+        A Galera node progresses through six states. From OPEN it joins the Primary
+        Component (1), becomes a JOINER while it requests a state transfer (2), then
+        JOINED once the transfer completes and it applies queued transactions (3). It
+        reaches SYNCED when fully caught up and operational (4). A SYNCED node may
+        become a DONOR to serve a State Snapshot Transfer to another node (5),
+        returning to JOINED afterward (6) before it syncs again.
+    }
+    [*] --> OPEN
+    OPEN --> PRIMARY: 1
+    PRIMARY --> JOINER: 2
+    JOINER --> JOINED: 3
+    JOINED --> SYNCED: 4
+    SYNCED --> DONOR: 5
+    DONOR --> JOINED: 6
+    classDef synced fill:#fff3a5,stroke:#333,stroke-width:2px,color:#111;
+    class SYNCED synced
+```
+
+_Galera node state transitions. `SYNCED` (highlighted) is the healthy, fully operational state._
 
 The value of `wsrep_local_state_comment` tells you exactly what a node is doing. The most common states include:
 

--- a/galera-cluster/readme/mariadb-galera-cluster-usage-guide.md
+++ b/galera-cluster/readme/mariadb-galera-cluster-usage-guide.md
@@ -23,7 +23,33 @@ Database replication is the process of continuously copying data from one databa
 
 #### **Primary/Replica**
 
-<div align="left"><figure><img src="../.gitbook/assets/asynchronousreplication.png" alt=""><figcaption><p>Primary/Primary Replication</p></figcaption></figure></div>
+```mermaid
+flowchart TD
+    accTitle: Primary/Replica replication
+    accDescr {
+        A client sends a write (transaction A) to the Primary node, which commits it
+        locally. The Primary then propagates transaction A through the replication layer
+        to one or more Replica nodes, which apply the same transaction to their own copy
+        of the data.
+    }
+    Client["Client<br/>writes trx A"]
+    Primary[("Primary<br/>trx A")]
+    Replica1[("Replica<br/>trx A")]
+    Replica2[("Replica<br/>trx A")]
+    Repl["Replication"]
+    Client --> Primary
+    Primary --> Repl
+    Repl --> Replica1
+    Repl --> Replica2
+    classDef primary fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#111;
+    classDef replica fill:#fff3cd,stroke:#ffc107,stroke-width:2px,color:#111;
+    classDef node fill:#f5f5f5,stroke:#333,stroke-width:1px,color:#111;
+    class Primary primary
+    class Replica1,Replica2 replica
+    class Client,Repl node
+```
+
+_Primary/Replica replication: one node accepts writes and propagates them to the replicas._
 
 The most common replication architecture is Primary/Replica (also known as Master/Slave). In this model:
 
@@ -33,7 +59,37 @@ The most common replication architecture is Primary/Replica (also known as Maste
 
 #### **Multi-Primary Replication**
 
-<div align="left"><figure><img src="../.gitbook/assets/synchronousreplication.png" alt=""><figcaption><p>Multi-primary Replication</p></figcaption></figure></div>
+```mermaid
+flowchart TD
+    accTitle: Multi-primary (synchronous) replication
+    accDescr {
+        Client applications connect transparently to any of three DBMS nodes. Every node
+        is a primary and accepts writes. All nodes are kept consistent by a synchronous
+        replication layer that applies each transaction on every node, so a commit is
+        confirmed only once the data exists on all of them.
+    }
+    subgraph Clients [Clients]
+        C1["Client"]
+        C2["Client"]
+        C3["Client"]
+    end
+    N1[("DBMS")]
+    N2[("DBMS")]
+    N3[("DBMS")]
+    Repl["Replication"]
+    C1 <--> N1
+    C2 <--> N2
+    C3 <--> N3
+    N1 <--> Repl
+    N2 <--> Repl
+    N3 <--> Repl
+    classDef node fill:#fff3cd,stroke:#ffc107,stroke-width:2px,color:#111;
+    classDef bar fill:#f5f5f5,stroke:#333,stroke-width:1px,color:#111;
+    class N1,N2,N3 node
+    class Repl bar
+```
+
+_Multi-primary replication: every node accepts writes and stays consistent through synchronous replication._
 
 In a multi-primary system, every node in the cluster acts as a primary. This means any node can accept write operations. When a node receives an update, it automatically propagates that change to all other primary nodes in the cluster. Each primary node logs its own changes and communicates them to its peers to maintain synchronization.
 


### PR DESCRIPTION
## What

Pilot for [DOCS-6351](https://mariadbcorp.atlassian.net/browse/DOCS-6351) — converting PNG diagram attachments in the docs to inline Mermaid. This PR converts **three** Galera PNGs across two pages so we can eyeball fidelity + the accessibility pattern before scaling to a campaign.

| PNG | → Mermaid | Page |
|-----|-----------|------|
| `galerafsm.png` | `stateDiagram-v2` | Monitoring MariaDB Galera Cluster |
| `asynchronousreplication.png` | `flowchart` (Primary/Replica) | Galera Cluster usage guide |
| `synchronousreplication.png` | `flowchart` (multi-primary) | Galera Cluster usage guide |

## Accessibility pattern (new convention for the campaign)

- **`accTitle:` + `accDescr { … }`** inside each diagram → embedded in the SVG `<title>`/`<desc>` for screen readers. (The original PNGs had **empty `alt` text**, so they were previously inaccessible.)
- **Visible italic caption** under each diagram → benefits all readers, replaces the old `<figcaption>`.
- Explicit high-contrast `style`/`classDef` for light + dark themes, matching existing house style.

## Incidental fix

The Primary/Replica figure was captioned **"Primary/Primary Replication"** — corrected during conversion.

## Notes

- The three source PNGs are now unreferenced; leaving them in-tree for this pilot (asset cleanup will be handled as part of the campaign).
- Full inventory: **116 schematic diagrams** across the docs (65 easy / 30 moderate / 21 hard to convert). Details in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6351]: https://mariadbcorp.atlassian.net/browse/DOCS-6351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ