### PR TITLE
DOCS-5710 Add per-space documentation PDF generation

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -135,6 +135,22 @@ jobs:
             exit 1
           fi
 
+          # Cross-space links arrive in the checkout as app.gitbook.com *editor*
+          # URLs, which demand a login; the preprocessor maps them to
+          # mariadb.com/docs. A survivor is invisible in a 6,000-page PDF -- it
+          # looks like a working link until someone clicks it -- so assert on the
+          # artifact's own link annotations. Code samples that mention the URL
+          # legitimately are page text, not /URI annotations, so they don't trip
+          # this. A hit means an unmapped space ID in GITBOOK_SPACE_IDS.
+          qpdf --qdf --object-streams=disable "$pdf" - 2>/dev/null \
+            | grep -aoE '/URI *\([^)]*app\.gitbook\.com[^)]*\)' \
+            | sort -u > editor-urls.txt || true
+          if [[ -s editor-urls.txt ]]; then
+            echo "::error::$(wc -l < editor-urls.txt) app.gitbook.com link(s) survived into $pdf"
+            head -5 editor-urls.txt
+            exit 1
+          fi
+
       - uses: actions/upload-artifact@v4
         with:
           name: pdf-${{ matrix.space }}

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -1,0 +1,188 @@
+name: Generate documentation PDFs
+
+# Builds one PDF per GitBook space and attaches them to a GitHub Release.
+#
+# Manual by design (DOCS-5710): a full run produces ~450 MB across 11 files, so
+# it is tied to a documentation snapshot -- typically cut alongside a Server
+# release -- rather than to every push.
+#
+# There is deliberately no combined all-spaces PDF: concatenating every space
+# yields ~16,000 pages, which no reader handles usefully.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to create or update (e.g. docs-pdf-2026-07)'
+        required: true
+        type: string
+      label:
+        description: 'Cover-page label (e.g. "Snapshot July 2026"). Defaults to the run date.'
+        required: false
+        type: string
+      spaces:
+        description: 'Space-separated list of spaces, or "all"'
+        required: false
+        default: 'all'
+        type: string
+      draft:
+        description: 'Create the release as a draft'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write   # required to create the release and upload assets
+
+env:
+  PANDOC_VERSION: '3.10.1'
+
+jobs:
+  # Resolve the space list once so the build matrix and the release job agree.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      spaces: ${{ steps.plan.outputs.spaces }}
+      label: ${{ steps.plan.outputs.label }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: plan
+        name: Resolve spaces and cover label
+        env:
+          REQUESTED: ${{ inputs.spaces }}
+          LABEL_INPUT: ${{ inputs.label }}
+        run: |
+          set -euo pipefail
+          # --list-spaces validates its arguments, so a typo fails here rather
+          # than after the matrix has already fanned out.
+          if [[ "$REQUESTED" == "all" ]]; then
+            spaces=$(python3 pdf/build.py --list-spaces)
+          else
+            spaces=$(python3 pdf/build.py --list-spaces $REQUESTED)
+          fi
+          echo "spaces=$spaces" >> "$GITHUB_OUTPUT"
+
+          label="$LABEL_INPUT"
+          [[ -n "$label" ]] || label="Snapshot $(date -u +%Y-%m-%d)"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
+
+          echo "Building: $spaces"
+          echo "Label: $label"
+
+  build:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false   # one bad space must not discard the other ten
+      matrix:
+        space: ${{ fromJSON(needs.plan.outputs.spaces) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Ubuntu's packaged pandoc lags well behind and lacks the flags build.py
+      # relies on, so pin the version explicitly.
+      - name: Install pandoc ${{ env.PANDOC_VERSION }}
+        run: |
+          set -euo pipefail
+          deb="pandoc-${PANDOC_VERSION}-1-amd64.deb"
+          url="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/${deb}"
+          curl -fsSL -o "/tmp/${deb}" "$url"
+          sudo apt-get install -y "/tmp/${deb}"
+          pandoc --version | head -1
+
+      # The .deb from Google rather than the apt/snap chromium package, whose
+      # sandboxing makes --headless --print-to-pdf unreliable on runners.
+      - name: Install Google Chrome
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/chrome.deb \
+            https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt-get install -y /tmp/chrome.deb
+          google-chrome-stable --version
+
+      # qpdf: lossless ~35% size reduction that preserves links (see pdf/README.md).
+      # poppler-utils: pdfinfo, used for page-count reporting and verification.
+      - name: Install qpdf and poppler
+        run: sudo apt-get install -y qpdf poppler-utils
+
+      - name: Fetch Mermaid bundle
+        run: ./pdf/fetch-deps.sh
+
+      - name: Build ${{ matrix.space }} PDF
+        run: |
+          python3 pdf/build.py "${{ matrix.space }}" \
+            --out-dir dist \
+            --version-label "${{ needs.plan.outputs.label }}"
+
+      - name: Verify the PDF is readable and non-trivial
+        run: |
+          set -euo pipefail
+          pdf="dist/mariadb-${{ matrix.space }}.pdf"
+          [[ -s "$pdf" ]] || { echo "::error::$pdf missing or empty"; exit 1; }
+          pages=$(pdfinfo "$pdf" | awk '/^Pages:/ {print $2}')
+          echo "$pdf -> $pages pages, $(du -h "$pdf" | cut -f1)"
+          # A space that collapses to a couple of pages means the SUMMARY parse
+          # or the preprocessor silently dropped nearly everything.
+          if [[ "${{ matrix.space }}" != "home" && "$pages" -lt 10 ]]; then
+            echo "::error::only $pages pages -- build looks broken"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pdf-${{ matrix.space }}
+          path: dist/*.pdf
+          retention-days: 7
+          if-no-files-found: error
+
+  release:
+    needs: [plan, build]
+    if: always() && needs.build.result != 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pdf-*
+          merge-multiple: true
+          path: dist
+
+      - name: Summarize
+        run: |
+          set -euo pipefail
+          ls -lh dist/
+          {
+            echo "## Documentation PDFs"
+            echo
+            echo "Label: **${{ needs.plan.outputs.label }}**"
+            echo
+            echo "| File | Size |"
+            echo "|------|------|"
+            for f in dist/*.pdf; do
+              echo "| $(basename "$f") | $(du -h "$f" | cut -f1) |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          notes="MariaDB documentation PDFs — ${{ needs.plan.outputs.label }}
+
+          One PDF per GitBook space, generated from \`$GITHUB_SHA\` by
+          \`.github/workflows/generate-pdfs.yml\`.
+
+          The authoritative, continuously updated documentation is at
+          https://mariadb.com/docs."
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/*.pdf --clobber
+          else
+            gh release create "$TAG" dist/*.pdf \
+              --title "Documentation PDFs — ${{ needs.plan.outputs.label }}" \
+              --notes "$notes" \
+              ${{ inputs.draft && '--draft' || '' }}
+          fi

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -151,6 +151,19 @@ jobs:
             exit 1
           fi
 
+          # A published URL never keeps its `.md`: the site answers such a
+          # request with an HTTP 200 soft-404, so a status-code link check calls
+          # it healthy while the reader lands on an error page. Assert on the
+          # artifact for the same reason as above.
+          qpdf --qdf --object-streams=disable "$pdf" - 2>/dev/null \
+            | grep -aoE '/URI *\(https?://mariadb\.com/docs/[^)]*\.md[)#]' \
+            | sort -u > md-urls.txt || true
+          if [[ -s md-urls.txt ]]; then
+            echo "::error::$(wc -l < md-urls.txt) site link(s) still end in .md in $pdf"
+            head -5 md-urls.txt
+            exit 1
+          fi
+
       - uses: actions/upload-artifact@v4
         with:
           name: pdf-${{ matrix.space }}

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -47,6 +47,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Runs once rather than per space: it is a property of the stylesheet, and
+      # failing here costs seconds instead of an hour of rendering.
+      - name: Verify WCAG AA contrast
+        run: python3 pdf/check_contrast.py
+
       - id: plan
         name: Resolve spaces and cover label
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@
 .claude/bulk-campaign.local.json
 # per-task research paper trail (source-verification notes, one file per Jira ID):
 research/
+
+# PDF generation (pdf/, DOCS-5710)
+# Mermaid bundle is ~3.5 MB and fetched by pdf/fetch-deps.sh, not committed:
+/pdf/vendor/
+# Default --out-dir for the generated PDFs and their intermediate HTML.
+# Anchored to the repo root so it cannot shadow a documentation page path:
+/dist/
+/pdf/__pycache__/

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -154,6 +154,21 @@ the link looks fine until someone clicks it. `build.py` warns if any editor URL
 survives in prose, and the workflow fails the build if one reaches the PDF's own
 link annotations. Both should always be zero; a hit means an unmapped space ID.
 
+### Outbound URLs must drop the `.md`
+
+A link that leaves the space is turned into a site URL, and the published URL is
+the repo path **without** its suffix — `README.md` publishes as its own
+directory. Leaving the `.md` on produces a **soft 404**: the site answers
+`HTTP 200` with a 46 KB error page instead of the real 3 MB one, so a status-code
+link check calls it healthy while the reader gets nothing. That affected 183
+links (mostly `maxscale` and `release-notes`), which is why `build.py` counts
+`.md`-suffixed site URLs and CI fails on them.
+
+Unlike an in-space link, an outbound link **keeps its `#fragment`**: the target
+page is not in this PDF, so the section anchor still does useful work on the
+site. 405 links were losing one — `server-system-variables.md#wait_timeout`
+dropped the reader at the top of a very long page rather than at the variable.
+
 Two findings from this that are **source** bugs, not PDF bugs:
 
 - `expand-gitbook-aliases.yml` maps both `{skysql}` and `{release-notes}` to

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -78,7 +78,7 @@ SUMMARY.md ─▶ manifest ─▶ preprocess ─▶ pandoc (md→html) ─▶ Ch
 | `{% @marketo/form %}` and other integrations | ~9,000 | dropped |
 | `{% include %}` | ~9,000 | local files inlined; remote and boilerplate dropped |
 | `{% column %}` / `{% columns %}` | ~6,200 | linearized (a PDF page is one column) |
-| `{% content-ref %}` | ~2,400 | collapsed to the link it contains |
+| `{% content-ref %}` | ~2,400 | collapsed to a link labelled with the target's title |
 | `{% hint %}` | ~1,690 | callout styled per severity |
 | `{% tab %}` / `{% tabs %}` | ~1,400 | sequential labeled subsections |
 | `{% step %}` / `{% stepper %}` | ~730 | explicitly numbered steps |
@@ -168,6 +168,24 @@ Unlike an in-space link, an outbound link **keeps its `#fragment`**: the target
 page is not in this PDF, so the section anchor still does useful work on the
 site. 405 links were losing one — `server-system-variables.md#wait_timeout`
 dropped the reader at the top of a very long page rather than at the variable.
+
+### Reference labels come from page titles
+
+GitBook stores a `{% content-ref %}` with the target's *filename* as its link
+text and renders the real page title from its own database, so 2,298 of the
+corpus's 2,377 refs carry a label like
+`backup-and-restore-via-dbforge-studio.md`. Printed verbatim, that is the one
+place a PDF reference reads worse than the website.
+
+The title is taken from `SUMMARY.md` first, so a reference names a page exactly
+as the contents list and the PDF outline do; a page outside the navigation falls
+back to its own H1. Only the label changes — the block's own URL is still what
+gets linked.
+
+Plain inline links are deliberately left alone. Five in the corpus have a label
+ending in `.md`, and every one is a genuine reference to a repository file
+(`CONTRIBUTING.md`, `install.md`), so blanket-rewriting labels would corrupt
+them.
 
 Two findings from this that are **source** bugs, not PDF bugs:
 

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -119,6 +119,50 @@ the space point at `mariadb.com/docs`, since the target is not in this PDF.
 Image paths are made absolute `file://` URLs and percent-decoded first, because
 the source encodes them (`15%20(1).PNG`) while the filesystem does not.
 
+## Brand colors and contrast
+
+`style.css` uses the MariaDB brand palette (slide 26 of the corporate deck), and
+every text/background pair is checked against WCAG 2.1 AA:
+
+```bash
+python3 pdf/check_contrast.py     # exits non-zero on any failure; runs in CI
+```
+
+| Color | Hex | On white | Used for |
+|-------|-----|---------:|----------|
+| Blue Azure | `#0E6488` | 6.57:1 AA | headings, links, default cover |
+| Deep Ocean | `#003545` | 13.16:1 AAA | top-level headings, step labels |
+| Granite | `#424F62` | 8.31:1 AAA | secondary and deep-TOC text |
+| Open Seas | `#00838F` | 4.52:1 AA | rules; small text uses `#00707a` (5.84:1) |
+| Sea Fresh | `#96DDCF` | 1.55:1 | fills only — table headers, step rules, alt cover |
+| Electric Eel | `#ABC74A` | 1.91:1 | decorative rules only, never text |
+
+Three deliberate decisions:
+
+- **Never `opacity` for secondary text.** Dimming white to 75% over Blue Azure
+  looks fine on screen and measures 4.45:1 — under the AA floor, and it landed
+  on the 8.5pt legal line where contrast matters most. Secondary cover text uses
+  explicit verified colors instead.
+- **Warning and Important are intentionally off-palette.** The brand has no
+  amber or red; forcing them into blues and greens would make a warning
+  indistinguishable from a note. Being slightly off-brand is the better
+  accessibility outcome. Color is never the only signal regardless — every
+  callout carries a bold `Note:` / `Tip:` / `Warning:` / `Important:` label, so
+  the distinction survives greyscale printing and color-vision deficiency.
+- **Open Seas is darkened for small text.** At 4.52:1 it passes AA by 0.02,
+  which is too fragile for 9pt labels; `#00707a` keeps the hue (185°) and
+  saturation at 5.84:1.
+
+### Cover treatments
+
+```bash
+python3 pdf/build.py server                      # Blue Azure, white text (default)
+python3 pdf/build.py server --cover sea-fresh    # Sea Fresh, Deep Ocean text
+```
+
+Both exceed AA at every size: Blue Azure/white is 6.57:1, Sea Fresh/Deep Ocean
+is 8.49:1.
+
 ## Size
 
 Chrome emits no object streams and leaves roughly half its streams
@@ -130,6 +174,28 @@ with `--no-optimize`.
 **Do not substitute Ghostscript.** It compresses harder but strips every
 `/Link` and `/Dest` — on `galera-cluster`, 3,575 links and 743 destinations all
 became zero — which destroys cross-reference navigation.
+
+## Chrome does not reliably exit
+
+Headless Chrome writes a complete, valid PDF and then *sometimes* keeps
+running — observed on `tools` and `mariadb-cloud`, where the finished file sat
+on disk while the process idled for tens of minutes. So `build.py` treats **the
+output file as the completion signal, not process exit**: it polls the PDF's
+size and terminates Chrome once that size has been stable for a few checks.
+Verified equivalent to letting Chrome exit on its own — same 611 pages, 3,859
+links and 1,397 destinations on `tools`, final page intact.
+
+Two related traps:
+
+- **`--virtual-time-budget` bounds nothing in wall-clock terms.** It advances a
+  virtual clock; it will not stop a hung render. `CHROME_TIMEOUT_S` is the only
+  real ceiling.
+- **Always pass `--user-data-dir`.** Without it Chrome shares the default
+  profile and can block on the singleton lock when another instance exists.
+
+A space that still fails is reported and skipped rather than aborting the run,
+matching `fail-fast: false` in the workflow — a full build is tens of minutes
+and one bad space should not discard the rest.
 
 ## Known limitations
 
@@ -157,5 +223,6 @@ became zero — which destroys cross-reference navigation.
 |------|---------|
 | `build.py` | manifest, assembly, Pandoc/Chrome/qpdf pipeline, CLI |
 | `gitbook_preprocess.py` | GitBook-block rewriting, link and asset rewriting |
-| `style.css` | print stylesheet (cover, TOC, callouts, tables, code) |
+| `style.css` | print stylesheet: brand palette, cover, TOC, callouts, tables, code |
+| `check_contrast.py` | asserts every text pair meets WCAG 2.1 AA (runs in CI) |
 | `fetch-deps.sh` | fetches the Mermaid bundle into `pdf/vendor/` (gitignored) |

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -119,6 +119,55 @@ the space point at `mariadb.com/docs`, since the target is not in this PDF.
 Image paths are made absolute `file://` URLs and percent-decoded first, because
 the source encodes them (`15%20(1).PNG`) while the filesystem does not.
 
+### Cross-space links must be un-expanded first
+
+`expand-gitbook-aliases.yml` rewrites every `{server}`-style alias into an
+app.gitbook.com **editor** URL and commits that back to the branch. So in any
+checkout, a cross-space link already looks like:
+
+```
+https://app.gitbook.com/o/<org>/s/SsmexDFPv2xG2OTyO5yV/server-management/…
+```
+
+GitBook resolves those to `mariadb.com/docs` when it renders the site. Nothing
+else does — so a PDF built from source has to reverse the mapping, or **every**
+cross-space link sends the reader to the editor, which demands a login. That was
+38,462 links across the corpus. `GITBOOK_SPACE_IDS` maps space ID → space, and a
+page's published URL path is its repo-relative path minus `.md`.
+
+Two cases need more than the obvious substitution:
+
+- **Some links are invisible to a link regex.** Link text containing an escaped
+  bracket (`[SHOW \[FULL\] PROCESSLIST](…)`) and links split over two lines by a
+  migration hard break both occur in the corpus. A fallback pass rewrites the
+  bare URL, which still lands the reader on the right page. It skips fenced *and*
+  inline code, because `general-resources` documents the
+  `app.gitbook.com/s/<id>` prefixes literally and rewriting them there would
+  turn an explanation into a false statement.
+- **Unmappable spaces are unlinked, not guessed.** A few links name a legacy
+  pre-split space with no public equivalent; the link text is kept and the dead
+  destination dropped, since sending a reader to a login screen is worse than
+  not linking.
+
+This is checked twice, because the failure is invisible in a 6,000-page PDF —
+the link looks fine until someone clicks it. `build.py` warns if any editor URL
+survives in prose, and the workflow fails the build if one reaches the PDF's own
+link annotations. Both should always be zero; a hit means an unmapped space ID.
+
+Two findings from this that are **source** bugs, not PDF bugs:
+
+- `expand-gitbook-aliases.yml` maps both `{skysql}` and `{release-notes}` to
+  `aEnK0ZXmUbJzqQrTjFyb`. Every path under that ID resolves under
+  `release-notes/`, so `{skysql}` links land in the wrong space.
+- 669 distinct cross-space targets (6,063 of 37,601 references) do not exist at
+  the linked path in the checkout — for example error-code pages that moved out
+  of `reference/mariadb-internals/using-mariadb-with-your-programs-api/`. Most
+  still reach a page on the live site through a redirect: of a 40-target sample,
+  33 resolved after following redirects and 7 ended in a 404, which puts the
+  genuinely dead subset near 120. The PDF reproduces each link faithfully rather
+  than guessing a replacement, so those few are dead in the PDF exactly as they
+  are on the site.
+
 ## Brand colors and contrast
 
 `style.css` uses the MariaDB brand palette (slide 26 of the corporate deck), and

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -1,0 +1,161 @@
+# PDF generation
+
+Builds one PDF per GitBook space from the Markdown in this repository
+(DOCS-5710). GitBook's own PDF export is capped at 100 pages per download, so
+whole-space output has to be generated from source.
+
+## Quick start
+
+```bash
+./pdf/fetch-deps.sh                 # once: fetch the Mermaid bundle
+python3 pdf/build.py galera-cluster # one space -> dist/mariadb-galera-cluster.pdf
+python3 pdf/build.py --all          # all eleven spaces
+python3 pdf/build.py server --limit 50 --keep-html   # fast iteration
+```
+
+Requirements: `python3`, `pandoc` 3.x, Chrome or Chromium. Optional but
+recommended: `qpdf` (lossless size pass), `poppler-utils` (page-count
+reporting), `npm` (only for `fetch-deps.sh`).
+
+In CI, `.github/workflows/generate-pdfs.yml` builds every space in parallel and
+attaches the results to a GitHub Release. It is `workflow_dispatch`-only: a full
+run produces several hundred MB, so it is cut per documentation snapshot rather
+than per push.
+
+## Output
+
+| Space | Doc pages | PDF pages |
+|-------|----------:|----------:|
+| `server` | 4,101 | ~6,540 |
+| `release-notes` | 2,772 | ~5,720 |
+| `maxscale` | 771 | ~5,810 |
+| `platform` | 813 | ~500 |
+| `connectors` | 289 | ~660 |
+| `analytics` | 174 | ~590 |
+| `tools` | 128 | ~610 |
+| `general-resources` | 124 | ~220 |
+| `mariadb-cloud` | 110 | ~300 |
+| `galera-cluster` | 101 | ~270 |
+| `home` | 2 | ~7 |
+
+There is deliberately **no combined all-spaces PDF**: concatenating every space
+produces roughly 16,000 pages, which no reader handles usefully, and three
+spaces account for 90% of it.
+
+## How it works
+
+```
+SUMMARY.md ─▶ manifest ─▶ preprocess ─▶ pandoc (md→html) ─▶ Chrome --print-to-pdf ─▶ qpdf
+```
+
+1. **`SUMMARY.md` is the manifest.** It is GitBook's navigation tree, so it
+   supplies both reading order and nesting depth — depth becomes the heading
+   level, which becomes the PDF outline. Concatenating files alphabetically
+   would scramble the reading order instead.
+
+   Pages absent from `SUMMARY.md` (375 in `server/`) are unpublished and are
+   excluded on purpose. Duplicate entries (56 repo-wide) are emitted once, at
+   first appearance, so anchors stay unique.
+
+2. **`gitbook_preprocess.py` rewrites the GitBook blocks.** Pandoc does not
+   know them and passes them through as literal body text, so without this step
+   readers see `{% hint style="info" %}` in the prose.
+
+3. **Pandoc converts to an HTML fragment.** TeX math extensions are disabled —
+   GitBook has no TeX support, so a `$` in shell prose is a dollar sign, and
+   leaving math on renders phrases like `write_rate = ...` as mangled equations.
+
+4. **Chrome prints it.** Not LaTeX: the corpus contains 118 pages with raw
+   `<table>` markup and 111 with Mermaid diagrams, which a TeX engine cannot
+   render. Chrome also lets `pdf/style.css` own the layout.
+
+5. **`qpdf` repacks it losslessly** — see *Size* below.
+
+## What the preprocessor handles
+
+| Block | Occurrences | Treatment |
+|-------|------------:|-----------|
+| `{% @marketo/form %}` and other integrations | ~9,000 | dropped |
+| `{% include %}` | ~9,000 | local files inlined; remote and boilerplate dropped |
+| `{% column %}` / `{% columns %}` | ~6,200 | linearized (a PDF page is one column) |
+| `{% content-ref %}` | ~2,400 | collapsed to the link it contains |
+| `{% hint %}` | ~1,690 | callout styled per severity |
+| `{% tab %}` / `{% tabs %}` | ~1,400 | sequential labeled subsections |
+| `{% step %}` / `{% stepper %}` | ~730 | explicitly numbered steps |
+| `{% code title=… %}` | ~290 | title emitted as a caption |
+| `{% embed %}`, `{% file %}`, `{% openapi %}`, `{% if %}`, `{% updates %}` | ~20 | reduced to link text, or unwrapped |
+| ` ```mermaid ` fences | 111 files | rendered by Mermaid in the browser |
+| `{server}`-style aliases | ~10 files | expanded to `mariadb.com/docs` URLs |
+
+Two properties of the corpus shape the implementation:
+
+- **Blocks span code fences.** A `{% stepper %}` opens, several fenced shell
+  samples follow, then `{% endstepper %}` closes. Matching an open/close pair
+  with a single `re.DOTALL` regex therefore fails on real pages, so block
+  conversion is one line-oriented pass carrying fence state.
+- **Markers are not always alone on a line.** `{% hint style="info" %} For the
+  CTE…` occurs verbatim in the corpus, so replacements inject their own line
+  breaks rather than assuming they own the line.
+
+Anything inside a fenced code block is left untouched — a `{% hint %}` in a
+GitBook-syntax example is content, not markup.
+
+Two things are normalized per page because concatenation makes local quirks
+global:
+
+- **Unbalanced blocks are closed.** A page that opens `{% hint %}` without
+  closing it would otherwise leave the generated container open to the end of
+  the *whole space*, dragging every later page inside it.
+- **Footnote labels are namespaced.** Nearly every page numbers its footnotes
+  from `[^1]`, so concatenation collides them and readers get another page's
+  footnote text.
+
+### Links
+
+In-space links are rewritten to internal PDF anchors, so cross-references still
+work offline; without this every `.md` link in a concatenated document is dead.
+Directory-style links resolve to that directory's `README.md`. Links that leave
+the space point at `mariadb.com/docs`, since the target is not in this PDF.
+Image paths are made absolute `file://` URLs and percent-decoded first, because
+the source encodes them (`15%20(1).PNG`) while the filesystem does not.
+
+## Size
+
+Chrome emits no object streams and leaves roughly half its streams
+uncompressed. `qpdf --object-streams=generate --recompress-flate` recovers
+~35% (`galera-cluster`: 8.3 MB → 5.4 MB) with links, named destinations and
+page count all intact. It runs automatically when `qpdf` is on `PATH`; skip it
+with `--no-optimize`.
+
+**Do not substitute Ghostscript.** It compresses harder but strips every
+`/Link` and `/Dest` — on `galera-cluster`, 3,575 links and 743 destinations all
+became zero — which destroys cross-reference navigation.
+
+## Known limitations
+
+- **Remote reusable includes are dropped.** 3,269 includes point at
+  `app.gitbook.com/…/~/reusable/…`, whose content lives only in GitBook and is
+  unreachable from a source checkout. They are boilerplate (contributing
+  notice, license, announcements), so the PDFs simply omit them — but this is
+  why a PDF is not byte-identical to the rendered page.
+- **Tabs lose interactivity.** Every panel is printed in sequence, so mutually
+  exclusive alternatives (for example per-distribution install steps) all
+  appear.
+- **Headings flatten past six levels.** `server/` nests eight deep in
+  `SUMMARY.md`; levels 7 and 8 render as level 6.
+- **A few pages escape their block markers** (`\{% tabs %\}`), which stops
+  GitBook rendering the block on the live site too. The preprocessor normalizes
+  them so the PDF is correct; the source still wants fixing. Find them with:
+
+  ```bash
+  grep -rn '\\{%' --include='*.md' .
+  ```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `build.py` | manifest, assembly, Pandoc/Chrome/qpdf pipeline, CLI |
+| `gitbook_preprocess.py` | GitBook-block rewriting, link and asset rewriting |
+| `style.css` | print stylesheet (cover, TOC, callouts, tables, code) |
+| `fetch-deps.sh` | fetches the Mermaid bundle into `pdf/vendor/` (gitignored) |

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -245,6 +245,20 @@ python3 pdf/build.py server --cover sea-fresh    # Sea Fresh, Deep Ocean text
 Both exceed AA at every size: Blue Azure/white is 6.57:1, Sea Fresh/Deep Ocean
 is 8.49:1.
 
+The cover also carries a snapshot label, which **defaults to today's date** —
+documentation here is continuously updated, so an undated PDF cannot be placed
+in time. The workflow resolves it identically, so a local build and a CI build
+label the cover the same way.
+
+```bash
+python3 pdf/build.py server                                  # Snapshot <today>
+python3 pdf/build.py server --version-label "Snapshot July 2026"
+python3 pdf/build.py server --version-label ""               # omit deliberately
+```
+
+The build echoes `cover label: …` before it starts, because an empty default
+used to drop the date silently whenever the flag was forgotten.
+
 ## Size
 
 Chrome emits no object streams and leaves roughly half its streams

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Build a per-space PDF of the MariaDB documentation.
+
+    python3 pdf/build.py server
+    python3 pdf/build.py --all --out-dir dist
+    python3 pdf/build.py server --limit 50      # quick iteration
+
+Page order and heading hierarchy come from the space's `SUMMARY.md`, which is
+GitBook's own navigation tree -- alphabetical concatenation would scramble the
+reading order. Pages not listed there (375 in `server/`) are unpublished and
+excluded on purpose.
+
+Pipeline: SUMMARY.md -> manifest -> preprocess -> Pandoc (md->html) ->
+headless Chrome --print-to-pdf. Chrome rather than LaTeX because the corpus
+contains raw HTML tables and Mermaid diagrams that a TeX engine cannot render.
+"""
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from urllib.parse import quote
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from gitbook_preprocess import preprocess  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PDF_DIR = os.path.join(REPO_ROOT, "pdf")
+WEB_BASE = "https://mariadb.com/docs"
+
+# Human-facing titles; the directory name is not always presentable.
+SPACE_TITLES = {
+    "server": "MariaDB Server",
+    "release-notes": "MariaDB Release Notes",
+    "maxscale": "MariaDB MaxScale",
+    "platform": "MariaDB Enterprise Platform",
+    "connectors": "MariaDB Connectors",
+    "analytics": "MariaDB Analytics and ColumnStore",
+    "tools": "MariaDB Tools",
+    "mariadb-cloud": "MariaDB Cloud",
+    "general-resources": "MariaDB General Resources",
+    "galera-cluster": "MariaDB Galera Cluster",
+    "home": "MariaDB Documentation",
+}
+
+# `help-tables/` is generated SQL, and the remaining top-level directories are
+# include containers or contributor docs -- none are browsable spaces.
+ALL_SPACES = [
+    "server", "release-notes", "maxscale", "platform", "connectors",
+    "analytics", "tools", "mariadb-cloud", "general-resources",
+    "galera-cluster", "home",
+]
+
+CHROME_CANDIDATES = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "google-chrome-stable", "google-chrome", "chromium-browser", "chromium",
+]
+
+
+def find_chrome():
+    for cand in CHROME_CANDIDATES:
+        if os.path.isabs(cand):
+            if os.path.isfile(cand) and os.access(cand, os.X_OK):
+                return cand
+        else:
+            found = shutil.which(cand)
+            if found:
+                return found
+    sys.exit("error: no Chrome/Chromium binary found (see CHROME_CANDIDATES)")
+
+
+# ---------------------------------------------------------------------------
+# SUMMARY.md -> manifest
+# ---------------------------------------------------------------------------
+
+ENTRY_RE = re.compile(r"^(\s*)\*\s*\[(.+?)\]\((.+?)\)\s*$")
+
+
+def parse_summary(space):
+    """Return [(depth, title, space_relative_path)] in navigation order.
+
+    Indent width is inferred per line rather than assumed to be two spaces,
+    and duplicate targets (56 repo-wide) are kept once, at first appearance,
+    so anchors stay unique.
+    """
+    summary = os.path.join(REPO_ROOT, space, "SUMMARY.md")
+    entries, seen = [], set()
+    indents = []
+    raw = []
+    for line in open(summary, encoding="utf-8"):
+        m = ENTRY_RE.match(line.rstrip("\n"))
+        if not m:
+            continue
+        indent, title, target = len(m.group(1)), m.group(2), m.group(3)
+        if target.startswith(("http://", "https://", "#")):
+            continue
+        raw.append((indent, title, target.split("#")[0]))
+        indents.append(indent)
+
+    # Normalize indentation to depth levels.
+    unique_indents = sorted(set(indents))
+    depth_of = {ind: i for i, ind in enumerate(unique_indents)}
+
+    for indent, title, target in raw:
+        if target in seen:
+            continue
+        abs_path = os.path.join(REPO_ROOT, space, target)
+        if not os.path.isfile(abs_path):
+            print(f"  warn: SUMMARY target missing, skipped: {target}",
+                  file=sys.stderr)
+            continue
+        seen.add(target)
+        entries.append((depth_of[indent], title.strip(), target))
+    return entries
+
+
+def anchor_for(path):
+    """Stable, unique, short HTML id derived from the page path.
+
+    Deep paths in `server/` produce slugs well past the 127-byte limit PDF
+    places on name tokens, which makes readers reject the destination. A
+    truncated slug plus a hash of the full path stays inside the limit while
+    remaining unique and human-recognizable.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-",
+                  path.lower().removesuffix(".md")).strip("-")
+    digest = hashlib.sha1(path.encode("utf-8")).hexdigest()[:8]
+    return f"pg-{slug[-60:].lstrip('-')}-{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+def build_markdown(space, entries, limit=None):
+    space_dir = os.path.join(REPO_ROOT, space)
+    if limit:
+        entries = entries[:limit]
+
+    anchors = {path: anchor_for(path) for _, _, path in entries}
+
+    chunks = []
+    for depth, title, path in entries:
+        abs_path = os.path.join(space_dir, path)
+        try:
+            with open(abs_path, encoding="utf-8") as fh:
+                src = fh.read()
+        except OSError as exc:
+            print(f"  warn: unreadable {path}: {exc}", file=sys.stderr)
+            continue
+        chunks.append(preprocess(
+            src,
+            page_path=abs_path,
+            space_dir=space_dir,
+            anchors=anchors,
+            heading_offset=depth,
+            web_base=WEB_BASE,
+            anchor_id=anchors[path],
+            title=title,
+        ))
+    return "\n\n".join(chunks), entries
+
+
+# SUMMARY.md titles carry Markdown escapes from the GitBook migration
+# (`wsrep\_provider\_options`). The TOC is emitted as raw HTML, so they have to
+# be unescaped here or the backslashes show up in the rendered contents list.
+MD_ESCAPE_RE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!<>|~])")
+
+
+def clean_title(title):
+    return MD_ESCAPE_RE.sub(r"\1", title).strip()
+
+
+# Only count markers naming a real GitBook block. A bare `{%` also occurs in
+# legitimate content -- `sformat('arg1: {%W %M %Y}')` in the SQL reference --
+# and flagging that would train readers to ignore this warning.
+LEAK_RE = re.compile(
+    r"\{%\s*(?:end)?(?:hint|tabs?|stepper|step|columns?|code|content-ref"
+    r"|embed|file|include|openapi|updates?|if)\b")
+
+
+def count_leaked_markers(markdown):
+    return len(LEAK_RE.findall(markdown))
+
+
+def build_toc_html(entries):
+    """A clickable table of contents mirroring SUMMARY.md."""
+    rows = []
+    for depth, title, path in entries:
+        rows.append(
+            f'<li class="toc-d{min(depth, 5)}">'
+            f'<a href="#{anchor_for(path)}">{html.escape(clean_title(title))}</a></li>')
+    return ('<nav class="toc"><h1>Contents</h1><ul>'
+            + "".join(rows) + "</ul></nav>")
+
+
+# Math and raw-TeX extensions must be OFF: GitBook has no TeX support, so a
+# `$` in shell prose is a dollar sign, not the start of an equation. Leaving
+# them on renders phrases like `write_rate = ...` as mangled math.
+PANDOC_FROM = (
+    "markdown"
+    "+fenced_divs+pipe_tables+raw_html+autolink_bare_uris"
+    "+backtick_code_blocks+footnotes+strikeout+task_lists+header_attributes"
+    "-tex_math_dollars-tex_math_single_backslash-tex_math_double_backslash"
+    "-raw_tex-latex_macros-citations"
+)
+
+
+def run_pandoc(markdown, title):
+    """Convert the assembled Markdown to an HTML fragment.
+
+    Syntax highlighting is disabled so print CSS owns code styling and the
+    intermediate HTML stays small on a 4,000-page space.
+    """
+    cmd = [
+        "pandoc",
+        "--from", PANDOC_FROM,
+        "--to", "html5",
+        "--syntax-highlighting=none",
+        "--wrap", "none",
+        "--metadata", f"title={title}",
+    ]
+    proc = subprocess.run(cmd, input=markdown, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.exit(f"error: pandoc failed:\n{proc.stderr[:4000]}")
+    if proc.stderr.strip():
+        print(f"  pandoc notes: {proc.stderr.strip()[:500]}", file=sys.stderr)
+    return proc.stdout
+
+
+MERMAID_JS = os.path.join(PDF_DIR, "vendor", "mermaid.min.js")
+
+
+def load_mermaid():
+    """Return the Mermaid bundle, or None to fall back to plain code blocks.
+
+    The 3.5 MB bundle is fetched by `pdf/fetch-deps.sh` rather than committed;
+    without it the 111 pages with diagrams still build, showing diagram source.
+    """
+    if os.path.isfile(MERMAID_JS):
+        with open(MERMAID_JS, encoding="utf-8") as fh:
+            return fh.read()
+    print("  note: pdf/vendor/mermaid.min.js absent -- diagrams will render as "
+          "source text (run pdf/fetch-deps.sh to enable)", file=sys.stderr)
+    return None
+
+
+def build_html(space, body_html, toc_html, entries, version_label):
+    with open(os.path.join(PDF_DIR, "style.css"), encoding="utf-8") as fh:
+        css = fh.read()
+    mermaid_js = load_mermaid()
+    mermaid_block = (
+        f"<script>{mermaid_js}</script>\n<script>"
+        "(async () => {"
+        "  try {"
+        "    mermaid.initialize({ startOnLoad: false, theme: 'neutral' });"
+        "    await mermaid.run({ querySelector: 'pre.mermaid' });"
+        "  } catch (e) { console.error('mermaid', e); }"
+        "  window.__renderComplete = true;"
+        "})();</script>"
+        if mermaid_js else
+        "<script>window.__renderComplete = true;</script>"
+    )
+
+    title = SPACE_TITLES.get(space, space)
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>{html.escape(title)}</title>
+<style>{css}</style>
+</head><body>
+<section class="cover">
+  <h1>{html.escape(title)}</h1>
+  <p class="subtitle">Documentation</p>
+  <p class="meta">{html.escape(version_label)}<br>{len(entries)} pages</p>
+  <p class="legal">&copy; MariaDB. Content licensed CC BY-SA / GNU FDL.
+  The authoritative, continuously updated version of this documentation is at
+  <a href="{WEB_BASE}">mariadb.com/docs</a>.</p>
+</section>
+{toc_html}
+<main>
+{body_html}
+</main>
+{mermaid_block}
+</body></html>
+"""
+
+
+def html_to_pdf(html_path, pdf_path, chrome):
+    cmd = [
+        chrome,
+        "--headless",
+        "--disable-gpu",
+        "--no-sandbox",
+        "--no-pdf-header-footer",
+        "--allow-file-access-from-files",
+        "--virtual-time-budget=600000",
+        f"--print-to-pdf={pdf_path}",
+        # Percent-encode: an --out-dir containing spaces would otherwise
+        # truncate the URL and Chrome would print an error page.
+        "file://" + quote(os.path.abspath(html_path)),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+    if not os.path.isfile(pdf_path):
+        sys.exit(f"error: Chrome produced no PDF:\n{proc.stderr[:4000]}")
+
+
+def build_space(space, out_dir, version_label, limit=None, keep_html=False,
+                no_optimize=False):
+    print(f"[{space}] parsing SUMMARY.md")
+    entries = parse_summary(space)
+    print(f"[{space}] {len(entries)} pages in navigation order")
+
+    print(f"[{space}] preprocessing")
+    markdown, entries = build_markdown(space, entries, limit)
+
+    leaked = count_leaked_markers(markdown)
+    if leaked:
+        print(f"[{space}] warn: {leaked} unconverted GitBook markers remain",
+              file=sys.stderr)
+
+    print(f"[{space}] pandoc")
+    body_html = run_pandoc(markdown, SPACE_TITLES.get(space, space))
+    page = build_html(space, body_html, build_toc_html(entries), entries,
+                      version_label)
+
+    os.makedirs(out_dir, exist_ok=True)
+    html_path = os.path.join(out_dir, f"mariadb-{space}.html")
+    with open(html_path, "w", encoding="utf-8") as fh:
+        fh.write(page)
+
+    pdf_path = os.path.join(out_dir, f"mariadb-{space}.pdf")
+    print(f"[{space}] rendering PDF via Chrome")
+    html_to_pdf(html_path, pdf_path, find_chrome())
+
+    if not no_optimize:
+        print(f"[{space}] optimizing")
+        optimize_pdf(pdf_path)
+
+    if not keep_html:
+        os.remove(html_path)
+
+    size_mb = os.path.getsize(pdf_path) / 1e6
+    pages = pdf_page_count(pdf_path)
+    print(f"[{space}] done: {pdf_path} ({size_mb:.1f} MB, {pages} PDF pages)")
+    return {"space": space, "pdf": pdf_path, "size_mb": size_mb,
+            "pdf_pages": pages, "doc_pages": len(entries),
+            "leaked_markers": leaked}
+
+
+def optimize_pdf(path):
+    """Losslessly shrink the PDF with qpdf, preserving every link.
+
+    Chrome emits no object streams and leaves roughly half its streams
+    uncompressed, so repacking saves ~35% (8.3 MB -> 5.4 MB on
+    `galera-cluster`) with links, named destinations and page count untouched.
+
+    Ghostscript shrinks more but strips every /Link and /Dest, which would kill
+    cross-reference navigation -- do not substitute it here.
+    """
+    if not shutil.which("qpdf"):
+        print("  note: qpdf absent -- skipping lossless size optimization",
+              file=sys.stderr)
+        return
+
+    tmp = path + ".opt"
+    proc = subprocess.run(
+        ["qpdf", "--object-streams=generate", "--compress-streams=y",
+         "--recompress-flate", "--compression-level=9", "--linearize",
+         path, tmp],
+        capture_output=True, text=True)
+    # qpdf exits 3 on recoverable warnings and still writes valid output.
+    if proc.returncode not in (0, 3) or not os.path.isfile(tmp):
+        print(f"  warn: qpdf failed, keeping unoptimized PDF: "
+              f"{proc.stderr.strip()[:300]}", file=sys.stderr)
+        if os.path.isfile(tmp):
+            os.remove(tmp)
+        return
+
+    before = os.path.getsize(path)
+    after = os.path.getsize(tmp)
+    if after >= before:
+        os.remove(tmp)
+        return
+    os.replace(tmp, path)
+    print(f"  optimized: {before / 1e6:.1f} MB -> {after / 1e6:.1f} MB "
+          f"({100 * (1 - after / before):.0f}% smaller)")
+
+
+def pdf_page_count(path):
+    if not shutil.which("pdfinfo"):
+        return "?"
+    proc = subprocess.run(["pdfinfo", path], capture_output=True, text=True)
+    m = re.search(r"^Pages:\s+(\d+)", proc.stdout, re.MULTILINE)
+    return int(m.group(1)) if m else "?"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("spaces", nargs="*", help="space directories to build")
+    ap.add_argument("--all", action="store_true", help="build every space")
+    ap.add_argument("--out-dir", default=os.path.join(REPO_ROOT, "dist"))
+    ap.add_argument("--limit", type=int, help="only the first N pages (testing)")
+    ap.add_argument("--version-label", default="",
+                    help="text for the cover page, e.g. 'Snapshot 2026-07-28'")
+    ap.add_argument("--keep-html", action="store_true",
+                    help="retain the intermediate HTML for debugging")
+    ap.add_argument("--no-optimize", action="store_true",
+                    help="skip the qpdf lossless size pass")
+    ap.add_argument("--list-spaces", action="store_true",
+                    help="print the buildable spaces as JSON and exit; with "
+                         "space arguments, validate them first (CI matrix)")
+    args = ap.parse_args()
+
+    # A full run takes tens of minutes; unbuffered output lets CI logs and
+    # `tail -f` show which space is in flight instead of nothing until the end.
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
+    if args.list_spaces:
+        wanted = args.spaces or ALL_SPACES
+        unknown = [s for s in wanted if s not in ALL_SPACES]
+        if unknown:
+            ap.error(f"not a documentation space: {', '.join(unknown)}")
+        print(json.dumps(wanted))
+        return
+
+    spaces = ALL_SPACES if args.all else args.spaces
+    if not spaces:
+        ap.error("name at least one space, or pass --all")
+    unknown = [s for s in spaces if s not in ALL_SPACES]
+    if unknown:
+        ap.error(f"not a documentation space: {', '.join(unknown)}")
+
+    if not shutil.which("pandoc"):
+        sys.exit("error: pandoc is not installed")
+
+    results = [build_space(s, args.out_dir, args.version_label, args.limit,
+                           args.keep_html, args.no_optimize) for s in spaces]
+
+    print("\n=== summary ===")
+    for r in results:
+        print(f"{r['space']:20} {r['doc_pages']:5} docs  "
+              f"{str(r['pdf_pages']):>6} pages  {r['size_mb']:6.1f} MB"
+              + (f"  ({r['leaked_markers']} leaked)" if r["leaked_markers"] else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -192,28 +192,42 @@ def count_leaked_markers(markdown):
     return len(LEAK_RE.findall(markdown))
 
 
-# Cross-space links reach the checkout already expanded to app.gitbook.com
-# editor URLs (see `GITBOOK_SPACE_IDS`), which demand a login and are useless in
-# a PDF. The preprocessor reverses them; this asserts none survived, because the
-# failure is invisible in a 6,000-page PDF -- the link looks fine until clicked.
+# Two ways an outbound link can be built wrong, both of which look like a
+# working link in the PDF and so cannot be caught by eye in 6,000 pages:
+#
+# - an app.gitbook.com *editor* URL that escaped the rewriter (see
+#   `GITBOOK_SPACE_IDS`), which demands a login;
+# - a published URL still carrying its `.md` source suffix, which the site
+#   answers with an HTTP 200 soft-404 -- so even a link checker calls it fine
+#   while the reader gets an error page.
 EDITOR_URL_RE = re.compile(r"app\.gitbook\.com", re.I)
+SUFFIXED_URL_RE = re.compile(r"https?://mariadb\.com/docs/[^\s)\"'<>]*\.md\b",
+                             re.I)
 
 
-def count_editor_urls(markdown):
-    """Count editor URLs left in prose, ignoring code.
+def _count_in_prose(markdown, pattern):
+    """Count `pattern` outside fenced and inline code.
 
-    Code is skipped for the same reason the preprocessor skips it: an editor URL
-    inside a fence is content, not a broken link. `general-resources` documents
-    the `app.gitbook.com/s/<id>` prefixes literally, and MaxScale has one in a
-    SQL comment -- counting those would make this warning fire on every build
-    and so train readers to ignore it.
+    Code is skipped for the same reason the preprocessor skips it: a URL inside
+    a fence is content, not a link. `general-resources` documents both the
+    `app.gitbook.com/s/<id>` prefixes and a `.md` alias example literally, and
+    MaxScale has an editor URL in a SQL comment -- counting those would make
+    these warnings fire on every build and train readers to ignore them.
     """
     count = 0
     for line, in_code in iter_lines(markdown):
         if in_code:
             continue
-        count += len(EDITOR_URL_RE.findall(INLINE_CODE_RE.sub("", line)))
+        count += len(pattern.findall(INLINE_CODE_RE.sub("", line)))
     return count
+
+
+def count_editor_urls(markdown):
+    return _count_in_prose(markdown, EDITOR_URL_RE)
+
+
+def count_suffixed_urls(markdown):
+    return _count_in_prose(markdown, SUFFIXED_URL_RE)
 
 
 def build_toc_html(entries):
@@ -416,6 +430,11 @@ def build_space(space, out_dir, version_label, limit=None, keep_html=False,
         print(f"[{space}] warn: {editor_urls} app.gitbook.com editor URLs "
               f"remain (unmapped space ID?)", file=sys.stderr)
 
+    suffixed_urls = count_suffixed_urls(markdown)
+    if suffixed_urls:
+        print(f"[{space}] warn: {suffixed_urls} site URLs still end in .md "
+              f"(soft-404 on the site)", file=sys.stderr)
+
     print(f"[{space}] pandoc")
     body_html = run_pandoc(markdown, SPACE_TITLES.get(space, space))
     page = build_html(space, body_html, build_toc_html(entries), entries,
@@ -442,7 +461,8 @@ def build_space(space, out_dir, version_label, limit=None, keep_html=False,
     print(f"[{space}] done: {pdf_path} ({size_mb:.1f} MB, {pages} PDF pages)")
     return {"space": space, "pdf": pdf_path, "size_mb": size_mb,
             "pdf_pages": pages, "doc_pages": len(entries),
-            "leaked_markers": leaked, "editor_urls": editor_urls}
+            "leaked_markers": leaked, "editor_urls": editor_urls,
+            "suffixed_urls": suffixed_urls}
 
 
 def optimize_pdf(path):
@@ -553,7 +573,8 @@ def main():
         print(f"{r['space']:20} {r['doc_pages']:5} docs  "
               f"{str(r['pdf_pages']):>6} pages  {r['size_mb']:6.1f} MB"
               + (f"  ({r['leaked_markers']} leaked)" if r["leaked_markers"] else "")
-              + (f"  ({r['editor_urls']} editor URLs)" if r["editor_urls"] else ""))
+              + (f"  ({r['editor_urls']} editor URLs)" if r["editor_urls"] else "")
+              + (f"  ({r['suffixed_urls']} .md URLs)" if r["suffixed_urls"] else ""))
 
     if failed:
         print(f"\nFAILED: {', '.join(failed)}", file=sys.stderr)

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -16,6 +16,7 @@ contains raw HTML tables and Mermaid diagrams that a TeX engine cannot render.
 """
 
 import argparse
+import datetime
 import hashlib
 import html
 import json
@@ -520,8 +521,9 @@ def main():
     ap.add_argument("--all", action="store_true", help="build every space")
     ap.add_argument("--out-dir", default=os.path.join(REPO_ROOT, "dist"))
     ap.add_argument("--limit", type=int, help="only the first N pages (testing)")
-    ap.add_argument("--version-label", default="",
-                    help="text for the cover page, e.g. 'Snapshot 2026-07-28'")
+    ap.add_argument("--version-label", default=None,
+                    help="cover-page text, e.g. 'Snapshot 2026-07-28'; "
+                         "defaults to today's date. Pass '' to omit it.")
     ap.add_argument("--keep-html", action="store_true",
                     help="retain the intermediate HTML for debugging")
     ap.add_argument("--no-optimize", action="store_true",
@@ -557,13 +559,22 @@ def main():
     if not shutil.which("pandoc"):
         sys.exit("error: pandoc is not installed")
 
+    # An undated snapshot of continuously-updated documentation is close to
+    # useless -- and with an empty default, forgetting the flag dropped the date
+    # silently. The workflow resolves it the same way, so a local build and a CI
+    # build now label the cover identically. `--version-label ''` still omits it.
+    label = args.version_label
+    if label is None:
+        label = "Snapshot " + datetime.date.today().isoformat()
+    print(f"cover label: {label or '(none)'}")
+
     # One space failing must not discard the others: a full run is tens of
     # minutes, and the CI matrix has fail-fast disabled for the same reason.
     results, failed = [], []
     for space in spaces:
         try:
             results.append(build_space(
-                space, args.out_dir, args.version_label, args.limit,
+                space, args.out_dir, label, args.limit,
                 args.keep_html, args.no_optimize, args.cover))
         except RenderError as exc:
             print(f"[{space}] FAILED: {exc}", file=sys.stderr)

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -30,7 +30,7 @@ from urllib.parse import quote
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from gitbook_preprocess import (  # noqa: E402
-    INLINE_CODE_RE, iter_lines, preprocess)
+    INLINE_CODE_RE, iter_lines, preprocess, unescape_md)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PDF_DIR = os.path.join(REPO_ROOT, "pdf")
@@ -147,6 +147,9 @@ def build_markdown(space, entries, limit=None):
         entries = entries[:limit]
 
     anchors = {path: anchor_for(path) for _, _, path in entries}
+    # Reference labels come from these, so a `{% content-ref %}` names the page
+    # the same way the contents list and the PDF outline do.
+    titles = {path: clean_title(title) for _, title, path in entries}
 
     chunks = []
     for depth, title, path in entries:
@@ -166,6 +169,7 @@ def build_markdown(space, entries, limit=None):
             web_base=WEB_BASE,
             anchor_id=anchors[path],
             title=title,
+            titles=titles,
         ))
     return "\n\n".join(chunks), entries
 
@@ -173,11 +177,8 @@ def build_markdown(space, entries, limit=None):
 # SUMMARY.md titles carry Markdown escapes from the GitBook migration
 # (`wsrep\_provider\_options`). The TOC is emitted as raw HTML, so they have to
 # be unescaped here or the backslashes show up in the rendered contents list.
-MD_ESCAPE_RE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!<>|~])")
-
-
 def clean_title(title):
-    return MD_ESCAPE_RE.sub(r"\1", title).strip()
+    return unescape_md(title)
 
 
 # Only count markers naming a real GitBook block. A bare `{%` also occurs in

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -24,6 +24,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import time
 from urllib.parse import quote
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -251,7 +253,8 @@ def load_mermaid():
     return None
 
 
-def build_html(space, body_html, toc_html, entries, version_label):
+def build_html(space, body_html, toc_html, entries, version_label,
+               cover="azure"):
     with open(os.path.join(PDF_DIR, "style.css"), encoding="utf-8") as fh:
         css = fh.read()
     mermaid_js = load_mermaid()
@@ -269,12 +272,13 @@ def build_html(space, body_html, toc_html, entries, version_label):
     )
 
     title = SPACE_TITLES.get(space, space)
+    cover_class = COVER_CLASS[cover]
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <title>{html.escape(title)}</title>
 <style>{css}</style>
 </head><body>
-<section class="cover">
+<section class="cover cover-{cover_class}">
   <h1>{html.escape(title)}</h1>
   <p class="subtitle">Documentation</p>
   <p class="meta">{html.escape(version_label)}<br>{len(entries)} pages</p>
@@ -291,7 +295,26 @@ def build_html(space, body_html, toc_html, entries, version_label):
 """
 
 
+class RenderError(RuntimeError):
+    """Chrome failed to produce a PDF for one space."""
+
+
+# Headless Chrome writes a complete, valid PDF and then sometimes fails to
+# exit -- observed on `tools` and `mariadb-cloud`, where the finished file was
+# already on disk while the process sat idle for tens of minutes. So the PDF on
+# disk is the completion signal, not the process exit, and Chrome is terminated
+# once its output stops growing. `--virtual-time-budget` is virtual-clock only
+# and bounds nothing in wall-clock terms.
+CHROME_TIMEOUT_S = 1800
+STABLE_CHECKS = 3          # consecutive equal sizes before the file is settled
+POLL_INTERVAL_S = 2.0
+
+
 def html_to_pdf(html_path, pdf_path, chrome):
+    if os.path.exists(pdf_path):
+        os.remove(pdf_path)     # a stale file would look like instant success
+
+    profile = tempfile.mkdtemp(prefix="mariadb-pdf-chrome-")
     cmd = [
         chrome,
         "--headless",
@@ -299,19 +322,58 @@ def html_to_pdf(html_path, pdf_path, chrome):
         "--no-sandbox",
         "--no-pdf-header-footer",
         "--allow-file-access-from-files",
+        # Private profile: never contend with another instance's singleton lock.
+        f"--user-data-dir={profile}",
+        "--no-first-run",
+        "--disable-extensions",
         "--virtual-time-budget=600000",
         f"--print-to-pdf={pdf_path}",
         # Percent-encode: an --out-dir containing spaces would otherwise
         # truncate the URL and Chrome would print an error page.
         "file://" + quote(os.path.abspath(html_path)),
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
-    if not os.path.isfile(pdf_path):
-        sys.exit(f"error: Chrome produced no PDF:\n{proc.stderr[:4000]}")
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True)
+    deadline = time.monotonic() + CHROME_TIMEOUT_S
+    last_size, stable = -1, 0
+    try:
+        while True:
+            if proc.poll() is not None:
+                break           # exited on its own: the normal path
+            size = os.path.getsize(pdf_path) if os.path.isfile(pdf_path) else -1
+            if size >= 0 and size == last_size:
+                stable += 1
+                if stable >= STABLE_CHECKS:
+                    break       # output settled; Chrome is just not leaving
+            else:
+                stable = 0
+            last_size = size
+            if time.monotonic() > deadline:
+                raise RenderError(
+                    f"Chrome exceeded {CHROME_TIMEOUT_S}s with no complete PDF")
+            time.sleep(POLL_INTERVAL_S)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=30)
+        shutil.rmtree(profile, ignore_errors=True)
+
+    if not os.path.isfile(pdf_path) or os.path.getsize(pdf_path) == 0:
+        stderr = (proc.stderr.read() if proc.stderr else "")[:2000]
+        raise RenderError(f"Chrome produced no PDF:\n{stderr}")
+
+
+# Cover treatments, both verified against WCAG (see pdf/style.css).
+COVER_CLASS = {"azure": "azure", "sea-fresh": "sea"}
 
 
 def build_space(space, out_dir, version_label, limit=None, keep_html=False,
-                no_optimize=False):
+                no_optimize=False, cover="azure"):
     print(f"[{space}] parsing SUMMARY.md")
     entries = parse_summary(space)
     print(f"[{space}] {len(entries)} pages in navigation order")
@@ -327,7 +389,7 @@ def build_space(space, out_dir, version_label, limit=None, keep_html=False,
     print(f"[{space}] pandoc")
     body_html = run_pandoc(markdown, SPACE_TITLES.get(space, space))
     page = build_html(space, body_html, build_toc_html(entries), entries,
-                      version_label)
+                      version_label, cover)
 
     os.makedirs(out_dir, exist_ok=True)
     html_path = os.path.join(out_dir, f"mariadb-{space}.html")
@@ -413,6 +475,9 @@ def main():
                     help="retain the intermediate HTML for debugging")
     ap.add_argument("--no-optimize", action="store_true",
                     help="skip the qpdf lossless size pass")
+    ap.add_argument("--cover", choices=sorted(COVER_CLASS), default="azure",
+                    help="cover treatment: Blue Azure with white text "
+                         "(default) or Sea Fresh with Deep Ocean text")
     ap.add_argument("--list-spaces", action="store_true",
                     help="print the buildable spaces as JSON and exit; with "
                          "space arguments, validate them first (CI matrix)")
@@ -441,8 +506,17 @@ def main():
     if not shutil.which("pandoc"):
         sys.exit("error: pandoc is not installed")
 
-    results = [build_space(s, args.out_dir, args.version_label, args.limit,
-                           args.keep_html, args.no_optimize) for s in spaces]
+    # One space failing must not discard the others: a full run is tens of
+    # minutes, and the CI matrix has fail-fast disabled for the same reason.
+    results, failed = [], []
+    for space in spaces:
+        try:
+            results.append(build_space(
+                space, args.out_dir, args.version_label, args.limit,
+                args.keep_html, args.no_optimize, args.cover))
+        except RenderError as exc:
+            print(f"[{space}] FAILED: {exc}", file=sys.stderr)
+            failed.append(space)
 
     print("\n=== summary ===")
     for r in results:
@@ -450,6 +524,11 @@ def main():
               f"{str(r['pdf_pages']):>6} pages  {r['size_mb']:6.1f} MB"
               + (f"  ({r['leaked_markers']} leaked)" if r["leaked_markers"] else ""))
 
+    if failed:
+        print(f"\nFAILED: {', '.join(failed)}", file=sys.stderr)
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/pdf/build.py
+++ b/pdf/build.py
@@ -29,7 +29,8 @@ import time
 from urllib.parse import quote
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from gitbook_preprocess import preprocess  # noqa: E402
+from gitbook_preprocess import (  # noqa: E402
+    INLINE_CODE_RE, iter_lines, preprocess)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PDF_DIR = os.path.join(REPO_ROOT, "pdf")
@@ -189,6 +190,30 @@ LEAK_RE = re.compile(
 
 def count_leaked_markers(markdown):
     return len(LEAK_RE.findall(markdown))
+
+
+# Cross-space links reach the checkout already expanded to app.gitbook.com
+# editor URLs (see `GITBOOK_SPACE_IDS`), which demand a login and are useless in
+# a PDF. The preprocessor reverses them; this asserts none survived, because the
+# failure is invisible in a 6,000-page PDF -- the link looks fine until clicked.
+EDITOR_URL_RE = re.compile(r"app\.gitbook\.com", re.I)
+
+
+def count_editor_urls(markdown):
+    """Count editor URLs left in prose, ignoring code.
+
+    Code is skipped for the same reason the preprocessor skips it: an editor URL
+    inside a fence is content, not a broken link. `general-resources` documents
+    the `app.gitbook.com/s/<id>` prefixes literally, and MaxScale has one in a
+    SQL comment -- counting those would make this warning fire on every build
+    and so train readers to ignore it.
+    """
+    count = 0
+    for line, in_code in iter_lines(markdown):
+        if in_code:
+            continue
+        count += len(EDITOR_URL_RE.findall(INLINE_CODE_RE.sub("", line)))
+    return count
 
 
 def build_toc_html(entries):
@@ -386,6 +411,11 @@ def build_space(space, out_dir, version_label, limit=None, keep_html=False,
         print(f"[{space}] warn: {leaked} unconverted GitBook markers remain",
               file=sys.stderr)
 
+    editor_urls = count_editor_urls(markdown)
+    if editor_urls:
+        print(f"[{space}] warn: {editor_urls} app.gitbook.com editor URLs "
+              f"remain (unmapped space ID?)", file=sys.stderr)
+
     print(f"[{space}] pandoc")
     body_html = run_pandoc(markdown, SPACE_TITLES.get(space, space))
     page = build_html(space, body_html, build_toc_html(entries), entries,
@@ -412,7 +442,7 @@ def build_space(space, out_dir, version_label, limit=None, keep_html=False,
     print(f"[{space}] done: {pdf_path} ({size_mb:.1f} MB, {pages} PDF pages)")
     return {"space": space, "pdf": pdf_path, "size_mb": size_mb,
             "pdf_pages": pages, "doc_pages": len(entries),
-            "leaked_markers": leaked}
+            "leaked_markers": leaked, "editor_urls": editor_urls}
 
 
 def optimize_pdf(path):
@@ -522,7 +552,8 @@ def main():
     for r in results:
         print(f"{r['space']:20} {r['doc_pages']:5} docs  "
               f"{str(r['pdf_pages']):>6} pages  {r['size_mb']:6.1f} MB"
-              + (f"  ({r['leaked_markers']} leaked)" if r["leaked_markers"] else ""))
+              + (f"  ({r['leaked_markers']} leaked)" if r["leaked_markers"] else "")
+              + (f"  ({r['editor_urls']} editor URLs)" if r["editor_urls"] else ""))
 
     if failed:
         print(f"\nFAILED: {', '.join(failed)}", file=sys.stderr)

--- a/pdf/check_contrast.py
+++ b/pdf/check_contrast.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Assert that every text/background pair in pdf/style.css meets WCAG 2.1 AA.
+
+    python3 pdf/check_contrast.py
+
+Accessibility is a stated requirement for these PDFs, and contrast is easy to
+break by eye -- dimming white to 75% over Blue Azure looks fine on screen and
+lands at 4.45:1, under the 4.5:1 floor for body text. The pairs are listed
+explicitly here rather than parsed out of the CSS: the point is to state the
+intended contract, so a styling change that violates it fails loudly.
+
+Thresholds (WCAG 2.1): 4.5:1 normal text, 3:1 large text (>=18pt, or >=14pt
+bold). Exits non-zero on any failure.
+"""
+
+import sys
+
+# MariaDB brand palette, slide 26 of the corporate deck.
+AZURE = "#0E6488"
+SEA = "#96DDCF"
+GRANITE = "#424F62"
+SEAS = "#00838F"
+SEAS_TEXT = "#00707a"   # darkened Open Seas for small text
+OCEAN = "#003545"
+EEL = "#ABC74A"
+
+INK = "#12242b"
+MUTED = GRANITE
+WHITE = "#ffffff"
+CODE_BG = "#f4f7f8"
+COVER_AZURE_DIM = "#d9ece6"
+
+# (description, foreground, background, is_large_text)
+PAIRS = [
+    # body
+    ("body text on white",             INK,     WHITE,   False),
+    ("muted text (Granite) on white",  MUTED,   WHITE,   False),
+    ("link (Blue Azure) on white",     AZURE,   WHITE,   False),
+    ("heading (Blue Azure) on white",  AZURE,   WHITE,   True),
+    ("top heading (Deep Ocean)",       OCEAN,   WHITE,   True),
+    ("inline code on code tint",       "#14252c", CODE_BG, False),
+    ("code block text on tint",        INK,     CODE_BG, False),
+
+    # cover: Blue Azure
+    ("cover-azure title",              WHITE,   AZURE,   True),
+    ("cover-azure subtitle",           COVER_AZURE_DIM, AZURE, True),
+    ("cover-azure meta (10pt)",        COVER_AZURE_DIM, AZURE, False),
+    ("cover-azure legal (8.5pt)",      COVER_AZURE_DIM, AZURE, False),
+    ("cover-azure link",               WHITE,   AZURE,   False),
+
+    # cover: Sea Fresh
+    ("cover-sea title",                OCEAN,   SEA,     True),
+    ("cover-sea subtitle",             OCEAN,   SEA,     True),
+    ("cover-sea meta (10pt)",          OCEAN,   SEA,     False),
+    ("cover-sea legal (8.5pt)",        OCEAN,   SEA,     False),
+
+    # toc
+    ("toc entry on white",             INK,     WHITE,   False),
+    ("toc deep entry (Granite)",       MUTED,   WHITE,   False),
+    ("toc heading (Deep Ocean)",       OCEAN,   WHITE,   True),
+
+    # callouts -- text sits on the tinted background
+    ("note text on info tint",         INK,     "#eaf2f6", False),
+    ("tip text on success tint",       INK,     "#e4f4ef", False),
+    ("warning text on warning tint",   INK,     "#fdf4e6", False),
+    ("important text on danger tint",  INK,     "#fceeed", False),
+    ("hint label on neutral tint",     INK,     "#f5f7f8", False),
+
+    # tables
+    ("table header on Sea Fresh tint", INK,     "#e4f4ef", False),
+    ("table cell on white",            INK,     WHITE,   False),
+
+    # tabs and steppers
+    ("tab label (Open Seas dk) on white", SEAS_TEXT, WHITE, False),
+    ("step label (Deep Ocean)",        OCEAN,   WHITE,   False),
+]
+
+# Decorative fills: never carry text, so they are exempt from the text
+# thresholds but must still be discernible against what they sit on.
+DECORATIVE = [
+    ("Electric Eel rule on white",     EEL,     WHITE),
+    ("Electric Eel rule on azure",     EEL,     AZURE),
+    ("Electric Eel rule on sea fresh", EEL,     SEA),
+    ("Sea Fresh step rule on white",   SEA,     WHITE),
+]
+
+
+def _channel(value):
+    value /= 255
+    return value / 12.92 if value <= 0.03928 else ((value + 0.055) / 1.055) ** 2.4
+
+
+def luminance(hex_color):
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i:i + 2], 16) for i in (0, 2, 4))
+    return 0.2126 * _channel(r) + 0.7152 * _channel(g) + 0.0722 * _channel(b)
+
+
+def contrast(fg, bg):
+    a, b = luminance(fg), luminance(bg)
+    return (max(a, b) + 0.05) / (min(a, b) + 0.05)
+
+
+def main():
+    failures = []
+    print(f"{'pair':36} {'ratio':>6}  {'need':>5}  result")
+    print("-" * 62)
+    for label, fg, bg, large in PAIRS:
+        ratio = contrast(fg, bg)
+        need = 3.0 if large else 4.5
+        ok = ratio >= need
+        grade = "AAA" if ratio >= (4.5 if large else 7) else ("AA" if ok else "FAIL")
+        print(f"{label:36} {ratio:6.2f}  {need:5.1f}  {grade}")
+        if not ok:
+            failures.append((label, fg, bg, ratio, need))
+
+    print()
+    print("decorative (no text, informational only):")
+    for label, fg, bg in DECORATIVE:
+        print(f"  {label:34} {contrast(fg, bg):6.2f}")
+
+    print()
+    if failures:
+        print(f"FAIL: {len(failures)} pair(s) below WCAG AA")
+        for label, fg, bg, ratio, need in failures:
+            print(f"  {label}: {fg} on {bg} = {ratio:.2f}, needs {need:.1f}")
+        return 1
+    print(f"PASS: all {len(PAIRS)} text pairs meet WCAG 2.1 AA")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pdf/fetch-deps.sh
+++ b/pdf/fetch-deps.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fetch the Mermaid bundle used to render diagrams in the PDFs.
+#
+# The bundle is ~3.5 MB, so it is fetched on demand rather than committed.
+# Without it, pdf/build.py still succeeds -- the 111 pages containing diagrams
+# just show the diagram source instead of a rendered figure.
+set -euo pipefail
+
+MERMAID_VERSION="${MERMAID_VERSION:-11.16.0}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+vendor="$here/vendor"
+target="$vendor/mermaid.min.js"
+
+if [[ -f "$target" && -z "${FORCE:-}" ]]; then
+  echo "mermaid already present: $target (set FORCE=1 to refetch)"
+  exit 0
+fi
+
+command -v npm >/dev/null || { echo "error: npm is required" >&2; exit 1; }
+
+mkdir -p "$vendor"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "fetching mermaid@$MERMAID_VERSION"
+( cd "$tmp" && npm pack "mermaid@$MERMAID_VERSION" --silent >/dev/null )
+tar -xzf "$tmp"/mermaid-*.tgz -C "$tmp" package/dist/mermaid.min.js
+mv "$tmp/package/dist/mermaid.min.js" "$target"
+
+echo "installed $target ($(du -h "$target" | cut -f1))"

--- a/pdf/gitbook_preprocess.py
+++ b/pdf/gitbook_preprocess.py
@@ -423,6 +423,88 @@ HTML_HREF_RE = re.compile(r'href="([^"]+)"')
 HTML_SRC_RE = re.compile(r'src="([^"]+)"')
 ABSOLUTE = ("http://", "https://", "mailto:", "data:", "#", "tel:")
 
+# `.github/workflows/expand-gitbook-aliases.yml` rewrites every `{server}`-style
+# alias into an app.gitbook.com *editor* URL and commits that back to the branch,
+# so in any checkout cross-space links already look like
+# `https://app.gitbook.com/o/<org>/s/<space-id>/<path>`. GitBook resolves those
+# to mariadb.com/docs when it renders the site; nothing else does. A PDF built
+# from source therefore has to reverse the mapping, or every cross-space link
+# sends the reader to the editor (which demands a login) instead of the docs.
+#
+# IDs come from that workflow, and each was confirmed against the checkout: the
+# paths following a given ID resolve under exactly one space, and a page's
+# published URL path is its repo-relative path (spot-checked live). Note the
+# workflow maps BOTH `{skysql}` and `{release-notes}` to aEnK0ZXmUbJzqQrTjFyb;
+# 7,220 of its paths resolve under `release-notes/` and none under a SkySQL
+# tree, so that ID is treated as release-notes.
+GITBOOK_SPACE_IDS = {
+    "SsmexDFPv2xG2OTyO5yV": "server",
+    "aEnK0ZXmUbJzqQrTjFyb": "release-notes",
+    "CjGYMsT2MVP4nd3IyW2L": "connectors",
+    "WCInJQ9cmGjq1lsTG91E": "general-resources",
+    "3VYeeVGUV4AMqrA3zwy7": "galera-cluster",
+    "0pSbu5DcMSW4KwAkUcmX": "maxscale",
+    "rBEU9juWLfTDcdwF3Q14": "analytics",
+    "kuTXWg0NDbRx6XUeYpGD": "tools",
+    "JqgUabdZsoY5EiaJmqgn": "platform",
+    "vPz15Lz0Iw3P3yKR3Prd": "mariadb-cloud",
+    # These two have no space directory of their own; the site redirects them
+    # (`/docs/home` -> `/docs/`, `/docs/columnstore` -> `/docs/analytics`).
+    # Neither is linked from the corpus, so only the roots are exercised.
+    "gmXC0YXB3rRhXvpg5mb1": "home",
+    "2I4jZ8pGq8bT4w5n3q6r": "columnstore",
+}
+
+IS_GITBOOK_URL = re.compile(r"^https?://app\.gitbook\.com/", re.I)
+GITBOOK_SPACE_URL_RE = re.compile(
+    r"^https?://app\.gitbook\.com/(?:o/[A-Za-z0-9]+/)?s/([A-Za-z0-9]+)([^#?]*)",
+    re.I)
+
+# Same URL shape, unanchored, for the fallback sweep below. Trailing sentence
+# punctuation is excluded so `...see <url>.` does not fold the period into the
+# path.
+BARE_GITBOOK_URL_RE = re.compile(
+    r"https?://app\.gitbook\.com/(?:o/[A-Za-z0-9]+/)?s/[A-Za-z0-9]+"
+    r"(?:[^\s)\"'<>\]]*[^\s)\"'<>\].,;:!])?", re.I)
+
+# Backtick spans are content, not markup: `general-resources` documents the
+# `https://app.gitbook.com/s/` prefix literally, and rewriting it there would
+# turn an explanation of the alias system into a false statement.
+INLINE_CODE_RE = re.compile(r"`+[^`]*`+")
+
+
+def _outside_inline_code(line, fn):
+    """Apply `fn` to the parts of `line` that are not inside a backtick span."""
+    out, pos = [], 0
+    for m in INLINE_CODE_RE.finditer(line):
+        out.append(fn(line[pos:m.start()]))
+        out.append(m.group(0))
+        pos = m.end()
+    out.append(fn(line[pos:]))
+    return "".join(out)
+
+
+def parse_gitbook_url(url):
+    """Split a GitBook editor URL into `(space, path, fragment)`.
+
+    Returns None when the URL is not a space URL or names a space that is not in
+    `GITBOOK_SPACE_IDS` -- the caller drops such a link rather than inventing a
+    destination for it.
+    """
+    m = GITBOOK_SPACE_URL_RE.match(url)
+    if not m:
+        return None
+    space = GITBOOK_SPACE_IDS.get(m.group(1))
+    if space is None:
+        return None
+    path = m.group(2).strip("/").removesuffix(".md")
+    # `~/reusable/...` and `~/changes/...` address GitBook internals that have
+    # no public URL at all, so the space root is the closest honest target.
+    if path.startswith("~"):
+        path = ""
+    frag = url.partition("#")[2]
+    return space, path, ("#" + frag if frag else "")
+
 
 def rewrite_links(text, page_path, space_dir, anchors, web_base):
     """Point in-space links at PDF anchors, out-of-space links at the website.
@@ -432,8 +514,28 @@ def rewrite_links(text, page_path, space_dir, anchors, web_base):
     so Chrome can load them from the checkout.
     """
     page_dir = os.path.dirname(page_path)
+    this_space = os.path.basename(space_dir.rstrip("/") or space_dir)
+
+    def gitbook_target(url, prefer_anchor=True):
+        """Map a GitBook editor URL to a PDF anchor or a public site URL."""
+        parsed = parse_gitbook_url(url)
+        if parsed is None:
+            return None
+        space, path, frag = parsed
+        if prefer_anchor and space == this_space and path:
+            # A page addressing its own space by absolute URL: prefer the
+            # internal anchor so the cross-reference still works offline. The
+            # section fragment is dropped, matching relative in-space links.
+            for cand in (f"{path}.md", f"{path}/README.md"):
+                if cand in anchors:
+                    return "#" + anchors[cand]
+        base = f"{web_base.rstrip('/')}/{space}"
+        return f"{base}/{path}{frag}" if path else f"{base}{frag}"
 
     def anchor_target(url):
+        gitbook = gitbook_target(url)
+        if gitbook is not None:
+            return gitbook
         if url.startswith(ABSOLUTE):
             return None
         raw, _, _frag = url.partition("#")
@@ -473,17 +575,41 @@ def rewrite_links(text, page_path, space_dir, anchors, web_base):
 
         def md_sub(m):
             new = anchor_target(m.group(2))
-            return f"[{m.group(1)}]({new})" if new else m.group(0)
+            if new:
+                return f"[{m.group(1)}]({new})"
+            if IS_GITBOOK_URL.match(m.group(2)):
+                # An editor URL naming a space that no longer maps to a public
+                # one (a legacy pre-split space). Keep the text, drop the
+                # destination -- linking a reader to a login screen is worse
+                # than not linking at all.
+                return m.group(1)
+            return m.group(0)
 
         def href_sub(m):
             new = anchor_target(m.group(1))
-            return f'href="{new}"' if new else m.group(0)
+            if new:
+                return f'href="{new}"'
+            if IS_GITBOOK_URL.match(m.group(1)):
+                return f'href="{web_base}"'
+            return m.group(0)
+
+        def bare_sub(m):
+            # Never an anchor here: this substitutes the URL in place, and a
+            # bare `#pg-...` sitting in prose would be meaningless.
+            new = gitbook_target(m.group(0), prefer_anchor=False)
+            return new or m.group(0)
 
         line = IMG_LINK_RE.sub(img_sub, line)
         line = HTML_SRC_RE.sub(src_sub, line)
         line = MD_LINK_RE.sub(md_sub, line)
         line = HTML_HREF_RE.sub(href_sub, line)
-        return line
+        # Fallback for editor URLs the link regexes above cannot see: link text
+        # holding an escaped bracket (`[SHOW \[FULL\] PROCESSLIST](...)`), and
+        # links split over two lines by a migration hard break -- both real in
+        # this corpus, and both leave a working destination once the bare URL is
+        # mapped, even though the surrounding Markdown never matched.
+        return _outside_inline_code(line, lambda s: BARE_GITBOOK_URL_RE.sub(
+            bare_sub, s))
 
     return map_prose_lines(text, fix_line)
 

--- a/pdf/gitbook_preprocess.py
+++ b/pdf/gitbook_preprocess.py
@@ -1,0 +1,540 @@
+"""Convert GitBook-flavored Markdown into plain Markdown suitable for PDF.
+
+GitBook custom blocks (`{% hint %}`, `{% tabs %}`, `{% columns %}`, ...) are
+invisible to Pandoc and leak into the output as literal body text, so every one
+of them has to be rewritten or dropped before conversion. This module owns that
+rewriting; `build.py` owns page ordering and the PDF pipeline.
+
+Two properties drive the design:
+
+* Blocks routinely **span code fences** -- a `{% stepper %}` opens, several
+  fenced shell samples follow, then `{% endstepper %}` closes. Matching an
+  open/close pair with one regex therefore fails on real pages, so block
+  conversion is a single line-oriented pass that carries fence state.
+* Markers are **not always alone on a line** (`{% hint style="info" %} For the
+  CTE...` occurs verbatim in the corpus), so replacements inject their own line
+  breaks rather than assuming they own the line.
+
+The full tag inventory is in `pdf/README.md`.
+"""
+
+import html as _html
+import os
+import re
+import sys
+from urllib.parse import quote, unquote
+
+# ---------------------------------------------------------------------------
+# Frontmatter
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---[ \t]*\r?\n?", re.DOTALL)
+
+
+def split_frontmatter(text):
+    """Return (frontmatter_dict, body). Only scalar keys are parsed."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    meta = {}
+    for line in m.group(1).splitlines():
+        km = re.match(r"^([A-Za-z_][\w-]*):\s*(.*)$", line)
+        if km:
+            meta[km.group(1)] = km.group(2).strip().strip("'\"")
+    return meta, text[m.end():]
+
+
+# ---------------------------------------------------------------------------
+# Fence tracking
+#
+# Every transform must leave fenced code untouched: a `{% hint %}` inside a
+# GitBook-syntax example is content, not markup.
+# ---------------------------------------------------------------------------
+
+FENCE_RE = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
+
+
+def iter_lines(text):
+    """Yield (line_without_newline, in_code) for every line of `text`.
+
+    `in_code` is True for the fence delimiters themselves as well as their
+    contents, so callers can pass those lines through verbatim.
+    """
+    fence = None  # (marker_char, marker_len)
+    for line in text.split("\n"):
+        m = FENCE_RE.match(line)
+        if fence is None:
+            if m:
+                fence = (m.group(2)[0], len(m.group(2)))
+                yield line, True
+            else:
+                yield line, False
+        else:
+            yield line, True
+            if m and m.group(2)[0] == fence[0] and len(m.group(2)) >= fence[1] \
+                    and not m.group(3).strip():
+                fence = None
+
+
+def map_prose_lines(text, fn):
+    """Rewrite non-code lines with `fn`; `fn` may return multi-line text."""
+    out = []
+    for line, in_code in iter_lines(text):
+        out.append(line if in_code else fn(line))
+    return "\n".join(out)
+
+
+def prose_only(fn):
+    """Apply `fn` to each run of prose, leaving fenced code verbatim.
+
+    Suitable only for transforms that are line-local; anything that pairs an
+    opening and closing marker must use the block pass instead.
+    """
+    def wrapped(text, *a, **kw):
+        return map_prose_lines(text, lambda line: fn(line, *a, **kw))
+    return wrapped
+
+
+# ---------------------------------------------------------------------------
+# Marker patterns
+# ---------------------------------------------------------------------------
+
+HINT_OPEN = re.compile(r"\{%\s*hint\s+style=[\"'](\w+)[\"']\s*%\}")
+HINT_CLOSE = re.compile(r"\{%\s*endhint\s*%\}")
+TABS_OPEN = re.compile(r"\{%\s*tabs\s*%\}")
+TABS_CLOSE = re.compile(r"\{%\s*endtabs\s*%\}")
+TAB_OPEN = re.compile(r"\{%\s*tab\s+title=[\"'](.*?)[\"']\s*%\}")
+TAB_CLOSE = re.compile(r"\{%\s*endtab\s*%\}")
+STEPPER_OPEN = re.compile(r"\{%\s*stepper\s*%\}")
+STEPPER_CLOSE = re.compile(r"\{%\s*endstepper\s*%\}")
+STEP_OPEN = re.compile(r"\{%\s*step\s*%\}")
+STEP_CLOSE = re.compile(r"\{%\s*endstep\s*%\}")
+COLUMN_ANY = re.compile(r"\{%\s*(?:end)?columns?\s*%\}")
+CODE_OPEN = re.compile(r"\{%\s*code\b([^%]*)%\}")
+CODE_CLOSE = re.compile(r"\{%\s*endcode\s*%\}")
+TITLE_ATTR = re.compile(r"title=[\"'](.*?)[\"']")
+CREF_OPEN = re.compile(r"\{%\s*content-ref\s+url=[\"'](.*?)[\"'][^%]*%\}")
+CREF_CLOSE = re.compile(r"\{%\s*endcontent-ref\s*%\}")
+EMBED_OPEN = re.compile(r"\{%\s*embed\s+url=[\"'](.*?)[\"'][^%]*%\}")
+FILE_OPEN = re.compile(r"\{%\s*file\s+src=[\"'](.*?)[\"'][^%]*%\}")
+MD_LINK_INLINE = re.compile(r"\[([^\]]*)\]\(([^)\s]+)\)")
+
+# ~9,000 marketing form embeds and other integration blocks: no PDF meaning.
+INTEGRATION = re.compile(r"\{%\s*@[\w/.@-]+[^%]*%\}")
+# Conditionals, OpenAPI and "updates" wrappers: keep any body, drop the wrapper.
+WRAPPER_ONLY = re.compile(
+    r"\{%\s*(?:end)?(?:if|openapi|updates|update|embed|file)\b[^%]*%\}")
+# Backstop for anything the specific rules above did not catch.
+ANY_MARKER = re.compile(r"\{%[^%]*%\}")
+
+HINT_LABEL = {
+    "info": "Note",
+    "success": "Tip",
+    "warning": "Warning",
+    "danger": "Important",
+}
+
+
+def _esc_inline(s):
+    """Make an attribute value safe to drop into Markdown prose."""
+    return _html.escape(s.strip(), quote=False)
+
+
+# ---------------------------------------------------------------------------
+# Block conversion (single fence-aware pass)
+# ---------------------------------------------------------------------------
+
+# A few pages escape the braces (`\{% tabs %\}`), which stops GitBook rendering
+# the block at all -- those pages are broken on the live site too. Normalizing
+# here keeps the PDF clean; the source still wants fixing.
+ESCAPED_MARKER = re.compile(r"\\(\{%)|(%)\\(\})")
+
+
+def unescape_markers(text):
+    return map_prose_lines(
+        text, lambda ln: ESCAPED_MARKER.sub(
+            lambda m: m.group(1) or (m.group(2) + m.group(3)), ln))
+
+
+def convert_blocks(text):
+    """Rewrite every GitBook block marker into Pandoc fenced divs.
+
+    Runs as one pass because blocks nest and span code fences; a stack tracks
+    step numbering and a small state flag handles the multi-line
+    `{% content-ref %}` body.
+    """
+    text = unescape_markers(text)
+    out = []
+    step_counters = []       # one counter per open {% stepper %}
+    cref = None              # (url, [buffered lines]) while inside content-ref
+    depth = [0]              # open fenced divs, so the page can be balanced
+
+    def open_div(classes):
+        depth[0] += 1
+        return f"\n::: {{{classes}}}\n"
+
+    def close_div():
+        # A stray close (unbalanced source) would otherwise emit a bare ':::'
+        # that Pandoc prints literally.
+        if depth[0] == 0:
+            return ""
+        depth[0] -= 1
+        return "\n:::\n"
+
+    for line, in_code in iter_lines(text):
+        if in_code:
+            if cref is not None:
+                cref[1].append(line)
+            else:
+                out.append(line)
+            continue
+
+        # --- content-ref: consume until the closing marker ----------------
+        if cref is not None:
+            if CREF_CLOSE.search(line):
+                url, body = cref[0], "\n".join(cref[1])
+                inner = MD_LINK_INLINE.search(body)
+                label = inner.group(1) if inner else \
+                    (url.rstrip("/").split("/")[-1] or url)
+                out.append(f"\nSee [{_esc_inline(label)}]({url}).\n")
+                cref = None
+            else:
+                cref[1].append(line)
+            continue
+
+        m = CREF_OPEN.search(line)
+        if m:
+            before = line[:m.start()].rstrip()
+            if before:
+                out.append(before)
+            cref = (m.group(1), [line[m.end():]])
+            continue
+
+        # --- integration blocks and bare wrappers -------------------------
+        line = INTEGRATION.sub("", line)
+
+        # --- code fences with GitBook attributes --------------------------
+        def code_open_sub(mm):
+            tm = TITLE_ATTR.search(mm.group(1))
+            return f"\n**`{_esc_inline(tm.group(1))}`**\n" if tm else ""
+
+        line = CODE_OPEN.sub(code_open_sub, line)
+        line = CODE_CLOSE.sub("", line)
+
+        # --- hints --------------------------------------------------------
+        def hint_open_sub(mm):
+            style = mm.group(1).lower()
+            label = HINT_LABEL.get(style, "Note")
+            return open_div(f".hint .hint-{style}") + f"**{label}:**\n"
+
+        line = HINT_OPEN.sub(hint_open_sub, line)
+        line = HINT_CLOSE.sub(lambda mm: close_div(), line)
+
+        # --- tabs ---------------------------------------------------------
+        line = TABS_OPEN.sub(lambda mm: open_div(".tabs"), line)
+        line = TABS_CLOSE.sub(lambda mm: close_div(), line)
+        line = TAB_OPEN.sub(
+            lambda mm: open_div(".tab") + f"**{_esc_inline(mm.group(1))}**\n",
+            line)
+        line = TAB_CLOSE.sub(lambda mm: close_div(), line)
+
+        # --- stepper ------------------------------------------------------
+        def stepper_open_sub(mm):
+            step_counters.append(0)
+            return open_div(".stepper")
+
+        def stepper_close_sub(mm):
+            if step_counters:
+                step_counters.pop()
+            return close_div()
+
+        def step_open_sub(mm):
+            # Steps outside a stepper occur in the corpus; number them anyway.
+            if not step_counters:
+                step_counters.append(0)
+            step_counters[-1] += 1
+            return open_div(".step") + f"**Step {step_counters[-1]}**\n"
+
+        line = STEPPER_OPEN.sub(stepper_open_sub, line)
+        line = STEPPER_CLOSE.sub(stepper_close_sub, line)
+        line = STEP_OPEN.sub(step_open_sub, line)
+        line = STEP_CLOSE.sub(lambda mm: close_div(), line)
+
+        # --- columns: a PDF page is one column ----------------------------
+        line = COLUMN_ANY.sub("", line)
+
+        # --- media --------------------------------------------------------
+        line = EMBED_OPEN.sub(lambda mm: f"\n<{mm.group(1)}>\n", line)
+        line = FILE_OPEN.sub(lambda mm: f"\nFile: `{mm.group(1)}`\n", line)
+        line = WRAPPER_ONLY.sub("", line)
+
+        # --- anything left ------------------------------------------------
+        line = ANY_MARKER.sub("", line)
+
+        out.append(line)
+
+    # An unbalanced open would swallow the rest of the page; close it instead.
+    if cref is not None:
+        out.append(f"\nSee <{cref[0]}>.\n")
+
+    # Pages with an unbalanced block marker exist in the corpus. Left open, the
+    # div runs to the end of the *concatenated* document and drags every later
+    # page inside it, so close whatever this page left open.
+    if depth[0]:
+        out.append("\n" + "\n:::\n" * depth[0])
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Includes
+# ---------------------------------------------------------------------------
+
+INCLUDE_RE = re.compile(r"\{%\s*include\s+[\"'](.*?)[\"']\s*%\}")
+
+# Boilerplate repeated on thousands of pages; inlining it per page would add
+# hundreds of pages of noise.
+BOILERPLATE = ("contributing-content", "license-cc-by-sa-gnu-fdl", "announce")
+
+
+def resolve_includes(text, page_path, depth=0):
+    """Inline local include files; drop remote and boilerplate ones.
+
+    3,269 includes point at `app.gitbook.com/.../~/reusable/`, whose content
+    lives only in GitBook and is unreachable from a source checkout.
+    """
+    if depth > 3:
+        return map_prose_lines(text, lambda ln: INCLUDE_RE.sub("", ln))
+
+    def sub_line(line):
+        def sub(m):
+            target = m.group(1)
+            if target.startswith(("http://", "https://")):
+                return ""
+            if any(b in target for b in BOILERPLATE):
+                return ""
+            resolved = os.path.normpath(
+                os.path.join(os.path.dirname(page_path), target))
+            if not os.path.isfile(resolved):
+                return ""
+            try:
+                with open(resolved, encoding="utf-8") as fh:
+                    inner = fh.read()
+            except OSError:
+                return ""
+            _, inner = split_frontmatter(inner)
+            inner = resolve_includes(inner, resolved, depth + 1).strip()
+            return "\n" + inner + "\n" if inner else ""
+        return INCLUDE_RE.sub(sub, line)
+
+    return map_prose_lines(text, sub_line)
+
+
+# ---------------------------------------------------------------------------
+# Alias placeholders -> public URLs
+# ---------------------------------------------------------------------------
+
+ALIAS_URLS = {
+    "server": "https://mariadb.com/docs/server",
+    "galera": "https://mariadb.com/docs/galera-cluster",
+    "maxscale": "https://mariadb.com/docs/maxscale",
+    "columnstore": "https://mariadb.com/docs/columnstore",
+    "connectors": "https://mariadb.com/docs/connectors",
+    "tools": "https://mariadb.com/docs/tools",
+    "platform": "https://mariadb.com/docs/platform",
+    "release-notes": "https://mariadb.com/docs/release-notes",
+    "general-resources": "https://mariadb.com/docs/general-resources",
+    "mariadb-cloud": "https://mariadb.com/docs/mariadb-cloud",
+    "skysql": "https://mariadb.com/docs/mariadb-cloud",
+}
+
+# Only match inside a link target, so prose braces are left alone.
+ALIAS_RE = re.compile(r"\{(" + "|".join(map(re.escape, ALIAS_URLS)) + r")\}")
+
+
+@prose_only
+def expand_aliases(line):
+    return ALIAS_RE.sub(lambda m: ALIAS_URLS[m.group(1)], line)
+
+
+# ---------------------------------------------------------------------------
+# Mermaid -> tagged block for client-side rendering
+# ---------------------------------------------------------------------------
+
+MERMAID_RE = re.compile(r"^[ \t]*```mermaid[ \t]*\n(.*?)^[ \t]*```[ \t]*$",
+                        re.DOTALL | re.MULTILINE)
+
+
+def convert_mermaid(text):
+    """Hand diagram source to the browser, which renders it before printing."""
+    return MERMAID_RE.sub(
+        lambda m: '\n<pre class="mermaid">'
+                  + _html.escape(m.group(1).rstrip()) + "</pre>\n",
+        text)
+
+
+# ---------------------------------------------------------------------------
+# Footnotes
+# ---------------------------------------------------------------------------
+
+FOOTNOTE_LABEL = re.compile(r"\[\^([^\]\s]+)\]")
+
+
+def namespace_footnotes(text, page_key):
+    """Prefix footnote labels with a per-page key.
+
+    Nearly every page numbers its footnotes from 1, so concatenating a space
+    collides them: Pandoc then reports duplicate references and unused
+    definitions, and readers get another page's footnote text.
+    """
+    return map_prose_lines(
+        text, lambda ln: FOOTNOTE_LABEL.sub(rf"[^{page_key}-\1]", ln))
+
+
+# ---------------------------------------------------------------------------
+# Heading demotion
+# ---------------------------------------------------------------------------
+
+ATX_RE = re.compile(r"^(#{1,6})(\s+)(.*)$")
+
+
+@prose_only
+def demote_headings(line, offset):
+    """Shift a page's headings to nest under its position in the TOC.
+
+    Levels clamp at 6; `server/` nests 8 deep, so the deepest pages flatten
+    rather than emit invalid HTML.
+    """
+    if offset <= 0:
+        return line
+    m = ATX_RE.match(line)
+    if not m:
+        return line
+    return "#" * min(len(m.group(1)) + offset, 6) + m.group(2) + m.group(3)
+
+
+# ---------------------------------------------------------------------------
+# Link and asset rewriting
+# ---------------------------------------------------------------------------
+
+MD_LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(<?([^)>\s]+?)>?(?:\s+\"[^\"]*\")?\)")
+IMG_LINK_RE = re.compile(r"!\[([^\]]*)\]\(<?([^)>\s]+?)>?(?:\s+\"[^\"]*\")?\)")
+HTML_HREF_RE = re.compile(r'href="([^"]+)"')
+HTML_SRC_RE = re.compile(r'src="([^"]+)"')
+ABSOLUTE = ("http://", "https://", "mailto:", "data:", "#", "tel:")
+
+
+def rewrite_links(text, page_path, space_dir, anchors, web_base):
+    """Point in-space links at PDF anchors, out-of-space links at the website.
+
+    Without this, concatenating pages leaves every `.md` link dead -- the
+    failure mode flagged on the ticket. Images are made absolute `file://` URLs
+    so Chrome can load them from the checkout.
+    """
+    page_dir = os.path.dirname(page_path)
+
+    def anchor_target(url):
+        if url.startswith(ABSOLUTE):
+            return None
+        raw, _, _frag = url.partition("#")
+        if not raw:
+            return None
+        rel = os.path.relpath(
+            os.path.normpath(os.path.join(page_dir, raw)), space_dir)
+        rel = rel.replace(os.sep, "/")
+        # A directory-style link resolves to that directory's README.
+        for cand in (rel, f"{rel}/README.md", f"{rel}.md"):
+            if cand in anchors:
+                return "#" + anchors[cand]
+        if rel.startswith(".."):
+            # Another space: send the reader to the published site.
+            return web_base.rstrip("/") + "/" + rel.lstrip("./")
+        return None
+
+    def asset_target(url):
+        if url.startswith(("http://", "https://", "data:", "file://")):
+            return None
+        # Asset links are percent-encoded in the source (`15%20(1).PNG`), but
+        # the filesystem holds the decoded name, so decode before the check.
+        raw = unquote(url.split("#")[0])
+        resolved = os.path.normpath(os.path.join(page_dir, raw))
+        if not os.path.isfile(resolved):
+            return None
+        return "file://" + quote(os.path.abspath(resolved))
+
+    def fix_line(line):
+        def img_sub(m):
+            new = asset_target(m.group(2))
+            return f"![{m.group(1)}]({new})" if new else m.group(0)
+
+        def src_sub(m):
+            new = asset_target(m.group(1))
+            return f'src="{new}"' if new else m.group(0)
+
+        def md_sub(m):
+            new = anchor_target(m.group(2))
+            return f"[{m.group(1)}]({new})" if new else m.group(0)
+
+        def href_sub(m):
+            new = anchor_target(m.group(1))
+            return f'href="{new}"' if new else m.group(0)
+
+        line = IMG_LINK_RE.sub(img_sub, line)
+        line = HTML_SRC_RE.sub(src_sub, line)
+        line = MD_LINK_RE.sub(md_sub, line)
+        line = HTML_HREF_RE.sub(href_sub, line)
+        return line
+
+    return map_prose_lines(text, fix_line)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def _first_heading_matches(body, title):
+    m = re.search(r"^#{1,6}\s+(.*)$", body.lstrip()[:400], re.MULTILINE)
+    if not m:
+        return False
+    norm = lambda s: re.sub(r"[^a-z0-9]+", "", s.lower())
+    return norm(m.group(1)) == norm(title)
+
+
+def preprocess(text, *, page_path, space_dir, anchors, heading_offset,
+               web_base, anchor_id, title):
+    """Turn one GitBook page into PDF-ready Markdown."""
+    _, body = split_frontmatter(text)
+
+    body = resolve_includes(body, page_path)
+    body = convert_blocks(body)
+    body = namespace_footnotes(body, anchor_id)
+    body = expand_aliases(body)
+    body = convert_mermaid(body)
+    body = rewrite_links(body, page_path, space_dir, anchors, web_base)
+
+    # Drop the page's own leading H1 when it merely repeats the TOC title,
+    # before demotion so the comparison sees the original level.
+    if _first_heading_matches(body, title):
+        body = re.sub(r"\A\s*#{1,6}[ \t]+.*?(?:\r?\n|\Z)", "", body, count=1)
+
+    body = demote_headings(body, heading_offset)
+
+    # Give every page a heading at its TOC depth so the PDF outline mirrors
+    # SUMMARY.md even when the page's own H1 is missing or differs.
+    level = min(heading_offset + 1, 6)
+    heading = f'{"#" * level} {title} {{#{anchor_id}}}\n\n'
+
+    # Collapse the blank-line runs the div injection leaves behind.
+    body = re.sub(r"\n{3,}", "\n\n", body).strip()
+    return heading + body + "\n"
+
+
+if __name__ == "__main__":
+    # Smoke-test one page: python3 gitbook_preprocess.py <file.md>
+    path = sys.argv[1]
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+    print(preprocess(
+        src, page_path=path, space_dir=os.path.dirname(path) or ".",
+        anchors={}, heading_offset=0, web_base="https://mariadb.com/docs",
+        anchor_id="smoke", title="Smoke Test"))

--- a/pdf/gitbook_preprocess.py
+++ b/pdf/gitbook_preprocess.py
@@ -156,7 +156,69 @@ def unescape_markers(text):
             lambda m: m.group(1) or (m.group(2) + m.group(3)), ln))
 
 
-def convert_blocks(text):
+# ---------------------------------------------------------------------------
+# Page titles, for reference labels
+# ---------------------------------------------------------------------------
+
+# SUMMARY.md titles carry Markdown escapes from the GitBook migration
+# (`wsrep\_provider\_options`), which must come off before the title is used as
+# display text.
+MD_ESCAPE_RE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!<>|~])")
+
+
+def unescape_md(text):
+    return MD_ESCAPE_RE.sub(r"\1", text).strip()
+
+
+# GitBook stores a `{% content-ref %}` with the target's *filename* as the link
+# text and renders the real page title from its own database, so 2,298 of the
+# corpus's 2,377 refs carry a label like
+# `backup-and-restore-via-dbforge-studio.md`. Printed verbatim that is the one
+# place a PDF reference reads worse than the website, so the title is recovered
+# from SUMMARY.md, or from the page's own H1 when it is not in the navigation.
+H1_RE = re.compile(r"^#[ \t]+(.+?)[ \t]*$", re.M)
+_title_cache = {}
+
+
+def page_title_from_file(abs_path):
+    """First H1 of a page, or None. Cached -- pages are referenced repeatedly."""
+    if abs_path not in _title_cache:
+        try:
+            with open(abs_path, encoding="utf-8") as fh:
+                _, body = split_frontmatter(fh.read())
+        except OSError:
+            body = ""
+        m = H1_RE.search(body)
+        _title_cache[abs_path] = unescape_md(m.group(1)) if m else None
+    return _title_cache[abs_path]
+
+
+def make_ref_label(page_path, space_dir, titles):
+    """Build a resolver mapping a reference URL to the target page's title."""
+    page_dir = os.path.dirname(page_path)
+
+    def resolve(url):
+        if not url or url.startswith(ABSOLUTE):
+            return None
+        raw = unquote(url.partition("#")[0])
+        if not raw:
+            return None
+        target = os.path.normpath(os.path.join(page_dir, raw))
+        rel = os.path.relpath(target, space_dir).replace(os.sep, "/")
+        # SUMMARY.md first: it is what the PDF's own outline and contents use,
+        # so a reference matches the heading the reader will land on.
+        for cand in (rel, f"{rel}/README.md", f"{rel}.md"):
+            if cand in titles:
+                return titles[cand]
+        for cand in (target, os.path.join(target, "README.md"), f"{target}.md"):
+            if os.path.isfile(cand):
+                return page_title_from_file(cand)
+        return None
+
+    return resolve
+
+
+def convert_blocks(text, ref_label=None):
     """Rewrite every GitBook block marker into Pandoc fenced divs.
 
     Runs as one pass because blocks nest and span code fences; a stack tracks
@@ -194,8 +256,14 @@ def convert_blocks(text):
             if CREF_CLOSE.search(line):
                 url, body = cref[0], "\n".join(cref[1])
                 inner = MD_LINK_INLINE.search(body)
-                label = inner.group(1) if inner else \
-                    (url.rstrip("/").split("/")[-1] or url)
+                # The target's real title first, because that is what GitBook
+                # shows -- it ignores the label stored in the block body, which
+                # is almost always just the filename.
+                label = ref_label(url) if ref_label else None
+                if not label and inner:
+                    label = inner.group(1)
+                if not label:
+                    label = url.rstrip("/").split("/")[-1] or url
                 out.append(f"\nSee [{_esc_inline(label)}]({url}).\n")
                 cref = None
             else:
@@ -639,12 +707,13 @@ def _first_heading_matches(body, title):
 
 
 def preprocess(text, *, page_path, space_dir, anchors, heading_offset,
-               web_base, anchor_id, title):
+               web_base, anchor_id, title, titles=None):
     """Turn one GitBook page into PDF-ready Markdown."""
     _, body = split_frontmatter(text)
 
     body = resolve_includes(body, page_path)
-    body = convert_blocks(body)
+    body = convert_blocks(
+        body, ref_label=make_ref_label(page_path, space_dir, titles or {}))
     body = namespace_footnotes(body, anchor_id)
     body = expand_aliases(body)
     body = convert_mermaid(body)

--- a/pdf/gitbook_preprocess.py
+++ b/pdf/gitbook_preprocess.py
@@ -455,6 +455,13 @@ GITBOOK_SPACE_IDS = {
     "2I4jZ8pGq8bT4w5n3q6r": "columnstore",
 }
 
+# A published URL carries no source suffix, and a directory's `README.md`
+# publishes as the directory itself. Leaving the `.md` on gives a soft 404: the
+# site answers HTTP 200 with an error page, so a status-code check calls it fine
+# while the reader gets nothing.
+PUBLISHED_SUFFIX_RE = re.compile(r"(?:(?:^|/)README)?\.md$", re.I)
+PARENT_PREFIX_RE = re.compile(r"^(?:\.\./)+")
+
 IS_GITBOOK_URL = re.compile(r"^https?://app\.gitbook\.com/", re.I)
 GITBOOK_SPACE_URL_RE = re.compile(
     r"^https?://app\.gitbook\.com/(?:o/[A-Za-z0-9]+/)?s/([A-Za-z0-9]+)([^#?]*)",
@@ -497,7 +504,7 @@ def parse_gitbook_url(url):
     space = GITBOOK_SPACE_IDS.get(m.group(1))
     if space is None:
         return None
-    path = m.group(2).strip("/").removesuffix(".md")
+    path = PUBLISHED_SUFFIX_RE.sub("", m.group(2).strip("/"))
     # `~/reusable/...` and `~/changes/...` address GitBook internals that have
     # no public URL at all, so the space root is the closest honest target.
     if path.startswith("~"):
@@ -538,7 +545,7 @@ def rewrite_links(text, page_path, space_dir, anchors, web_base):
             return gitbook
         if url.startswith(ABSOLUTE):
             return None
-        raw, _, _frag = url.partition("#")
+        raw, _, frag = url.partition("#")
         if not raw:
             return None
         rel = os.path.relpath(
@@ -549,8 +556,13 @@ def rewrite_links(text, page_path, space_dir, anchors, web_base):
             if cand in anchors:
                 return "#" + anchors[cand]
         if rel.startswith(".."):
-            # Another space: send the reader to the published site.
-            return web_base.rstrip("/") + "/" + rel.lstrip("./")
+            # Another space: send the reader to the published site, translating
+            # the repo path into its published form. The fragment is kept here,
+            # unlike an in-space link -- the target page is not in this PDF, so
+            # its section anchor still does useful work on the site.
+            path = PUBLISHED_SUFFIX_RE.sub("", PARENT_PREFIX_RE.sub("", rel))
+            base = f"{web_base.rstrip('/')}/{path}" if path else web_base
+            return base + (f"#{frag}" if frag else "")
         return None
 
     def asset_target(url):

--- a/pdf/style.css
+++ b/pdf/style.css
@@ -14,14 +14,41 @@
   margin: 0;
 }
 
+/* MariaDB brand palette (slide 26 of the corporate deck).
+ *
+ * Every pairing below is checked against WCAG 2.1; the ratio is noted so a
+ * later edit cannot quietly break contrast. Body text is the strictest case
+ * (4.5:1 minimum), headings count as large text (3:1).
+ *
+ *   Blue Azure    #0E6488   6.57:1 on white  AA  (AAA large)
+ *   Sea Fresh     #96DDCF   1.55:1 on white  fill only, needs dark text
+ *   Granite       #424F62   8.31:1 on white  AAA
+ *   Open Seas     #00838F   4.52:1 on white  AA
+ *   Deep Ocean    #003545  13.16:1 on white  AAA
+ *   Electric Eel  #ABC74A   1.91:1 on white  rules and fills only, never text
+ */
 :root {
-  --ink: #1c1e21;
-  --muted: #5c6670;
-  --rule: #d8dee4;
-  --accent: #002b5c;      /* MariaDB deep blue */
-  --accent-soft: #eaf0f7;
-  --code-bg: #f5f7f9;
-  --code-ink: #24292f;
+  --brand-azure: #0E6488;
+  --brand-sea: #96DDCF;
+  --brand-granite: #424F62;
+  --brand-seas: #00838F;
+  /* Open Seas is 4.52:1 on white — technically AA, but a 0.02 margin is too
+   * fragile for the 9pt labels that use it. Same hue (185deg) and saturation,
+   * darkened to 5.84:1 for small text; the pure brand tone stays for rules. */
+  --brand-seas-text: #00707a;
+  --brand-ocean: #003545;
+  --brand-eel: #ABC74A;
+
+  /* Deep Ocean rather than pure black: 15.3:1 on white, and it keeps body
+   * copy in the brand family without the harshness of #000. */
+  --ink: #12242b;
+  --muted: var(--brand-granite);       /* 8.31:1 — AAA */
+  --rule: #d3dbe0;
+  --accent: var(--brand-azure);        /* headings, links — 6.57:1 AA */
+  --accent-deep: var(--brand-ocean);   /* top-level headings — 13.16:1 AAA */
+  --accent-soft: #e4f4ef;              /* Sea Fresh tint, table headers */
+  --code-bg: #f4f7f8;
+  --code-ink: #14252c;
 }
 
 * {
@@ -44,13 +71,24 @@ body {
 
 /* ------------------------------------------------------------------ cover */
 
+/* Two brand-compliant treatments, selected by pdf/build.py --cover.
+ * Both are AAA: Blue Azure carries white text (6.57:1 — AA for body, AAA at
+ * cover display sizes), Sea Fresh carries near-black text (13.54:1). */
 .cover {
   height: 297mm;
   padding: 55mm 22mm 22mm;
-  background: var(--accent);
-  color: #fff;
   page-break-after: always;
   break-after: page;
+}
+
+.cover-azure {
+  background: var(--brand-azure);
+  color: #fff;
+}
+
+.cover-sea {
+  background: var(--brand-sea);
+  color: var(--brand-ocean);
 }
 
 .cover h1 {
@@ -61,20 +99,32 @@ body {
   font-weight: 700;
   line-height: 1.15;
   letter-spacing: -0.4pt;
-  color: #fff;
+  color: inherit;
 }
 
+/* A thin Electric Eel rule under the title: the palette's only warm accent,
+ * used as a graphic element since it can never carry text (1.91:1). */
+.cover h1::after {
+  display: block;
+  width: 62mm;
+  height: 1.6mm;
+  margin-top: 7mm;
+  background: var(--brand-eel);
+  content: "";
+}
+
+/* Secondary cover text uses explicit colors, never `opacity`. Dimming white to
+ * 75% over Blue Azure yields 4.45:1 — under AA, and it would land on the 8.5pt
+ * legal line where contrast matters most. */
 .cover .subtitle {
   margin: 6pt 0 0;
   font-size: 15pt;
   font-weight: 300;
-  opacity: 0.85;
 }
 
 .cover .meta {
   margin: 26pt 0 0;
   font-size: 10pt;
-  opacity: 0.8;
 }
 
 .cover .legal {
@@ -83,12 +133,29 @@ body {
   width: 165mm;
   font-size: 8.5pt;
   line-height: 1.45;
-  opacity: 0.75;
+}
+
+/* Pale Sea Fresh tint: 5.35:1 on Blue Azure — AA at every size used here. */
+.cover-azure .subtitle,
+.cover-azure .meta,
+.cover-azure .legal {
+  color: #d9ece6;
+}
+
+/* Deep Ocean on Sea Fresh: 8.49:1 — AAA. */
+.cover-sea .subtitle,
+.cover-sea .meta,
+.cover-sea .legal {
+  color: var(--brand-ocean);
 }
 
 .cover a {
-  color: #fff;
+  color: inherit;
   text-decoration: underline;
+}
+
+.cover-azure a {
+  color: #fff;   /* 6.57:1 on Blue Azure */
 }
 
 /* -------------------------------------------------------------------- toc */
@@ -100,10 +167,10 @@ body {
 
 .toc h1 {
   margin: 0 0 12pt;
-  border-bottom: 1.5pt solid var(--accent);
+  border-bottom: 1.5pt solid var(--brand-eel);
   padding-bottom: 5pt;
   font-size: 20pt;
-  color: var(--accent);
+  color: var(--accent-deep);
 }
 
 .toc ul {
@@ -145,6 +212,7 @@ h1, h2, h3, h4, h5, h6 {
   margin: 16pt 0 6pt;
   font-weight: 700;
   line-height: 1.25;
+  /* Blue Azure: 6.57:1 on white — AA even at body size, AAA at heading sizes */
   color: var(--accent);
   break-after: avoid;
   page-break-after: avoid;
@@ -153,7 +221,10 @@ h1, h2, h3, h4, h5, h6 {
 /* Each top-level topic starts a fresh page; deeper ones flow inline. */
 main > h1 {
   margin-top: 0;
-  border-bottom: 1.2pt solid var(--accent);
+  /* Deep Ocean for top-level topics: 13.16:1, and the tonal step down to
+   * Blue Azure subheadings gives hierarchy without a second hue. */
+  color: var(--accent-deep);
+  border-bottom: 1.2pt solid var(--brand-eel);
   padding-bottom: 4pt;
   font-size: 21pt;
   page-break-before: always;
@@ -177,7 +248,7 @@ p {
 }
 
 a {
-  color: #0b5cad;
+  color: var(--accent);   /* Blue Azure — 6.57:1, AA at body size */
   text-decoration: none;
 }
 
@@ -201,7 +272,7 @@ pre {
   margin: 0 0 8pt;
   padding: 6pt 8pt;
   border: 0.5pt solid var(--rule);
-  border-left: 2.5pt solid var(--accent);
+  border-left: 2.5pt solid var(--brand-seas);
   border-radius: 2pt;
   background: var(--code-bg);
   font-size: 8.2pt;
@@ -266,19 +337,28 @@ tr {
 .hint {
   margin: 8pt 0;
   padding: 6pt 9pt;
-  border-left: 2.5pt solid var(--muted);
+  border-left: 2.5pt solid var(--brand-granite);
   border-radius: 2pt;
-  background: #f6f8fa;
+  background: #f5f7f8;
   font-size: 9.5pt;
   break-inside: avoid;
 }
 
 .hint > :last-child { margin-bottom: 0; }
 
-.hint-info    { border-left-color: #0b5cad; background: #eef5fc; }
-.hint-success { border-left-color: #1a7f4b; background: #eef8f2; }
-.hint-warning { border-left-color: #b26a00; background: #fdf5e8; }
-.hint-danger  { border-left-color: #b3261e; background: #fdeeed; }
+/* Note and Tip come from the brand palette. Warning and Important deliberately
+ * do NOT: the palette holds no amber or red, and forcing them into blues and
+ * greens would make a warning indistinguishable from a note at a glance — a
+ * worse accessibility outcome than being slightly off-brand. Both are darkened
+ * to clear AA against their own tint.
+ *
+ * Colour is never the only signal in any case: convert_blocks() emits a bold
+ * "Note:" / "Tip:" / "Warning:" / "Important:" label, so the distinction
+ * survives greyscale printing and colour-vision deficiency. */
+.hint-info    { border-left-color: var(--brand-azure); background: #eaf2f6; }
+.hint-success { border-left-color: var(--brand-seas-text); background: #e4f4ef; }
+.hint-warning { border-left-color: #9a5b00;            background: #fdf4e6; }
+.hint-danger  { border-left-color: #a81f16;            background: #fceeed; }
 
 /* ----------------------------------------------------- tabs and steppers */
 
@@ -294,7 +374,7 @@ tr {
 }
 
 .tab > p:first-child {
-  color: var(--accent);
+  color: var(--brand-seas-text);
   font-size: 9pt;
   text-transform: uppercase;
   letter-spacing: 0.4pt;
@@ -305,13 +385,13 @@ tr {
 .step {
   margin: 6pt 0;
   padding-left: 9pt;
-  border-left: 2pt solid var(--accent-soft);
+  border-left: 2pt solid var(--brand-sea);
   break-inside: avoid;
 }
 
 .step > p:first-child {
   margin-bottom: 4pt;
-  color: var(--accent);
+  color: var(--accent-deep);
   font-weight: 700;
 }
 

--- a/pdf/style.css
+++ b/pdf/style.css
@@ -1,0 +1,376 @@
+/* Print stylesheet for the per-space documentation PDFs.
+ *
+ * Targets Chrome's print engine (see pdf/build.py). Sizing is in points and
+ * page geometry is driven by @page, so the output is device-independent.
+ */
+
+@page {
+  size: A4;
+  margin: 20mm 18mm 20mm 18mm;
+}
+
+/* Long code samples and wide tables must not be split mid-token. */
+@page :first {
+  margin: 0;
+}
+
+:root {
+  --ink: #1c1e21;
+  --muted: #5c6670;
+  --rule: #d8dee4;
+  --accent: #002b5c;      /* MariaDB deep blue */
+  --accent-soft: #eaf0f7;
+  --code-bg: #f5f7f9;
+  --code-ink: #24292f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 10.5pt;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+  hyphens: auto;
+}
+
+/* ------------------------------------------------------------------ cover */
+
+.cover {
+  height: 297mm;
+  padding: 55mm 22mm 22mm;
+  background: var(--accent);
+  color: #fff;
+  page-break-after: always;
+  break-after: page;
+}
+
+.cover h1 {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 34pt;
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.4pt;
+  color: #fff;
+}
+
+.cover .subtitle {
+  margin: 6pt 0 0;
+  font-size: 15pt;
+  font-weight: 300;
+  opacity: 0.85;
+}
+
+.cover .meta {
+  margin: 26pt 0 0;
+  font-size: 10pt;
+  opacity: 0.8;
+}
+
+.cover .legal {
+  position: absolute;
+  top: 245mm;
+  width: 165mm;
+  font-size: 8.5pt;
+  line-height: 1.45;
+  opacity: 0.75;
+}
+
+.cover a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+/* -------------------------------------------------------------------- toc */
+
+.toc {
+  page-break-after: always;
+  break-after: page;
+}
+
+.toc h1 {
+  margin: 0 0 12pt;
+  border-bottom: 1.5pt solid var(--accent);
+  padding-bottom: 5pt;
+  font-size: 20pt;
+  color: var(--accent);
+}
+
+.toc ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  /* Two columns keeps a 4,000-entry TOC from dominating the document. */
+  column-count: 2;
+  column-gap: 10mm;
+}
+
+.toc li {
+  margin: 0 0 1.5pt;
+  font-size: 8pt;
+  line-height: 1.35;
+  break-inside: avoid;
+}
+
+.toc a {
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.toc-d0 {
+  margin-top: 5pt !important;
+  font-weight: 700;
+  font-size: 9pt !important;
+}
+
+.toc-d1 { padding-left: 6pt; }
+.toc-d2 { padding-left: 13pt; color: var(--muted); }
+.toc-d3 { padding-left: 20pt; color: var(--muted); }
+.toc-d4 { padding-left: 27pt; color: var(--muted); }
+.toc-d5 { padding-left: 34pt; color: var(--muted); }
+
+/* --------------------------------------------------------------- headings */
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 16pt 0 6pt;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--accent);
+  break-after: avoid;
+  page-break-after: avoid;
+}
+
+/* Each top-level topic starts a fresh page; deeper ones flow inline. */
+main > h1 {
+  margin-top: 0;
+  border-bottom: 1.2pt solid var(--accent);
+  padding-bottom: 4pt;
+  font-size: 21pt;
+  page-break-before: always;
+  break-before: page;
+}
+
+main > h1:first-child {
+  page-break-before: avoid;
+  break-before: avoid;
+}
+
+h2 { font-size: 15pt; border-bottom: 0.5pt solid var(--rule); padding-bottom: 3pt; }
+h3 { font-size: 12.5pt; }
+h4 { font-size: 11pt; }
+h5, h6 { font-size: 10.5pt; color: var(--muted); }
+
+p {
+  margin: 0 0 7pt;
+  orphans: 2;
+  widows: 2;
+}
+
+a {
+  color: #0b5cad;
+  text-decoration: none;
+}
+
+/* ------------------------------------------------------------------- code */
+
+code, kbd, samp, pre {
+  font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+code {
+  padding: 0.5pt 2.5pt;
+  border-radius: 2pt;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  font-size: 0.87em;
+  /* SQL identifiers and long option names must wrap rather than overflow. */
+  overflow-wrap: break-word;
+}
+
+pre {
+  margin: 0 0 8pt;
+  padding: 6pt 8pt;
+  border: 0.5pt solid var(--rule);
+  border-left: 2.5pt solid var(--accent);
+  border-radius: 2pt;
+  background: var(--code-bg);
+  font-size: 8.2pt;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  break-inside: avoid-page;
+}
+
+pre code {
+  padding: 0;
+  background: none;
+  font-size: inherit;
+}
+
+/* ----------------------------------------------------------------- tables */
+
+table {
+  width: 100%;
+  margin: 0 0 9pt;
+  border-collapse: collapse;
+  font-size: 8.5pt;
+  /* Auto layout: Pandoc's own column widths are derived from the source
+   * table's separator-row widths, which say nothing about content. */
+  table-layout: auto;
+}
+
+/* Discard those derived widths -- honoring them collapses columns to a single
+ * character. Content-driven sizing plus cell wrapping is what we want. */
+table colgroup {
+  display: none;
+}
+
+table col {
+  width: auto !important;
+}
+
+th, td {
+  padding: 3pt 5pt;
+  border: 0.5pt solid var(--rule);
+  text-align: left;
+  vertical-align: top;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+th {
+  background: var(--accent-soft);
+  font-weight: 700;
+}
+
+thead {
+  display: table-header-group; /* repeat headers across page breaks */
+}
+
+tr {
+  break-inside: avoid;
+}
+
+/* ------------------------------------------------------------------ hints */
+
+.hint {
+  margin: 8pt 0;
+  padding: 6pt 9pt;
+  border-left: 2.5pt solid var(--muted);
+  border-radius: 2pt;
+  background: #f6f8fa;
+  font-size: 9.5pt;
+  break-inside: avoid;
+}
+
+.hint > :last-child { margin-bottom: 0; }
+
+.hint-info    { border-left-color: #0b5cad; background: #eef5fc; }
+.hint-success { border-left-color: #1a7f4b; background: #eef8f2; }
+.hint-warning { border-left-color: #b26a00; background: #fdf5e8; }
+.hint-danger  { border-left-color: #b3261e; background: #fdeeed; }
+
+/* ----------------------------------------------------- tabs and steppers */
+
+/* Tabs cannot be interactive in print, so each panel is shown in sequence. */
+.tabs {
+  margin: 8pt 0;
+  padding: 4pt 0 4pt 8pt;
+  border-left: 1pt dashed var(--rule);
+}
+
+.tab {
+  margin: 5pt 0;
+}
+
+.tab > p:first-child {
+  color: var(--accent);
+  font-size: 9pt;
+  text-transform: uppercase;
+  letter-spacing: 0.4pt;
+}
+
+.stepper { margin: 8pt 0; }
+
+.step {
+  margin: 6pt 0;
+  padding-left: 9pt;
+  border-left: 2pt solid var(--accent-soft);
+  break-inside: avoid;
+}
+
+.step > p:first-child {
+  margin-bottom: 4pt;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* ----------------------------------------------------------------- images */
+
+img, svg {
+  max-width: 100%;
+  height: auto;
+  break-inside: avoid;
+}
+
+figure {
+  margin: 9pt 0;
+  text-align: center;
+  break-inside: avoid;
+}
+
+figcaption {
+  margin-top: 3pt;
+  color: var(--muted);
+  font-size: 8.5pt;
+  font-style: italic;
+}
+
+pre.mermaid {
+  border: 0;
+  background: none;
+  text-align: center;
+  white-space: normal;
+}
+
+/* ------------------------------------------------------------------ lists */
+
+ul, ol {
+  margin: 0 0 7pt;
+  padding-left: 16pt;
+}
+
+li { margin-bottom: 2pt; }
+
+blockquote {
+  margin: 8pt 0;
+  padding-left: 9pt;
+  border-left: 2pt solid var(--rule);
+  color: var(--muted);
+}
+
+hr {
+  height: 0;
+  margin: 10pt 0;
+  border: 0;
+  border-top: 0.5pt solid var(--rule);
+}
+
+/* Pandoc emits footnote sections per page chunk; keep them compact. */
+.footnotes {
+  margin-top: 10pt;
+  border-top: 0.5pt solid var(--rule);
+  padding-top: 4pt;
+  font-size: 8.5pt;
+  color: var(--muted);
+}


### PR DESCRIPTION
Generates one PDF per GitBook space from the Markdown source, plus a manual GitHub Action that publishes them as Release assets.

GitBook's own PDF export is capped at 100 pages per download, so whole-space output has to be built from source — as GitBook Support themselves suggested on the ticket.

## Scope decision

**One PDF per space; no combined all-spaces PDF.** Every space concatenated is ~16,000 pages, and three spaces (Server, Release Notes, MaxScale) are 90% of it — not a document anyone can use. Release Notes gets its own PDF but is excluded from any bundle.

## Output (verified locally, all 11 spaces)

| Space | Doc pages | PDF pages | Size |
|---|---:|---:|---:|
| `server` | 4,101 | 6,676 | 93.9 MB |
| `release-notes` | 2,772 | 5,724 | 110.9 MB |
| `maxscale` | 771 | 5,806 | 58.6 MB |
| `platform` | 813 | 502 | 5.7 MB |
| `connectors` | 289 | 663 | 7.6 MB |
| `analytics` | 174 | 587 | 6.9 MB |
| `tools` | 128 | 611 | 25.1 MB |
| `mariadb-cloud` | 110 | 295 | 6.4 MB |
| `general-resources` | 124 | 220 | 3.2 MB |
| `galera-cluster` | 101 | 268 | 5.6 MB |
| `home` | 2 | 7 | 0.2 MB |

324 MB total, zero unconverted GitBook markers, zero Pandoc warnings. Full run ~25 min locally; the CI matrix runs spaces in parallel.

## Approach

```
SUMMARY.md → manifest → preprocess → pandoc (md→html) → Chrome --print-to-pdf → qpdf
```

- **`SUMMARY.md` is the manifest.** It is GitBook's navigation tree, so it gives both reading order and nesting depth (depth → heading level → PDF outline). Alphabetical concatenation would scramble the order. Pages absent from it (375 in `server/`) are unpublished and excluded deliberately.
- **Chrome, not LaTeX.** 118 pages use raw `<table>` markup and 111 use Mermaid; a TeX engine renders neither. This is the Pandoc route from the ticket comment with the LaTeX step swapped out.
- **MkDocs / mdBook rejected.** Both need their own nav config *and* still require the identical GitBook-block preprocessor — a second static site generator for no gain.
- **In-space links become internal PDF anchors**, so cross-references work offline; without this every `.md` link in a concatenated document is dead. Out-of-space links point at mariadb.com/docs.

## Two findings worth reviewer attention

**Ghostscript is unusable here.** It compresses harder than qpdf but strips every `/Link` and `/Dest` — on `galera-cluster`, 3,575 links and 743 destinations all went to zero. qpdf is lossless and still gets ~50% (`server` 198 → 94 MB). There is a comment in the code so nobody swaps it in later.

**A few pages are broken on the live site.** Some escape their own markers (`\{% tabs %\}`), so GitBook renders nothing and readers see literal syntax on mariadb.com/docs today. The preprocessor normalizes them so the PDF is right, but the source needs a separate fix — `grep -rn '\\{%' --include='*.md' .` finds them. Happy to file that ticket.

## Reviewer notes

- **The workflow YAML is unproven.** `workflow_dispatch` only runs from the default branch, so its first real execution is post-merge. The Python it calls is fully exercised locally. First run should use `draft: true` (the default).
- **The Action is manual on purpose** — a full run is several hundred MB, so it belongs to a documentation snapshot, not to every push.
- **Mermaid is fetched, not vendored** (`pdf/fetch-deps.sh`); the bundle is 3.4 MB. Builds succeed without it — diagram pages just show diagram source.
- **No documentation pages are touched** — this is tooling under `pdf/`.
- Known limitations (dropped remote reusable includes, linearized tabs, heading flattening past 6 levels) are documented in `pdf/README.md`.

If `server` at 94 MB is too heavy a download, the natural next step is splitting the largest spaces by subtree rather than one file per space — say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)