### PR TITLE
DOCS-6354 Show the left sidebar on the docs landing page

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -9,7 +9,7 @@ layout:
   description:
     visible: true
   tableOfContents:
-    visible: false
+    visible: true
   outline:
     visible: true
   pagination:

--- a/home/SUMMARY.md
+++ b/home/SUMMARY.md
@@ -1,7 +1,4 @@
 # Table of contents
 
 * [MariaDB Documentation](README.md)
-
-## MariaDB Ecosystem
-
 * [MariaDB Server Ecosystem Hub](mariadb-server-ecosystem-hub.md)


### PR DESCRIPTION
Follow-up to [DOCS-6354](https://mariadbcorp.atlassian.net/browse/DOCS-6354) / PRs #790, #791.

## Root cause

The Ecosystem Hub was never missing from the navigation — it was correctly in `home/SUMMARY.md` and present in the live nav payload the whole time. It didn't appear on `mariadb.com/docs` because **the landing page suppresses its own sidebar**:

```yaml
layout:
  tableOfContents:
    visible: false
```

GitBook honors that by rendering the page list with `page-no-toc:hidden`, so on `/docs` the left sidebar is hidden regardless of what `SUMMARY.md` contains. This setting predates all of today's work.

## Changes

* **`home/README.md`** — `layout.tableOfContents.visible: false` → `true`, so the left sidebar renders on the docs landing page. This is a visible change to `mariadb.com/docs` for all visitors, made deliberately.
* **`home/SUMMARY.md`** — revert the `## MariaDB Ecosystem` group added in #791. The group nested the page under a `/mariadb-ecosystem/` URL segment; dropping it restores `/docs/mariadb-server-ecosystem-hub` and avoids a third URL change for this page in one day.

The **Ecosystem** section added to the landing page body in #791 is kept — it's useful independently of the sidebar.

`lychee` passes 27/27 on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6354]: https://mariadbcorp.atlassian.net/browse/DOCS-6354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ