### PR TITLE
DOCS-6354 Surface the Ecosystem Hub in nav and on the landing page

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -30,7 +30,7 @@ New to MariaDB? Start here to set up your environment, connect to your first dat
 
 * [Installation Guides](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/mariadb-quickstart-guides/installing-mariadb-server-guide)
 * [Basic Concepts](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/mariadb-quickstart-guides/basics-guide)
-* [Connecting to MariaDB](/broken/spaces/SsmexDFPv2xG2OTyO5yV/pages/aUF70dDKMyaR6xBiNmrt)
+* [Connecting to MariaDB](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/mariadb-quickstart-guides/mariadb-connecting-guide)
 * [First SQL Queries](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/mariadb-quickstart-guides/mariadb-advanced-sql-guide)
 
 ### Product Documentation
@@ -48,6 +48,12 @@ Dedicated resources for specific MariaDB products and tools.
   * [MariaDB Enterprise Kubernetes Operator](https://app.gitbook.com/s/kuTXWg0NDbRx6XUeYpGD/mariadb-enterprise-operator)
   * [MariaDB Enterprise MCP Server](https://app.gitbook.com/s/kuTXWg0NDbRx6XUeYpGD/mariadb-enterprise-mcp-server)
   * [MariaDB AI RAG](https://app.gitbook.com/s/kuTXWg0NDbRx6XUeYpGD/mariadb-ai-rag)
+
+### Ecosystem
+
+Discover the tools, services, platforms, and partners that work with MariaDB Server.
+
+* [MariaDB Server Ecosystem Hub](mariadb-server-ecosystem-hub.md)
 
 ### Release Notes
 

--- a/home/SUMMARY.md
+++ b/home/SUMMARY.md
@@ -1,4 +1,7 @@
 # Table of contents
 
 * [MariaDB Documentation](README.md)
+
+## MariaDB Ecosystem
+
 * [MariaDB Server Ecosystem Hub](mariadb-server-ecosystem-hub.md)


### PR DESCRIPTION
Follow-up to [DOCS-6354](https://mariadbcorp.atlassian.net/browse/DOCS-6354) / PR #790, after `GITBOOK-32` removed the Roadmap section.

## What was wrong

The page itself published fine — `/docs/mariadb-server-ecosystem-hub` returns 200, the old `/docs/mariadb-roadmap/...` URL 307-redirects to it, and the page is in the live sidebar nav payload. But:

* Deleting the Roadmap group removed the `## MariaDB Roadmap` label that used to sit above it, leaving the Hub as an unlabeled top-level entry directly under "MariaDB Documentation" — easy to miss.
* It was **never** listed in the `/docs` landing page body. `home/README.md` is a hand-curated set of link lists, and `git log -S ecosystem -- home/README.md` returns nothing, so this was a pre-existing gap rather than a regression.

## Changes

* **`home/SUMMARY.md`** — add a `## MariaDB Ecosystem` group above the entry, so it renders as a labeled sidebar section again.
* **`home/README.md`** — add an **Ecosystem** section alongside Getting Started / Product Documentation / Release Notes, linking to the Hub. Same-space, so a relative `.md` link.

## Incidental fix (required for CI)

The Getting Started list had a broken link — `[Connecting to MariaDB](/broken/spaces/SsmexDFPv2xG2OTyO5yV/pages/aUF70dDKMyaR6xBiNmrt)`, a GitBook lost-reference placeholder. lychee only scans **changed** files, so touching `README.md` surfaces it and `fail: true` would have failed this PR on a link I didn't introduce.

Retargeted at the [Connecting to MariaDB Guide](https://mariadb.com/docs/server/mariadb-quickstart-guides/mariadb-connecting-guide) (verified live, 200) — the obvious match by title, and consistent with its three sibling links which all point into `mariadb-quickstart-guides`.

Note it uses a **raw `app.gitbook.com` URL rather than a `{server}` alias**, which is deliberate: `expand-gitbook-aliases.yml` skips any file named `README.md` (`! -name "README.md"`), so an alias here would never be expanded and would render literally. That's also why every other link in this file is a raw URL.

`lychee` passes 27/27 on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6354]: https://mariadbcorp.atlassian.net/browse/DOCS-6354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ