### PR TITLE
DOCS-6356 Fix links on Vector Framework Integrations

### DIFF
--- a/server/reference/sql-structure/vectors/vector-framework-integrations.md
+++ b/server/reference/sql-structure/vectors/vector-framework-integrations.md
@@ -9,22 +9,20 @@ description: >-
 
 {% include "../../../.gitbook/includes/vectors-are-available-from-....md" %}
 
-MariaDB Vector has integrations in several frameworks.
+MariaDB Vector has integrations in several frameworks. For a general overview of MariaDB Vector — feature summary, benchmarks, tutorials, and demos — see the [MariaDB Vector project page](https://mariadb.org/projects/mariadb-vector/).
 
 ## AI Framework Integrations
 
-* [LangChain, MariaDB Vector Store](https://pypi.org/project/langchain-mariadb/) - Python
-* [LangChain.js, MariaDB Vector Store](https://js.langchain.com/docs/integrations/vectorstores/mariadb/) - Node.js
+* [LangChain, MariaDB Vector Store](https://docs.langchain.com/oss/python/integrations/vectorstores/mariadb) - Python ([PyPI package](https://pypi.org/project/langchain-mariadb/))
 * [LangChain4j, MariaDB Embedding Store](https://docs.langchain4j.dev/integrations/embedding-stores/mariadb/) - Java
-* [LlamaIndex, MariaDB Vector Store](https://docs.llamaindex.ai/en/stable/api_reference/storage/vector_store/mariadb/) - Python
+* [LlamaIndex, MariaDB Vector Store](https://developers.llamaindex.ai/python/framework-api-reference/storage/vector_store/mariadb/) - Python
 * [MCP (Model Context Protocol), MariaDB MCP server](https://github.com/mariadb/mcp) - Python
 * [Spring AI, MariaDB Vector Store](https://docs.spring.io/spring-ai/reference/api/vectordbs/mariadb.html) - Java
-* [VectorDBBench](https://github.com/zilliztech/VectorDBBench/pull/375) - benchmarking for vector databases
+* [VectorDBBench](https://github.com/zilliztech/VectorDBBench) - benchmarking for vector databases
 
 ## Potential Future Vector or AI Integrations
 * [AutoGen](https://github.com/microsoft/autogen) - Agent to agent, Python
 * [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) - private LLM, vector search and text2sql, see [integration docs](http://docs.dbgpt.cn/docs/installation), Python
-* [DSPy](https://github.com/stanfordnlp/dspy) - Workflow, not accepting external integrations anymore, Python
 * [Feast](https://github.com/feast-dev/feast) - machine learning (not GenAI), Python
 * [Firebase Studio template for MariaDB Vector](https://firebase.uservoice.com/forums/948424-general/suggestions/49702310-mariadb-vector) - visit link to vote for suggestion
 * [LangGraph](https://github.com/langchain-ai/langgraph) - Agentic workflow, Python


### PR DESCRIPTION
[DOCS-6356](https://mariadbcorp.atlassian.net/browse/DOCS-6356) — from GitHub issue [#785](https://github.com/mariadb-corporation/mariadb-docs/issues/785) by @anjutawren.

Page: `server/reference/sql-structure/vectors/vector-framework-integrations.md`

All five requested items, plus one related defect found while verifying. Every target URL below was fetched and its page title checked — a 200 alone was not treated as proof (see the LangChain.js note).

### Ticket items

**1. LangChain (Python) — docs page primary, PyPI secondary.**
The issue proposed `python.langchain.com/docs/integrations/vectorstores/mariadb/`. That 308s to the no-slash form and then lands on `docs.langchain.com/oss/python/integrations/vectorstores/mariadb`. I used that canonical URL instead, applying the issue's own item-3 principle (don't link something that resolves only via a docs-platform-migration redirect) consistently to both projects. PyPI kept as a parenthetical secondary reference.

**2. VectorDBBench — the tool, not the PR.** Now `github.com/zilliztech/VectorDBBench`. PR #375 is MERGED (2025-03-11), so the repo link fully supersedes it.

**3. LlamaIndex — canonical URL.** `docs.llamaindex.ai/...` 301s to `developers.llamaindex.ai/python/framework-api-reference/storage/vector_store/mariadb/`; now links the target directly.

**4. MariaDB Vector project page added** to the intro paragraph as the general overview, per the request to link it near the top.

**5. DSPy removed.** On the second half of item 5 — whether an aspirational list belongs in SQL reference docs — the rest of the "Potential Future" section is kept for now; that's a broader editorial call than this ticket, and DOCS-6355 already added an Ecosystem Hub pointer at the foot of the page.

### Related defect fixed (not in the ticket)

**LangChain.js entry removed.** `js.langchain.com/docs/integrations/vectorstores/mariadb/` returns 200 but is a soft-404 — it redirects to a generic *"LangChain overview"* page. The integration is gone upstream: no MariaDB entry in the JS vector-stores index, `@langchain/mariadb` 404s on the npm registry, and `MariaDBStore` has 0 hits in `langchain-ai/langchainjs` (only a stray `docker-compose.example.yml` and a `mariadb` devDependency remain). Listing it under "AI Framework Integrations" claimed something MariaDB does not currently have, so the entry is removed rather than repointed.

### Checks

`codespell` and `lychee` both pass locally via `.claude/hooks/doc-lint.sh`, plus the CI-exact codespell invocation.

Note: `http://docs.dbgpt.cn` on the DB-GPT line is left as HTTP deliberately — see [PR #793](https://github.com/mariadb-corporation/mariadb-docs/pull/793). Port 443 is filtered on that host and the HTTPS-looking alternative is a parked domain. Please don't "fix" it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6356]: https://mariadbcorp.atlassian.net/browse/DOCS-6356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ