### PR TITLE
DOCS-6349 Document account matching for privilege checks

### DIFF
--- a/server/reference/sql-statements/account-management-sql-statements/create-user.md
+++ b/server/reference/sql-statements/account-management-sql-statements/create-user.md
@@ -366,8 +366,9 @@ The following table shows a list of example account as sorted by these criteria:
 +---------+-------------+
 ```
 
-Once connected, you only have the privileges granted on a particular object to the account that matched, not all accounts that could have matched. For example, consider the following\
-commands:
+The account that matched determines your identity and your global privileges. Privileges below the global level are looked up separately, and at each level only the most specific matching grant applies — grants belonging to less specific accounts are not added to it. For the full rule, see [Account Name Matching for Privilege Checks](grant.md#account-name-matching-for-privilege-checks) on the `GRANT` page.
+
+For example, consider the following commands:
 
 ```sql
 CREATE USER 'joffrey'@'192.168.0.3';
@@ -376,7 +377,9 @@ GRANT SELECT ON test.t1 TO 'joffrey'@'192.168.0.3';
 GRANT INSERT ON test.t1 TO 'joffrey'@'%';
 ```
 
-If you connect as joffrey from `192.168.0.3`, you will have the `SELECT` privilege on the table `test.t1`, but not INSERT. If you connect as joffrey from any other IP address, you will have the `INSERT` privilege on the table `test.t1`, but not `SELECT`.
+If you connect as joffrey from `192.168.0.3`, you will have the `SELECT` privilege on the table `test.t1`, but not `INSERT`. If you connect as joffrey from any other IP address, you will have the `INSERT` privilege on the table `test.t1`, but not `SELECT`.
+
+If the matching account has no grant at all at a given level, a grant belonging to a less specific account can still apply. Without the `test.t1` grant to `'joffrey'@'192.168.0.3'`, the grant to `'joffrey'@'%'` would be the only match, and a connection from `192.168.0.3` would have the `INSERT` privilege on `test.t1`.
 
 Usernames can be up to 80 characters long before 10.6 and starting from 10.6 it can be 128 characters long.
 

--- a/server/reference/sql-statements/account-management-sql-statements/create-user.md
+++ b/server/reference/sql-statements/account-management-sql-statements/create-user.md
@@ -366,8 +366,9 @@ The following table shows a list of example account as sorted by these criteria:
 +---------+-------------+
 ```
 
-Once connected, you only have the privileges granted on a particular object to the account that matched, not all accounts that could have matched. For example, consider the following
-commands:
+The account that matched determines your identity and your global privileges. Privileges below the global level are looked up separately, and at each level only the most specific matching grant applies — grants belonging to less specific accounts are not added to it. For the full rule, see [Account Name Matching for Privilege Checks](grant.md#account-name-matching-for-privilege-checks) on the `GRANT` page.
+
+For example, consider the following commands:
 
 ```sql
 CREATE USER 'joffrey'@'192.168.0.3';
@@ -376,7 +377,9 @@ GRANT SELECT ON test.t1 TO 'joffrey'@'192.168.0.3';
 GRANT INSERT ON test.t1 TO 'joffrey'@'%';
 ```
 
-If you connect as joffrey from `192.168.0.3`, you will have the `SELECT` privilege on the table `test.t1`, but not INSERT. If you connect as joffrey from any other IP address, you will have the `INSERT` privilege on the table `test.t1`, but not `SELECT`.
+If you connect as joffrey from `192.168.0.3`, you will have the `SELECT` privilege on the table `test.t1`, but not `INSERT`. If you connect as joffrey from any other IP address, you will have the `INSERT` privilege on the table `test.t1`, but not `SELECT`.
+
+If the matching account has no grant at all at a given level, a grant belonging to a less specific account can still apply. Without the `test.t1` grant to `'joffrey'@'192.168.0.3'`, the grant to `'joffrey'@'%'` would be the only match, and a connection from `192.168.0.3` would have the `INSERT` privilege on `test.t1`.
 
 Usernames can be up to 80 characters long before 10.6 and starting from 10.6 it can be 128 characters long.
 

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -116,6 +116,68 @@ Use the [SHOW GRANTS](../administrative-sql-statements/show/show-grants.md) stat
 
 For `GRANT` statements, account names are specified as the `username` argument in the same way as they are for [CREATE USER](create-user.md) statements. See [account names](create-user.md#account-names) from the `CREATE USER` page for details on how account names are specified.
 
+#### Account Name Matching for Privilege Checks
+
+An account is a user name together with a host pattern, and the two parts are matched at two different times.
+
+When a client connects, MariaDB selects exactly one account: the one whose user name matches exactly and whose host pattern is the most specific match for the client's host. That account authenticates the connection, it is what [CURRENT\_USER()](../../sql-functions/secondary-functions/information-functions/current_user.md) returns, and its row in the [mysql.global\_priv table](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md) is the only source of the connection's global privileges. For the rules that decide which account is the most specific match, see [account names](create-user.md#account-names) on the `CREATE USER` page.
+
+Privileges below the global level are resolved separately. For each level, MariaDB searches that level's grant table again, using the user name of the account that authenticated the connection together with the host the client actually connected from. The host pattern of the account itself is not used:
+
+* Database privileges are matched in the [mysql.db table](../../system-tables/the-mysql-database-tables/mysql-db-table.md).
+* Table privileges are matched in the [mysql.tables\_priv table](../../system-tables/the-mysql-database-tables/mysql-tables_priv-table.md).
+* Column privileges are matched in the [mysql.columns\_priv table](../../system-tables/the-mysql-database-tables/mysql-columns_priv-table.md).
+
+At each of these levels, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
+
+A privilege granted to one account can therefore apply to a connection that authenticated as a different account with the same user name:
+
+```sql
+CREATE USER foo@localhost;
+CREATE USER foo@'%';
+CREATE DATABASE db;
+CREATE TABLE db.t1 (a INT);
+INSERT INTO db.t1 VALUES (1),(2),(3);
+GRANT SELECT ON db.* TO foo@'%';
+```
+
+Connecting as `foo` from the local host authenticates as `foo@localhost`, because `localhost` is a more specific match than `%`:
+
+```sql
+SELECT CURRENT_USER();
+```
+
+```
++----------------+
+| CURRENT_USER() |
++----------------+
+| foo@localhost  |
++----------------+
+```
+
+No privilege was granted to `foo@localhost`, but the `mysql.db` entry granted to `foo@'%'` matches, because `%` matches the host the client connected from. The `SELECT` succeeds:
+
+```sql
+SELECT * FROM db.t1;
+```
+
+Granting any database privilege to `foo@localhost` changes the result. The `mysql.db` table then holds a more specific matching entry, and that entry applies instead of the one granted to `foo@'%'`, not in addition to it:
+
+```sql
+GRANT INSERT ON db.* TO foo@localhost;
+SELECT * FROM db.t1;
+```
+
+```
+ERROR 1142 (42000): SELECT command denied to user 'foo'@'localhost' for table `db`.`t1`
+```
+
+Global privileges do not work this way. They come only from the account that authenticated the connection, so a global privilege granted to `foo@'%'` has no effect on a connection that authenticated as `foo@localhost`.
+
+{% hint style="info" %}
+[SHOW GRANTS](../administrative-sql-statements/show/show-grants.md) lists the privileges recorded for the account that authenticated the connection. Privileges that reach the connection through an entry belonging to another account, as in the example above, are not listed, so `SHOW GRANTS` can report fewer privileges than the connection actually has.
+{% endhint %}
+
 #### Database Name Wildcard Matching Order
 
 When multiple `GRANT` entries match a database name (since database names in `GRANT` can contain `%` and `_` wildcards), MariaDB applies the most specific matching grant. Specificity is determined by how many database names a pattern can match, a pattern matching fewer databases is more specific and takes precedence.

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -120,6 +120,68 @@ From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), a privilege blo
 
 For `GRANT` statements, account names are specified as the `username` argument in the same way as they are for [CREATE USER](create-user.md) statements. See [account names](create-user.md#account-names) from the `CREATE USER` page for details on how account names are specified.
 
+#### Account Name Matching for Privilege Checks
+
+An account is a user name together with a host pattern, and the two parts are matched at two different times.
+
+When a client connects, MariaDB selects exactly one account: the one whose user name matches exactly and whose host pattern is the most specific match for the client's host. That account authenticates the connection, it is what [CURRENT\_USER()](../../sql-functions/secondary-functions/information-functions/current_user.md) returns, and its row in the [mysql.global\_priv table](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md) is the only source of the connection's global privileges. For the rules that decide which account is the most specific match, see [account names](create-user.md#account-names) on the `CREATE USER` page.
+
+Privileges below the global level are resolved separately. For each level, MariaDB searches that level's grant table again, using the user name of the account that authenticated the connection together with the host the client actually connected from. The host pattern of the account itself is not used:
+
+* Database privileges are matched in the [mysql.db table](../../system-tables/the-mysql-database-tables/mysql-db-table.md).
+* Table privileges are matched in the [mysql.tables\_priv table](../../system-tables/the-mysql-database-tables/mysql-tables_priv-table.md).
+* Column privileges are matched in the [mysql.columns\_priv table](../../system-tables/the-mysql-database-tables/mysql-columns_priv-table.md).
+
+At each of these levels, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
+
+A privilege granted to one account can therefore apply to a connection that authenticated as a different account with the same user name:
+
+```sql
+CREATE USER foo@localhost;
+CREATE USER foo@'%';
+CREATE DATABASE db;
+CREATE TABLE db.t1 (a INT);
+INSERT INTO db.t1 VALUES (1),(2),(3);
+GRANT SELECT ON db.* TO foo@'%';
+```
+
+Connecting as `foo` from the local host authenticates as `foo@localhost`, because `localhost` is a more specific match than `%`:
+
+```sql
+SELECT CURRENT_USER();
+```
+
+```
++----------------+
+| CURRENT_USER() |
++----------------+
+| foo@localhost  |
++----------------+
+```
+
+No privilege was granted to `foo@localhost`, but the `mysql.db` entry granted to `foo@'%'` matches, because `%` matches the host the client connected from. The `SELECT` succeeds:
+
+```sql
+SELECT * FROM db.t1;
+```
+
+Granting any database privilege to `foo@localhost` changes the result. The `mysql.db` table then holds a more specific matching entry, and that entry applies instead of the one granted to `foo@'%'`, not in addition to it:
+
+```sql
+GRANT INSERT ON db.* TO foo@localhost;
+SELECT * FROM db.t1;
+```
+
+```
+ERROR 1142 (42000): SELECT command denied to user 'foo'@'localhost' for table `db`.`t1`
+```
+
+Global privileges do not work this way. They come only from the account that authenticated the connection, so a global privilege granted to `foo@'%'` has no effect on a connection that authenticated as `foo@localhost`.
+
+{% hint style="info" %}
+[SHOW GRANTS](../administrative-sql-statements/show/show-grants.md) lists the privileges recorded for the account that authenticated the connection. Privileges that reach the connection through an entry belonging to another account, as in the example above, are not listed, so `SHOW GRANTS` can report fewer privileges than the connection actually has.
+{% endhint %}
+
 #### Database Name Wildcard Matching Order
 
 When multiple `GRANT` entries match a database name (since database names in `GRANT` can contain `%` and `_` wildcards), MariaDB applies the most specific matching grant. Specificity is determined by how many database names a pattern can match, a pattern matching fewer databases is more specific and takes precedence.

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -127,8 +127,9 @@ Privileges below the global level are resolved separately. For each level, Maria
 * Database privileges are matched in the [mysql.db table](../../system-tables/the-mysql-database-tables/mysql-db-table.md).
 * Table privileges are matched in the [mysql.tables\_priv table](../../system-tables/the-mysql-database-tables/mysql-tables_priv-table.md).
 * Column privileges are matched in the [mysql.columns\_priv table](../../system-tables/the-mysql-database-tables/mysql-columns_priv-table.md).
+* Function and procedure privileges are matched in the [mysql.procs\_priv table](../../system-tables/the-mysql-database-tables/mysql-procs_priv-table.md).
 
-At each of these levels, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
+Each of these tables is searched independently, so the account whose privileges apply can differ from one level to the next. At each level, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
 
 A privilege granted to one account can therefore apply to a connection that authenticated as a different account with the same user name:
 

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -131,8 +131,9 @@ Privileges below the global level are resolved separately. For each level, Maria
 * Database privileges are matched in the [mysql.db table](../../system-tables/the-mysql-database-tables/mysql-db-table.md).
 * Table privileges are matched in the [mysql.tables\_priv table](../../system-tables/the-mysql-database-tables/mysql-tables_priv-table.md).
 * Column privileges are matched in the [mysql.columns\_priv table](../../system-tables/the-mysql-database-tables/mysql-columns_priv-table.md).
+* Function and procedure privileges are matched in the [mysql.procs\_priv table](../../system-tables/the-mysql-database-tables/mysql-procs_priv-table.md).
 
-At each of these levels, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
+Each of these tables is searched independently, so the account whose privileges apply can differ from one level to the next. At each level, the single most specific matching entry applies, and it applies on its own. Entries with less specific host patterns are not merged into it.
 
 A privilege granted to one account can therefore apply to a connection that authenticated as a different account with the same user name:
 


### PR DESCRIPTION
Closes [DOCS-6349](https://mariadbcorp.atlassian.net/browse/DOCS-6349) (reported by Sergei Golubchik).

The `GRANT` page covered database-name matching but never explained user/host account matching, leaving this unexplained:

```sql
CREATE USER foo@localhost;
CREATE USER foo@'%';
GRANT SELECT ON db.* TO foo@'%';
-- connect as foo from localhost -> authenticates as foo@localhost
SELECT * FROM db.t1;   -- succeeds
```

## Why it happens

Only **global** privileges come from the account that authenticated the connection. Database, table, and column privileges are each resolved by a *separate* lookup keyed on the client's **actual host/IP** plus the account's **user name** — the authenticated account's host pattern is not used there. At each level the single most specific matching entry applies **instead of**, not in addition to, the less specific ones.

## Changes

* **`grant.md`** — new `#### Account Name Matching for Privilege Checks` section under *Account Names*, alongside the existing *Database Name Wildcard Matching Order*. Covers the two-stage matching, the per-level grant tables, the worked example above, the follow-on case where granting to `foo@localhost` *removes* the inherited `SELECT`, and a hint that `SHOW GRANTS` can under-report effective privileges.
* **`create-user.md`** — corrects a sentence that stated the opposite rule: *"Once connected, you only have the privileges granted on a particular object to the account that matched, not all accounts that could have matched."* That is wrong whenever the matched account has no grant at that level. The existing `joffrey` example is accurate and is kept; the missing case is added.

## Verification

Every claim checked against `mariadb-server` `main` @ `df64bf81` (13.1.0) — key lines `sql/sql_acl.cc:4649` (db level), `:10183` (table/column), `:14189-14197` (global), `:11213-11218` (`SHOW GRANTS`) — and reproduced empirically on MariaDB 12.3.2, including the global-vs-database contrast (`RELOAD` granted only to `qux@'%'` is denied to a `qux@localhost` session, while `SELECT ON db.*` granted the same way is allowed).

Full fact-check report (11 claims, 10 VERIFIED / 1 CORRECTED) is attached to the Jira ticket at handoff.

## Note

Routine-level (`FUNCTION`/`PROCEDURE`) checks use `sctx->priv_host` rather than the client's actual host, unlike every other level. That asymmetry is deliberately **not** documented here pending confirmation from Sergei that it is intended — [asked on the ticket](https://mariadbcorp.atlassian.net/browse/DOCS-6349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6349]: https://mariadbcorp.atlassian.net/browse/DOCS-6349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ