### PR TITLE
DOCS-5710 Link the documentation PDFs from the home page

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -68,3 +68,22 @@ Stay updated with the latest releases and version-specific changes.
 * [MariaDB Enterprise Kubernetes Operator](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/enterprise-operator)
 * [MariaDB AI RAG](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/ai-rag-release-notes)
 * [MariaDB MCP Server](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/mcp-server-release-notes)
+
+### Offline Downloads
+
+Read the documentation offline. Each PDF covers one documentation set and links internally, so cross-references still work without a connection. Every link below serves the most recent snapshot.
+
+| Documentation set | PDF | Pages |
+|---|---|---:|
+| MariaDB Server | [mariadb-server.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-server.pdf) | 6,166 |
+| MariaDB Release Notes | [mariadb-release-notes.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-release-notes.pdf) | 5,738 |
+| MariaDB MaxScale | [mariadb-maxscale.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-maxscale.pdf) | 5,803 |
+| MariaDB Enterprise Platform | [mariadb-platform.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-platform.pdf) | 502 |
+| MariaDB Connectors | [mariadb-connectors.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-connectors.pdf) | 659 |
+| MariaDB Analytics and ColumnStore | [mariadb-analytics.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-analytics.pdf) | 587 |
+| MariaDB Tools | [mariadb-tools.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-tools.pdf) | 611 |
+| MariaDB Cloud | [mariadb-mariadb-cloud.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-mariadb-cloud.pdf) | 295 |
+| MariaDB Galera Cluster | [mariadb-galera-cluster.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-galera-cluster.pdf) | 266 |
+| MariaDB General Resources | [mariadb-general-resources.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-general-resources.pdf) | 220 |
+
+Page counts describe the July 2026 snapshot and grow as the documentation does. [Browse every snapshot](https://github.com/mariadb-corporation/mariadb-docs/releases) to download an older set. This site is always the authoritative version.


### PR DESCRIPTION
The per-space PDFs have been generated and released since #798 / #800 — [docs-pdf-2026-07](https://github.com/mariadb-corporation/mariadb-docs/releases/tag/docs-pdf-2026-07), 11 assets, 275 MB — but nothing on the site pointed at them, so readers had no way to find them.

Ticket: [DOCS-5710](https://mariadbcorp.atlassian.net/browse/DOCS-5710)

Adds an **Offline Downloads** section to the home space front page, matching the existing `###`-heading-plus-list pattern.

## Decisions worth reviewing

- **`/releases/latest/download/` rather than pinned URLs.** Always serves the newest snapshot, so cutting the next one needs no edit here. The tradeoff: `latest` means the newest release in the repo, so if a non-PDF release series is ever published, every link breaks. Today `docs-pdf-2026-07` is the only release.
- **Raw `github.com` URLs.** `expand-gitbook-aliases.yml` skips every `README.md` by filename, so an alias placeholder would render literally on this page.
- **Ten of eleven assets listed.** The `home` PDF is omitted: it's a 7-page render of this very front page.
- **Page counts labeled as the July 2026 snapshot**, since self-updating links will eventually outrun them.

## Verification

- All 11 URLs resolve, checked individually with a ranged `curl -L` against the live release (every one 206, i.e. the redirect chain to the asset works).
- `codespell` clean with the CI-exact invocation.
- No alias placeholders on the page.
- Asset filenames verified against the release rather than assumed — note `mariadb-mariadb-cloud.pdf` really does carry the doubled prefix, because `build.py` names output `mariadb-{space}` and the space itself is `mariadb-cloud`. Cosmetic, but it's the actual filename, so the link text matches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5710]: https://mariadbcorp.atlassian.net/browse/DOCS-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ