### PR TITLE
DOCS-6362 Hold back download-artifact v8 and slack-github-action v4 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,23 @@ updates:
       actions:
         patterns:
           - "*"
+    # Two majors are held back on purpose, because they change behavior rather
+    # than just the Node runtime. Without these entries every monthly run
+    # re-proposes them (PR #802 did on day one) and the reasoning below gets
+    # undone by a routine-looking bump. Revisit deliberately, not by deleting
+    # the entry to make a PR go green.
+    ignore:
+      # v8 makes an artifact digest mismatch a hard failure and stops
+      # auto-unzipping based on Content-Type. The PDF release job downloads
+      # eleven artifacts up to ~94 MB each, so both changes need a real run
+      # behind them first. See DOCS-5710.
+      - dependency-name: actions/download-artifact
+        versions: [">=8"]
+      # v4 pulls in js-yaml v5, which parses multi-line values more strictly.
+      # generate-help-tables.yml passes its Slack message as a multi-line
+      # payload: block, which is exactly that shape.
+      - dependency-name: slackapi/slack-github-action
+        versions: [">=4"]
     commit-message:
       prefix: "CI"
     labels:


### PR DESCRIPTION
Dependabot opened its first grouped PR ([#802](https://github.com/mariadb-corporation/mariadb-docs/pull/802)) within minutes of #799 landing, and proposed the newest major for everything — including the two majors #799 deliberately stopped short of. Both change behavior rather than just the Node runtime.

Ticket: [DOCS-6362](https://mariadbcorp.atlassian.net/browse/DOCS-6362) (already closed — happy to reopen or file a fresh one if you'd rather this be tracked separately)

| Held at | Why |
|---|---|
| `actions/download-artifact` `>=8` | v8 makes an artifact digest mismatch a **hard failure** and stops auto-unzipping based on `Content-Type`. The PDF release job pulls eleven artifacts, up to ~94 MB each — both changes want a real run behind them. See DOCS-5710. |
| `slackapi/slack-github-action` `>=4` | v4 pulls in js-yaml v5, which parses multi-line values more strictly. The Slack notification in `generate-help-tables.yml` passes its message as a multi-line `payload:` block — exactly that shape. |

Neither is unsafe. The point is that both deserve a deliberate decision, and without an `ignore` entry every monthly run re-proposes them until somebody merges one to turn a PR green — which is how the reasoning in #799 gets quietly undone a month from now. The comments in the config say as much, so the next person doesn't delete the entry to unblock a bump.

Scoped to `>=8` and `>=4` rather than blocking all majors, so patch and minor updates within v7 and v3 keep flowing.

## Effect on #802

Once this merges, #802 as it stands is stale — it still contains both bumps. Comment `@dependabot recreate` on it and the group PR comes back without them, leaving the harmless remainder (`checkout` v7, `setup-python` v7, `upload-artifact` v7, `lychee-action` v2.9.0).

## Verification

Parses, and the ignore list reads back as the two intended entries. Dependabot itself only re-reads the config on its next run or on an explicit `@dependabot recreate`, so #802 won't change on merge alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6362]: https://mariadbcorp.atlassian.net/browse/DOCS-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ