### PR TITLE
DOCS-5710 Fix the release job and validate the tag up front

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -47,6 +47,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The tag becomes a Git ref when the release is published, so reject
+      # anything git would refuse. A draft release accepts an invalid name (it
+      # creates no ref), which hides the problem until publish time -- an hour
+      # of rendering later. check-ref-format needs no repository, just git.
+      - name: Validate the release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! git check-ref-format "refs/tags/$TAG"; then
+            echo "::error::'$TAG' is not a usable tag name: no spaces, no '..'," \
+                 "no trailing '.lock', no control characters."
+            exit 1
+          fi
+          # check-ref-format allows a leading '-', but gh would then parse the
+          # tag as an option.
+          case "$TAG" in
+            -*) echo "::error::'$TAG' must not start with '-'"; exit 1 ;;
+          esac
+          echo "Tag OK: $TAG"
+
       # Runs once rather than per space: it is a property of the stylesheet, and
       # failing here costs seconds instead of an hour of rendering.
       - name: Verify WCAG AA contrast
@@ -185,6 +206,15 @@ jobs:
       - name: Summarize
         run: |
           set -euo pipefail
+          # This job runs with if: always(), so it is reached even when every
+          # build failed. Say so plainly instead of letting an unexpanded
+          # dist/*.pdf glob reach gh release as a literal filename.
+          shopt -s nullglob
+          pdfs=(dist/*.pdf)
+          if [[ ${#pdfs[@]} -eq 0 ]]; then
+            echo "::error::no PDFs were produced -- every build job failed"
+            exit 1
+          fi
           ls -lh dist/
           {
             echo "## Documentation PDFs"
@@ -201,6 +231,10 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job downloads artifacts and never checks out, so there is no
+          # git remote for gh to infer the repository from -- without GH_REPO
+          # every gh call fails with "not a git repository".
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -215,7 +249,11 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" dist/*.pdf --clobber
           else
+            # --target pins the tag to the commit the PDFs were built from;
+            # with no git context gh would otherwise tag the default branch
+            # head, contradicting the $GITHUB_SHA the notes above cite.
             gh release create "$TAG" dist/*.pdf \
+              --target "$GITHUB_SHA" \
               --title "Documentation PDFs — ${{ needs.plan.outputs.label }}" \
               --notes "$notes" \
               ${{ inputs.draft && '--draft' || '' }}


### PR DESCRIPTION
Follow-up to #798. The first full run ([30383732198](https://github.com/mariadb-corporation/mariadb-docs/actions/runs/30383732198)) rendered **all 11 spaces successfully** — ~20,850 pages, ~278 MB — and then lost them at the very last step.

Ticket: [DOCS-5710](https://mariadbcorp.atlassian.net/browse/DOCS-5710)

## 1. `release` job couldn't reach `gh` (the actual failure)

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `release` job downloads artifacts and never checks out, so `gh` had no git remote to infer the repository from. Fixed by setting `GH_REPO: ${{ github.repository }}` on the step rather than by adding a pointless full checkout.

## 2. Tag validation in `plan`

That run passed `Initial PDF` as the tag. Spaces aren't legal in a Git ref, so the draft would have been created — a draft makes no ref — and then failed at *publish* time, an hour of rendering after the typo. Now validated with `git check-ref-format` in the `plan` job, alongside the contrast check, on the same "fail in seconds, not after an hour" principle the job was already built around.

Also rejects a leading `-`, which `check-ref-format` permits but `gh` would parse as an option. Verified against `Initial PDF` (reject), `bad..tag` (reject), `-oops` (reject), `docs-pdf-2026-07` (accept).

## 3. `--target "$GITHUB_SHA"` on `gh release create`

With no git context, `gh` defaults `--target` to the default branch head — which would contradict the `$GITHUB_SHA` the release notes themselves cite as the source commit.

## 4. Clear failure when nothing was built

The job runs `if: always()`, so a run where every build failed previously reached `gh release` with an unexpanded `dist/*.pdf` glob as a literal filename. It now fails with `no PDFs were produced -- every build job failed`.

Item 4 is slightly beyond the reported bug; it's the same failure mode (a cryptic error where a clear one belongs) and six lines.

## Verification

`generate-pdfs.yml` parses, and both new shell guards were simulated locally against the inputs above. The workflow is `workflow_dispatch`-only, so this PR's checks don't exercise it — the next real run does. Re-rendering isn't needed to recover the current run: its artifacts are on the run page until **2026-08-04**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5710]: https://mariadbcorp.atlassian.net/browse/DOCS-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ