### PR TITLE
DOCS-6355 Point framework catalog at Ecosystem Hub

### DIFF
--- a/server/reference/sql-structure/vectors/vector-framework-integrations.md
+++ b/server/reference/sql-structure/vectors/vector-framework-integrations.md
@@ -32,7 +32,7 @@ MariaDB Vector has integrations in several frameworks.
 * [Open WebUI](https://github.com/open-webui/open-webui) - AI Interface, Python & Javascript
 * [Vanna AI](https://github.com/vanna-ai/vanna) - Vector search and text2sql, Python
 
-For further alternatives, see [Qdrant's list of framework integrations](https://qdrant.tech/documentation/frameworks/).
+For the full, continuously updated catalog of AI frameworks, platforms, and tools that work with MariaDB, see the [AI & Application Development category of the MariaDB Ecosystem Hub](https://ecohub.mariadb.org/ai-application-development).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 


### PR DESCRIPTION
Closes [DOCS-6355](https://mariadbcorp.atlassian.net/browse/DOCS-6355) / GitHub issue #784.

## What

On [Vector Framework Integrations](https://mariadb.com/docs/server/reference/sql-structure/vectors/vector-framework-integrations), replace the closing line

> For further alternatives, see [Qdrant's list of framework integrations](https://qdrant.tech/documentation/frameworks/).

with

> For the full, continuously updated catalog of AI frameworks, platforms, and tools that work with MariaDB, see the [AI & Application Development category of the MariaDB Ecosystem Hub](https://ecohub.mariadb.org/ai-application-development).

## Why

The old line sent readers to a competing vector database's framework catalog, which carries no signal about MariaDB compatibility. The Ecosystem Hub category is maintained continuously and scoped to tools that actually work with MariaDB.

Requested by @anjutawren; the replacement wording is hers, used verbatim.

## Checks

- `docs-check` (codespell + lychee): pass
- All 18 external links on the page verified live — every one returns 200, including the new Ecosystem Hub target

## Note: the one `http://` link is deliberate

Line 26 links `http://docs.dbgpt.cn/docs/installation` over plain HTTP. This was investigated and **left as-is on purpose** — please don't "fix" it:

- `https://docs.dbgpt.cn/...` does not work. Port 443 is filtered and the connection times out; the host serves HTTP only.
- `docs.dbgpt.site` returns HTTPS 200 but is a parked **"This domain is for sale"** page, not the DB-GPT docs.
- The current HTTP URL still serves the genuine *"Install Overview | DB-GPT"* page.

Switching the scheme would break a working link. Upstream has no TLS; that isn't ours to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6355]: https://mariadbcorp.atlassian.net/browse/DOCS-6355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ