### PR TITLE
DOCS-6362 Bump GitHub Actions off the Node 20 runtime, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+# Keeps the pinned GitHub Actions in .github/workflows/ current, so runtime
+# deprecations (e.g. the Node 20 -> Node 24 move that prompted DOCS-6362) arrive
+# as a reviewable PR instead of accumulating as a warning on every job.
+#
+# Scoped to the github-actions ecosystem on purpose. The Python used by the
+# help-tables and PDF pipelines is invoked from the runner's stock interpreter
+# with no pinned requirements file, so there is nothing for a pip ecosystem
+# entry to track.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    # One PR per batch rather than per action: these bumps are reviewed together
+    # and almost always land together.
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "CI"
+    labels:
+      - dependencies
+    open-pull-requests-limit: 3

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,13 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changes
-        uses: tj-actions/changed-files@v45
+        # SHA-pinned rather than tag-pinned: this action was compromised in
+        # March 2025 (CVE-2025-30066), when tags in the v1-v45 range were
+        # repointed at code that leaked runner secrets. Pinning the commit
+        # removes the retag vector. Dependabot keeps the SHA and the comment
+        # in sync. See DOCS-6362.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **.md

--- a/.github/workflows/expand-gitbook-aliases.yml
+++ b/.github/workflows/expand-gitbook-aliases.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout PR commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/extract-function-skills.yml
+++ b/.github/workflows/extract-function-skills.yml
@@ -25,9 +25,9 @@ jobs:
   regenerate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -35,7 +35,7 @@ jobs:
         run: python3 agent-skills/extractor/regenerate.py
 
       - name: Open a PR if anything changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: agent-skills/regen-tier2-functions
           base: main

--- a/.github/workflows/generate-help-tables.yml
+++ b/.github/workflows/generate-help-tables.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -51,7 +51,7 @@ jobs:
           '
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fill_help_tables
           path: help-tables/fill_help_tables.sql
@@ -63,7 +63,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -45,7 +45,7 @@ jobs:
       spaces: ${{ steps.plan.outputs.spaces }}
       label: ${{ steps.plan.outputs.label }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Runs once rather than per space: it is a property of the stylesheet, and
       # failing here costs seconds instead of an hour of rendering.
@@ -84,7 +84,7 @@ jobs:
       matrix:
         space: ${{ fromJSON(needs.plan.outputs.spaces) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Ubuntu's packaged pandoc lags well behind and lacks the flags build.py
       # relies on, so pin the version explicitly.
@@ -164,7 +164,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pdf-${{ matrix.space }}
           path: dist/*.pdf
@@ -176,7 +176,7 @@ jobs:
     if: always() && needs.build.result != 'cancelled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: pdf-*
           merge-multiple: true

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -9,13 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changes
-        uses: tj-actions/changed-files@v45
+        # SHA-pinned rather than tag-pinned: this action was compromised in
+        # March 2025 (CVE-2025-30066), when tags in the v1-v45 range were
+        # repointed at code that leaked runner secrets. Pinning the commit
+        # removes the retag vector. Dependabot keeps the SHA and the comment
+        # in sync. See DOCS-6362.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **.md

--- a/.github/workflows/nightly-error-sync.yml
+++ b/.github/workflows/nightly-error-sync.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout Documentation Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/sync-topical-skills.yml
+++ b/.github/workflows/sync-topical-skills.yml
@@ -31,9 +31,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -41,7 +41,7 @@ jobs:
         run: python3 agent-skills/topical/sync_topical.py --ref "${{ inputs.ref || 'main' }}"
 
       - name: Open a PR if upstream moved
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: agent-skills/sync-topical
           base: main


### PR DESCRIPTION
Closes the "Node.js 20 is deprecated ... being forced to run on Node.js 24" warning that every job in every workflow currently logs. Cosmetic today — the runner already executes these actions on Node 24 — but it appears on every run, which trains reviewers to ignore Actions warnings.

Ticket: [DOCS-6362](https://mariadbcorp.atlassian.net/browse/DOCS-6362)

## What changed

Targets were picked by reading `runs.using:` at each candidate tag and the release notes, not by taking the newest major:

| Action | Now | → | Why that target |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | Node 24, no behavior change |
| `actions/upload-artifact` | v4 | v6 | **v5 still defaults to node20** — one major isn't enough |
| `actions/download-artifact` | v4 | v7 | v6 also still node20. Deliberately not v8: it makes a digest mismatch fatal and stops auto-unzipping based on `Content-Type` |
| `actions/setup-python` | v5 | v6 | Node 24; v7 drops the (unused) `pip-install` input |
| `peter-evans/create-pull-request` | v7 | v8 | Node 24 only |
| `slackapi/slack-github-action` | v2.0.0 | v3.0.5 | v3 is a pure runtime bump; v4 tightens YAML parsing of the multi-line `payload` |
| `tj-actions/changed-files` | v45 | v47.0.6 | Node 24, plus SHA-pinned — see below |

`codespell-project/actions-codespell` (Docker) and `lycheeverse/lychee-action` (composite) target no Node runtime and are untouched.

All Node 24 majors require Actions Runner >= 2.327.1. Every job here runs on `ubuntu-latest`, so that's already satisfied.

## Why changed-files is pinned by SHA

That action was compromised in March 2025 ([CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3)): tags across the v1–v45 range were repointed at code that wrote runner secrets into build logs. It was remediated and the moving tag is safe now, so this repo was never running the bad commit — but v45 is the last tag in the affected range, and pinning the commit removes the retag vector entirely. Both call sites pass `outputs.all_changed_files` into an action input, which behaves identically at v47.

## Dependabot

New `.github/dependabot.yml`, `github-actions` ecosystem, monthly, grouped into one PR. So the next runtime deprecation arrives as a reviewable bump rather than as log noise for a year. Scoped to actions only — the Python in the help-tables and PDF pipelines uses the runner's stock interpreter with no pinned requirements file.

## Verification

- All nine YAML files parse.
- `codespell` clean on the changed files.
- `codespell`, `link-check-pr`, and `expand-gitbook-aliases` self-test on this PR — watch their checks below.
- The rest are dispatch- or schedule-only. `generate-help-tables`, `nightly-error-sync`, `extract-function-skills`, and `sync-topical-skills` want a manual run before or shortly after merge; for `generate-pdfs`, smoke-test with `spaces=home` into a throwaway tag rather than paying a full ~1 hour / ~450 MB run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6362]: https://mariadbcorp.atlassian.net/browse/DOCS-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ