### PR TITLE
Exclude flaky/example external hosts from lychee link-check

### DIFF
--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -31,6 +31,10 @@ jobs:
         uses: lycheeverse/lychee-action@v2.3.0
         with:
           # ADDED: Excludes for both raw '{' and encoded '%7B'
+          # Flaky/example external hosts (bottom of the list): mcs1 is a
+          # placeholder hostname in ColumnStore cmapi curl samples; the rest
+          # time out, rate-limit (429), or return cert errors from CI but are
+          # otherwise valid links.
           args: >-
             --no-progress
             --exclude dev\.mysql\.com
@@ -63,6 +67,11 @@ jobs:
             --exclude www\.canonware\.com
             --exclude www\.npmjs\.com
             --exclude npmjs\.org
+            --exclude mcs1
+            --exclude s\.petrunia\.net
+            --exclude mysql\.taobao\.org
+            --exclude www\.shannon-sys\.com
+            --exclude www\.hashicorp\.com
             ${{ steps.changes.outputs.all_changed_files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee


### PR DESCRIPTION
## What

Adds five hosts to the lychee exclude list in `link-check-pr.yml`:

| Host | Why |
|------|-----|
| `mcs1` | Placeholder hostname in ColumnStore cmapi `curl` samples — never meant to resolve |
| `s.petrunia.net` | Intermittent cert/network error |
| `mysql.taobao.org` | Times out from CI |
| `www.shannon-sys.com` | Times out from CI |
| `www.hashicorp.com` | Rate-limits CI with HTTP 429 |

## Why

These are pre-existing links scattered across many pages on `main`. They surfaced on **#777** (PNG→Mermaid conversion) only because lychee re-checks the *full content* of any changed file — none were introduced by that PR, and they aren't broken from a reader's perspective (they're example hosts, or valid hosts that time out / rate-limit / throw cert errors specifically from CI).

Added at the bottom of the existing per-host exclude list, matching the established pattern (`www.mysql.com`, `linux.die.net`, etc.).

## Deliberately *not* excluded

- `www.anchormodeling.com/.../SU_KTH_Course_Presentation.pdf` — a genuine **404**; should be fixed/removed in a separate broken-link sweep, not hidden.
- `broken-reference` — the endemic GitBook migration artifact (~279 files); left unexcluded by long-standing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)