### PR TITLE
DOCS-5710 Link each space's PDF from its landing page

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -11,6 +11,10 @@ description: >-
 MariaDB ColumnStore and MariaDB Exa are exclusive to MariaDB Enterprise Server.
 {% endhint %}
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-analytics.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-analytics.pdf) (~590 pages, 5.5 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 ## MariaDB ColumnStore
 
 For fast, ad hoc analytics at scale, MariaDB ColumnStore is a powerful columnar database that can be deployed as a standalone analytics solution or integrated with MariaDB Enterprise Server to act as a powerful query accelerator. It stores data in a columnar format and can be distributed across a cluster of servers, allowing it to execute complex queries in parallel on petabytes of data.

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -25,6 +25,10 @@ layout:
 
 # MariaDB Connectors
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-connectors.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-connectors.pdf) (~660 pages, 6 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 {% content-ref url="connectors-quickstart-guides/" %}
 [connectors-quickstart-guides](connectors-quickstart-guides/)
 {% endcontent-ref %}

--- a/galera-cluster/README.md
+++ b/galera-cluster/README.md
@@ -7,6 +7,10 @@ icon: circle-nodes
 
 # MariaDB Galera Cluster
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-galera-cluster.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-galera-cluster.pdf) (~270 pages, 4.7 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 {% content-ref url="galera-cluster-quickstart-guides/" %}
 [galera-cluster-quickstart-guides](galera-cluster-quickstart-guides/)
 {% endcontent-ref %}

--- a/general-resources/README.md
+++ b/general-resources/README.md
@@ -1,5 +1,9 @@
 # About MariaDB Documentation
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-general-resources.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-general-resources.pdf) (~220 pages, 2.5 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 The documentation for MariaDB products is
 
 * written in standard American English,

--- a/mariadb-cloud/README.md
+++ b/mariadb-cloud/README.md
@@ -8,6 +8,10 @@ icon: cloud-sun
 
 # MariaDB Cloud
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-mariadb-cloud.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-mariadb-cloud.pdf) (~300 pages, 5.5 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 ## Overview
 
 MariaDB Cloud (previously called SkySQL) is an AI-driven, fully managed Database-as-a-Service (DBaaS), designed to deploy MariaDB and MySQL-compatible workloads across diverse environments including multiple data centers, regions, and cloud providers. It now offers both traditional provisioned and serverless deployment options, catering to a wide range of use cases and workload patterns while preventing over-provisioning. With the addition of the no-code AI Agent builder, developers can easily provide natural language interfaces to their end users to ask questions of the data without SQL expertise.

--- a/maxscale/README.md
+++ b/maxscale/README.md
@@ -7,6 +7,10 @@ icon: maximize
 
 # MariaDB MaxScale
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-maxscale.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-maxscale.pdf) (~5,800 pages, 50 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 {% content-ref url="maxscale-quickstart-guides/" %}
 [maxscale-quickstart-guides](maxscale-quickstart-guides/)
 {% endcontent-ref %}

--- a/platform/README.md
+++ b/platform/README.md
@@ -1,5 +1,9 @@
 # MariaDB Enterprise Platform
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-platform.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-platform.pdf) (~500 pages, 4.5 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 ### What is MariaDB Enterprise Platform? <a href="#what-is-mariadb-enterprise-platform" id="what-is-mariadb-enterprise-platform"></a>
 
 MariaDB Enterprise Platform is designed to deliver best-in-class performance, data security, replication, clustering, and high availability for production workloads in any cloud environment, including private, public, hybrid, or multicloud setups. It empowers modern data strategies with an end-to-end database solution, ensuring consistent performance and unwavering stability for mission-critical applications in demanding environments. The platform simplifies the data landscape by running all workloads in a single, robust MariaDB environment, powered by open-source technology and fortified with enterprise-grade reliability, security, and support.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -6,6 +6,10 @@ description: >-
 
 # MariaDB Release Notes
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-release-notes.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-release-notes.pdf) (~5,700 pages, 93 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 Release dates for upcoming MariaDB Enterprise Server releases can be found [here](enterprise-server/about/enterprise-server-release-schedule.md#next-scheduled-releases). Release dates for MariaDB Community Server releases can be found [on Jira](https://jira.mariadb.org/).
 
 ## MariaDB Server Release Notes

--- a/server/README.md
+++ b/server/README.md
@@ -8,6 +8,10 @@ icon: server
 
 # MariaDB Server Documentation
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-server.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-server.pdf) (~6,200 pages, 80 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 {% columns %}
 {% column %}
 {% content-ref url="mariadb-quickstart-guides/" %}

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,6 +7,10 @@ description: >-
 
 # Tools
 
+{% hint style="info" %}
+📄 Read offline: [mariadb-tools.pdf](https://github.com/mariadb-corporation/mariadb-docs/releases/latest/download/mariadb-tools.pdf) (~610 pages, 23 MB). The PDF is a point-in-time snapshot; this site is always current.
+{% endhint %}
+
 ## MariaDB Enterprise Manager
 
 {% columns %}


### PR DESCRIPTION
#806 put the full download table on the home page, but a reader already inside a space had no way to reach the PDF for the space they were in. This adds a one-line hint under each landing-page title, linking that space's PDF only.

Ticket: [DOCS-5710](https://mariadbcorp.atlassian.net/browse/DOCS-5710) (closed — happy to reopen it, or move this to a fresh ticket, whichever you prefer)

## What it looks like

```
# MariaDB Server Documentation

{% hint style="info" %}
📄 Read offline: [mariadb-server.pdf](…/releases/latest/download/mariadb-server.pdf) (~6,200 pages, 80 MB). The PDF is a point-in-time snapshot; this site is always current.
{% endhint %}
```

Ten spaces, one link each: `server`, `release-notes`, `maxscale`, `platform`, `connectors`, `analytics`, `tools`, `mariadb-cloud`, `general-resources`, `galera-cluster`. `home` is untouched — it already carries the full table from #806.

## Decisions worth a look

- **`/releases/latest/download/`** again, so cutting a snapshot needs no edit here.
- **Rounded figures** (`~6,200 pages, 80 MB`) rather than exact. The links self-update, so exact numbers would silently drift away from the file actually being served. Sizes are stated at all because three of these are 50–93 MB downloads and that's worth knowing before clicking.
- **`analytics/README.md` differs**: its landing page already opens with a hint (ColumnStore and Exa being Enterprise-only), so the download line goes *after* it. Stacking two hints under the title looked bad and would have pushed the product caveat down.
- **Raw `github.com` URLs**, since `expand-gitbook-aliases.yml` skips every `README.md` by filename.
- **The snapshot caveat is repeated in every hint.** Slightly repetitive across the site, but each landing page is an entry point and readers won't have seen it elsewhere.

## Verification

- All 10 URLs resolve — ranged `curl -L` against the live release, one per file, every one 206.
- `{% hint %}` / `{% endhint %}` balanced in all 10 files (`analytics` correctly shows 2/2).
- `codespell` clean, CI-exact invocation.
- Each insertion point checked in the diff: every hint sits immediately after the `# ` title, except `analytics` as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-5710]: https://mariadbcorp.atlassian.net/browse/DOCS-5710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ