### PR TITLE
docs: fix broken cross-space GitBook links in MaxScale space

### DIFF
--- a/maxscale/mariadb-maxscale-tutorials/using-keepalived-with-mariadb-maxscale.md
+++ b/maxscale/mariadb-maxscale-tutorials/using-keepalived-with-mariadb-maxscale.md
@@ -23,7 +23,7 @@ cluster manipulation operations. Cooperative monitoring only affects MaxScale
 itself; it does not control which MaxScale the application talks to. Both
 MaxScales process queries equally. The application can utilize multiple
 MaxScales with a connector that supports connection failover, e.g.
-[Connector/J](https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver)
+[Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver)
 
 The setup described above is not applicable to all situations:
 

--- a/maxscale/maxscale-management/deployment/upgrading-maxscale/upgrade-to-maxscale-25.01.md
+++ b/maxscale/maxscale-management/deployment/upgrading-maxscale/upgrade-to-maxscale-25.01.md
@@ -7,7 +7,7 @@ description: >-
 
 # Upgrade to MaxScale 25.01
 
-These instructions detail the upgrade to **MariaDB MaxScale 25.01** in a **MaxScale Instance** configuration on a range of [supported Operating Systems](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/architecture/topologies/compatibility).
+These instructions detail the upgrade to **MariaDB MaxScale 25.01** in a **MaxScale Instance** configuration on a range of [supported Operating Systems](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/architecture/topologies/compatibility).
 
 MariaDB MaxScale is an advanced database proxy and query router.
 
@@ -15,7 +15,7 @@ MariaDB MaxScale is an advanced database proxy and query router.
 
 | Term              | Definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MaxScale instance | <ul><li>MariaDB MaxScale running by itself on a single host.</li><li>It interacts with other hosts, such as deployments using <a href="https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication">MariaDB Replication</a>, <a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/">Galera Cluster</a>, and <a href="https://app.gitbook.com/s/rBEU9juWLfTDcdwF3Q14/mariadb-columnstore">ColumnStore</a>.</li><li>It serves as the database proxy and load balancer.</li></ul> |
+| MaxScale instance | <ul><li>MariaDB MaxScale running by itself on a single host.</li><li>It interacts with other hosts, such as deployments using <a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication">MariaDB Replication</a>, <a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/">Galera Cluster</a>, and <a href="https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/rBEU9juWLfTDcdwF3Q14/mariadb-columnstore">ColumnStore</a>.</li><li>It serves as the database proxy and load balancer.</li></ul> |
 | upgrade           | <ul><li>A change from lower-versioned release of MariaDB MaxScale to a higher-versioned release of MariaDB MaxScale.</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ## Backing Up Configuration
@@ -70,7 +70,7 @@ Retrieve your Customer Download Token at [https://customers.mariadb.com/download
 {% step %}
 **Configure YUM / DNF package repository**
 
-Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
+Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
 
 To configure YUM package repositories:
 
@@ -121,7 +121,7 @@ Retrieve your Customer Download Token at [https://customers.mariadb.com/download
 {% step %}
 **Configure APT package repository**
 
-Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
+Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
 
 To configure APT package repositories:
 
@@ -176,7 +176,7 @@ Retrieve your Customer Download Token at [https://customers.mariadb.com/download
 {% step %}
 **Configure ZYpp package repository**
 
-Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
+Pass the version you want to install using the `--mariadb-maxscale-version` flag to the [mariadb\_es\_repo\_setup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) script. The following directions reference `25.01`.
 
 To configure ZYpp package repositories:
 

--- a/maxscale/maxscale-management/maxscale-troubleshooting.md
+++ b/maxscale/maxscale-management/maxscale-troubleshooting.md
@@ -246,7 +246,7 @@ JournalSizeMax=1G
 #KeepFree=
 ```
 
-Read the MariaDB documentation for [enabling core dumps](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/product-development/mariadb-fault-finding/enabling-core-dumps) and [how to produce a full stack trace for mysqld](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/product-development/mariadb-fault-finding/how-to-produce-a-full-stack-trace-for-mariadbd). Most of the operating system level documentation applies to MaxScale as well except that MaxScale is always run as a SystemD service and it only supports Linux as the platform.
+Read the MariaDB documentation for [enabling core dumps](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/product-development/debugging-mariadb/enabling-core-dumps) and [how to produce a full stack trace for mysqld](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/product-development/debugging-mariadb/how-to-produce-a-full-stack-trace-for-mariadbd). Most of the operating system level documentation applies to MaxScale as well except that MaxScale is always run as a SystemD service and it only supports Linux as the platform.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/maxscale/maxscale-security/securing-your-maxscale-deployment.md
+++ b/maxscale/maxscale-security/securing-your-maxscale-deployment.md
@@ -70,7 +70,7 @@ To properly secure the MaxScale REST-API, enable TLS encryption for data in tran
 
 **1. Generate SSL key and certificate:**
 
-* See [Certificate Creation with OpenSSL](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/securing-mariadb/encryption/data-in-transit-encryption/certificate-creation-with-openssl.md) for information on certificate creation.
+* See [Certificate Creation with OpenSSL](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl) for information on certificate creation.
 * Move the generated files to a secure location MaxScale can access.
 
 **2. Update MaxScale configuration:**
@@ -132,7 +132,7 @@ admin_audit_file = /var/log/maxscale/audit_files/audit.csv
 
 This configuration activates auditing and specifies the location of the audit file. Ensure that the specified directory exists before restarting MaxScale.
 
-Implement log rotation to manage the size and number of audit files. This can be achieved using standard Linux log rotation tools. See [Rotating Logs on Unix and Linux](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/rotating-logs-on-unix-and-linux.md)
+Implement log rotation to manage the size and number of audit files. This can be achieved using standard Linux log rotation tools. See [Rotating Logs on Unix and Linux](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/rotating-logs-on-unix-and-linux)
 
 For manual log rotation, use the following MaxCtrl command:
 
@@ -179,7 +179,7 @@ ssl_ca=/certs/my_ca_cert.pem
 
 ### Encrypt Outgoing Database Connections
 
-Outgoing database connections are the connections MaxScale makes to MariaDB Servers on behalf of incoming clients. If MaxScale and the servers are running in the same network, and you consider the network already secure, then encrypting these connections may not be necessary. If this is not the case, both MaxScale and the servers need to be configured to use TLS. To configure MariaDB Server for encryption, see [Secure Connections Overview](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/security/securing-mariadb/encryption/data-in-transit-encryption/secure-connections-overview.md).
+Outgoing database connections are the connections MaxScale makes to MariaDB Servers on behalf of incoming clients. If MaxScale and the servers are running in the same network, and you consider the network already secure, then encrypting these connections may not be necessary. If this is not the case, both MaxScale and the servers need to be configured to use TLS. To configure MariaDB Server for encryption, see [Secure Connections Overview](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/secure-connections-overview).
 
 To enable MaxScale to connect securely to MariaDB Servers:
 

--- a/maxscale/reference/maxscale-authenticators/maxscale-ed25519-authenticator.md
+++ b/maxscale/reference/maxscale-authenticators/maxscale-ed25519-authenticator.md
@@ -11,7 +11,7 @@ description: >-
 
 Ed25519 is a highly secure authentication method based on public key cryptography. It is used with the `auth_ed25519` plugin of MariaDB Server.
 
-When a client authenticates via ed25519, MaxScale first sends them a random message. The client signs the message using their password as private key and sends the signature back. MaxScale then checks the signature using the public key fetched from the `mysql.user` table. The client password or an equivalent token is never exposed. For more information, see the [ed25519 plugin](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519) documentation.
+When a client authenticates via ed25519, MaxScale first sends them a random message. The client signs the message using their password as private key and sends the signature back. MaxScale then checks the signature using the public key fetched from the `mysql.user` table. The client password or an equivalent token is never exposed. For more information, see the [ed25519 plugin](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/plugins/authentication-plugins/authentication-plugin-ed25519) documentation.
 
 The security of this authentication scheme presents a problem for a proxy such as MaxScale since MaxScale needs to log in to backend servers on behalf of the client. Since each server generates their own random messages, MaxScale cannot simply forward the original signature. Either the real password is required, or a different authentication scheme must be used between MaxScale and backends. The MaxScale `ed25519auth` plugin supports both alternatives.
 


### PR DESCRIPTION
## What

A user reported (via Salesforce) that the **Secure Connections Overview** link on `maxscale/maxscale-security/securing-your-maxscale-deployment.md` sends readers to a private `app.gitbook.com` URL instead of the public docs page.

Root cause: the link used the malformed alias form `https://app.gitbook.com/s/<spaceId>/…`, which omits the `/o/diTpXxF5WsbHqTReoBsS/` org segment. The `expand-gitbook-aliases` Action only recognizes the full `/o/<org>/s/<space>/…` alias, so these were left as raw internal URLs. Sweeping the rest of the MaxScale space (non-archive) found the same defect on other pages.

## Changes

Fixed **9 cross-space links across 5 files** — added the missing org segment, and corrected two stale target paths encountered along the way:

- `security/securing-mariadb/encryption/…` → `security/encryption/…`
- `reference/product-development/mariadb-fault-finding/…` → `reference/product-development/debugging-mariadb/…`

| File | Links |
|------|-------|
| `maxscale-security/securing-your-maxscale-deployment.md` | Certificate Creation with OpenSSL; Rotating Logs; **Secure Connections Overview** (reported) |
| `maxscale-management/maxscale-troubleshooting.md` | enabling core dumps; full stack trace (both also path-corrected) |
| `maxscale-management/deployment/upgrading-maxscale/upgrade-to-maxscale-25.01.md` | supported OS; standard replication; ColumnStore; 3× repo-setup |
| `mariadb-maxscale-tutorials/using-keepalived-with-mariadb-maxscale.md` | Connector/J failover |
| `reference/maxscale-authenticators/maxscale-ed25519-authenticator.md` | ed25519 plugin |

The legit `{% include %}` reusable-content block in `upgrading-maxscale/README.md` was left untouched.

All target paths verified to exist on disk. No DOCS ticket (per request). `docs-check` (codespell + lychee + structural) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)