### PR TITLE
DOCS-6358 Add web framework and ORM vector integrations

### DIFF
--- a/server/reference/sql-structure/vectors/vector-framework-integrations.md
+++ b/server/reference/sql-structure/vectors/vector-framework-integrations.md
@@ -20,6 +20,15 @@ MariaDB Vector has integrations in several frameworks. For a general overview of
 * [Spring AI, MariaDB Vector Store](https://docs.spring.io/spring-ai/reference/api/vectordbs/mariadb.html) - Java
 * [VectorDBBench](https://github.com/zilliztech/VectorDBBench) - benchmarking for vector databases
 
+## Web Framework and ORM Integrations
+
+* [Laravel, vector columns and vector indexes in the schema builder](https://laravel.com/docs/13.x/migrations#column-method-vector) - PHP, since Laravel 13; `$table->vectorIndex('embedding')` compiles to a MariaDB `VECTOR INDEX` with `M=6 DISTANCE=cosine` ([laravel/framework#60334](https://github.com/laravel/framework/pull/60334))
+* [laravel-mariadb-vector, vector casts and similarity search for Eloquent models](https://packagist.org/packages/devilsberg/laravel-mariadb-vector) - PHP, community package
+* [TypeORM, MariaDB vector columns](https://typeorm.io/docs/drivers/mysql/) - TypeScript/Node.js, since TypeORM 0.3.28
+* [Hibernate ORM, MariaDB vector type](https://hibernate.atlassian.net/browse/HHH-18900) - Java, since Hibernate ORM 7.0
+
+For a worked example of picking an embedding model for MariaDB Vector in a Laravel application, see [MariaDB Vector in Laravel: insights on choosing an embedding model](https://mariadb.org/mariadb-vector-in-laravel-insights-on-choosing-an-embedding-model/).
+
 ## Potential Future Vector or AI Integrations
 * [AutoGen](https://github.com/microsoft/autogen) - Agent to agent, Python
 * [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) - private LLM, vector search and text2sql, see [integration docs](http://docs.dbgpt.cn/docs/installation), Python


### PR DESCRIPTION
Closes [DOCS-6358](https://mariadbcorp.atlassian.net/browse/DOCS-6358) / GitHub issue #787 (reported by @anjutawren).

Adds a **Web Framework and ORM Integrations** section to `server/reference/sql-structure/vectors/vector-framework-integrations.md`, between the AI list and the "Potential Future" list.

## What the report asked for, and what I verified

| Claim | Verified against |
|---|---|
| Laravel 13 schema builder creates a MariaDB `VECTOR INDEX` | `Blueprint::vectorIndex()` on `13.x` picks `M=6 DISTANCE=cosine` for `MariaDbGrammar`; `MariaDbGrammar::compileVectorIndex()` emits `alter table … add vector index …`. laravel/framework#60334 merged 2026-05-31 into `13.x`; Laravel 13 is released (v13.23.0). |
| `laravel-mariadb-vector` provides the Eloquent layer | Packagist package is live and maintained — v1.2.1 (2026-06-12), requires `laravel/framework ^12.0 \|\| ^13.0`. Labelled a *community package* on the page. |
| TypeORM supports MariaDB vector columns since late 2025 | `vector` is in `MysqlDriver`'s supported/with-length column types; added by typeorm/typeorm#11670 (2025-11-27), first released in 0.3.28 (2025-12-03). |

Both suggested URLs resolve to real pages (body-checked, not just status-checked). Two deviations from the suggested entries:

- **Laravel** — linked the Laravel migration docs rather than the PR as the primary target, since that is what a reader can act on; the PR is cited inline for the MariaDB-specific index support.
- **TypeORM** — used `https://typeorm.io/docs/drivers/mysql/` ("MySQL / MariaDB" driver page, has the *Vector Types* section) instead of the site root. Note the trailing slash: without it the URL 308s.

## One addition the report did not have

**Hibernate ORM** has shipped a MariaDB vector type since 7.0 (`MariaDBVectorJdbcType`, `MariaDBFunctionContributor`, `MariaDBTypeContributor` in the `hibernate-vector` module; HHH-18900, fix version 7.0.0.Beta4). It is genuinely undocumented upstream — no mention in the user guide, migration guide, or published javadoc — so the entry cites the tracker issue. **Reviewer call:** if we want every entry to point at real documentation, drop that bullet.

Considered and left out: `@nestjs-ai/vector-store-mariadb` on npm (v0.1.0, single release, ~48 downloads/month) — too new to list.

## Checks

`docs-check` clean: codespell PASS (CI-exact invocation), lychee 25/25 OK. The one redirect lychee reports is the pre-existing `http://docs.dbgpt.cn` link, deliberately left as `http://` per DOCS-6355.

[DOCS-6358]: https://mariadbcorp.atlassian.net/browse/DOCS-6358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ