### PR TITLE
DOCS-6368 Run the PDF workflow monthly as well as on demand

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -2,9 +2,15 @@ name: Generate documentation PDFs
 
 # Builds one PDF per GitBook space and attaches them to a GitHub Release.
 #
-# Manual by design (DOCS-5710): a full run produces ~450 MB across 11 files, so
-# it is tied to a documentation snapshot -- typically cut alongside a Server
-# release -- rather than to every push.
+# Snapshot-based (DOCS-5710), never per-push: a full run produces ~450 MB across
+# 11 files. Two ways in:
+#
+#   * monthly cron, so a dated snapshot exists even in a month nobody cuts one;
+#   * manual dispatch, to re-cut after a Server release lands.
+#
+# Both resolve to one release per calendar month (docs-pdf-YYYY-MM), so a manual
+# re-cut updates that month's assets in place instead of piling up near-identical
+# releases.
 #
 # There is deliberately no combined all-spaces PDF: concatenating every space
 # yields ~16,000 pages, which no reader handles usefully.
@@ -13,8 +19,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to create or update (e.g. docs-pdf-2026-07)'
-        required: true
+        description: 'Release tag to create or update. Defaults to docs-pdf-YYYY-MM.'
+        required: false
         type: string
       label:
         description: 'Cover-page label (e.g. "Snapshot July 2026"). Defaults to the run date.'
@@ -31,21 +37,84 @@ on:
         default: true
         type: boolean
 
+  # 04:00 UTC on the 15th of every month. Off-hours for CET/CEST reviewers, and
+  # mid-month so it never collides with month-boundary release work.
+  #
+  # Cron only fires on the default branch, and GitHub suspends a schedule after
+  # 60 days without a repository push -- not a risk at this repo's commit rate,
+  # but the reason to check the Actions tab if a month goes by with no release.
+  schedule:
+    - cron: '0 4 15 * *'
+
 permissions:
   contents: write   # required to create the release and upload assets
+
+# A scheduled run and a manual one could otherwise target the same monthly tag
+# concurrently, and `gh release upload --clobber` is not atomic. Queue instead of
+# cancelling: a run that has already spent an hour rendering should finish.
+concurrency:
+  group: generate-pdfs
+  cancel-in-progress: false
 
 env:
   PANDOC_VERSION: '3.10.1'
 
 jobs:
-  # Resolve the space list once so the build matrix and the release job agree.
+  # Resolve every input once -- a scheduled run supplies none of them -- so the
+  # build matrix and the release job agree on one set of values.
   plan:
     runs-on: ubuntu-latest
     outputs:
       spaces: ${{ steps.plan.outputs.spaces }}
       label: ${{ steps.plan.outputs.label }}
+      tag: ${{ steps.plan.outputs.tag }}
+      draft: ${{ steps.plan.outputs.draft }}
     steps:
       - uses: actions/checkout@v7
+
+      - id: plan
+        name: Resolve tag, spaces, cover label, and draft state
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+          REQUESTED: ${{ inputs.spaces }}
+          LABEL_INPUT: ${{ inputs.label }}
+          DRAFT_INPUT: ${{ inputs.draft }}
+        run: |
+          set -euo pipefail
+          # One release per calendar month, so the monthly cron and a mid-month
+          # manual re-cut land on the same tag.
+          tag="$TAG_INPUT"
+          [[ -n "$tag" ]] || tag="docs-pdf-$(date -u +%Y-%m)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+          # --list-spaces validates its arguments, so a typo fails here rather
+          # than after the matrix has already fanned out. A scheduled run leaves
+          # REQUESTED empty, which the script already reads as every space.
+          if [[ -z "$REQUESTED" || "$REQUESTED" == "all" ]]; then
+            spaces=$(python3 pdf/build.py --list-spaces)
+          else
+            spaces=$(python3 pdf/build.py --list-spaces $REQUESTED)
+          fi
+          echo "spaces=$spaces" >> "$GITHUB_OUTPUT"
+
+          label="$LABEL_INPUT"
+          [[ -n "$label" ]] || label="Snapshot $(date -u +%Y-%m-%d)"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
+
+          # A draft release does not move `releases/latest`, which the docs home
+          # page links to -- so an unattended run has to publish, or the monthly
+          # rebuild silently never reaches readers. Manual runs keep the draft
+          # default, so a hand-cut snapshot can still be eyeballed first.
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            draft=false
+          else
+            draft="${DRAFT_INPUT:-true}"
+          fi
+          echo "draft=$draft" >> "$GITHUB_OUTPUT"
+
+          echo "Tag: $tag (draft: $draft)"
+          echo "Building: $spaces"
+          echo "Label: $label"
 
       # The tag becomes a Git ref when the release is published, so reject
       # anything git would refuse. A draft release accepts an invalid name (it
@@ -53,7 +122,7 @@ jobs:
       # of rendering later. check-ref-format needs no repository, just git.
       - name: Validate the release tag
         env:
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ steps.plan.outputs.tag }}
         run: |
           set -euo pipefail
           if ! git check-ref-format "refs/tags/$TAG"; then
@@ -72,29 +141,6 @@ jobs:
       # failing here costs seconds instead of an hour of rendering.
       - name: Verify WCAG AA contrast
         run: python3 pdf/check_contrast.py
-
-      - id: plan
-        name: Resolve spaces and cover label
-        env:
-          REQUESTED: ${{ inputs.spaces }}
-          LABEL_INPUT: ${{ inputs.label }}
-        run: |
-          set -euo pipefail
-          # --list-spaces validates its arguments, so a typo fails here rather
-          # than after the matrix has already fanned out.
-          if [[ "$REQUESTED" == "all" ]]; then
-            spaces=$(python3 pdf/build.py --list-spaces)
-          else
-            spaces=$(python3 pdf/build.py --list-spaces $REQUESTED)
-          fi
-          echo "spaces=$spaces" >> "$GITHUB_OUTPUT"
-
-          label="$LABEL_INPUT"
-          [[ -n "$label" ]] || label="Snapshot $(date -u +%Y-%m-%d)"
-          echo "label=$label" >> "$GITHUB_OUTPUT"
-
-          echo "Building: $spaces"
-          echo "Label: $label"
 
   build:
     needs: plan
@@ -235,7 +281,7 @@ jobs:
           # git remote for gh to infer the repository from -- without GH_REPO
           # every gh call fails with "not a git repository".
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ needs.plan.outputs.tag }}
         run: |
           set -euo pipefail
           notes="MariaDB documentation PDFs — ${{ needs.plan.outputs.label }}
@@ -256,5 +302,5 @@ jobs:
               --target "$GITHUB_SHA" \
               --title "Documentation PDFs — ${{ needs.plan.outputs.label }}" \
               --notes "$notes" \
-              ${{ inputs.draft && '--draft' || '' }}
+              ${{ needs.plan.outputs.draft == 'true' && '--draft' || '' }}
           fi

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -18,9 +18,20 @@ recommended: `qpdf` (lossless size pass), `poppler-utils` (page-count
 reporting), `npm` (only for `fetch-deps.sh`).
 
 In CI, `.github/workflows/generate-pdfs.yml` builds every space in parallel and
-attaches the results to a GitHub Release. It is `workflow_dispatch`-only: a full
-run produces several hundred MB, so it is cut per documentation snapshot rather
-than per push.
+attaches the results to a GitHub Release. A full run produces several hundred MB,
+so it is cut per documentation snapshot rather than per push:
+
+- **Automatically**, at 04:00 UTC on the 15th of each month, so a current
+  snapshot exists even in a month when nobody remembers to cut one. Scheduled
+  runs publish immediately, because a draft release does not move
+  `releases/latest`, which the documentation home page links to.
+- **Manually** (`workflow_dispatch`), to re-cut after a Server release lands.
+  Manual runs default to a draft so the output can be checked before it is
+  published.
+
+Both default to the tag `docs-pdf-YYYY-MM` — one release per calendar month, so
+a mid-month re-cut replaces that month's assets rather than adding a
+near-identical release. Pass an explicit `tag` to keep a snapshot separate.
 
 ## Output
 


### PR DESCRIPTION
[DOCS-6368](https://mariadbcorp.atlassian.net/browse/DOCS-6368) — follow-on to DOCS-5710.

`generate-pdfs.yml` was `workflow_dispatch`-only, so the per-space PDFs were only refreshed when someone remembered to cut a snapshot. This adds a monthly cron (04:00 UTC on the 15th) so a reasonably current snapshot always exists, while keeping manual dispatch for re-cutting after a Server release.

A scheduled run supplies **none** of the `workflow_dispatch` inputs, so three things needed handling:

1. **All inputs resolved centrally.** `inputs.tag` was `required: true` and read directly by the tag-validation and release steps — on a scheduled run it is empty and `git check-ref-format "refs/tags/"` would have failed the run within the minute. Tag / label / spaces / draft are now resolved in one step in the `plan` job, and the release job reads `needs.plan.outputs.*`.
2. **Tag defaults to `docs-pdf-YYYY-MM`** — one release per calendar month, so a mid-month manual re-cut updates that month's assets in place instead of piling up near-identical ~450 MB releases. This also makes the manual `tag` input optional; the trade-off is that a manual run with no tag now overwrites the current month rather than erroring.
3. **Scheduled runs publish, they do not draft.** The documentation home page links to `/releases/latest/download/`, and a draft release does not move `releases/latest` — an unattended draft would render for an hour and never reach readers. Manual dispatch keeps the existing `draft: true` default so a hand-cut snapshot can still be checked first.

Also adds a `concurrency` group with `cancel-in-progress: false`, since a scheduled and a manual run could otherwise upload to the same monthly tag at once and `gh release upload --clobber` is not atomic. Queueing rather than cancelling, because a run that has already spent an hour rendering should finish.

`pdf/README.md` stated the workflow was `workflow_dispatch`-only, so it is updated too.

## Verification

- Workflow YAML parses; both triggers present, all four `plan` outputs wired through, no `inputs.*` references left outside the single resolve step.
- Resolve logic smoke-tested locally for all three paths — cron with zero inputs, manual with defaults, manual with explicit tag/spaces/publish. Matrix JSON and `git check-ref-format` good in each.
- codespell clean on both changed files.

Next cron fires 15 Aug → `docs-pdf-2026-08`. The existing `docs-pdf-2026-07` release is untouched.

## For reviewers

- **Storage** grows ~450 MB/month (~5.4 GB/year). Worth deciding a retention rule (e.g. keep 12 months) separately if that matters. Runner cost is negligible — the last full run was ~13 minutes wall clock.
- **GitHub suspends a cron after 60 days without a repository push.** Not a real risk at this repo's commit rate, but it is why the workflow comment points at the Actions tab if a month passes with no release.
- The **15th / 04:00 UTC** slot and the **monthly-tag** convention are the two easily-changed judgment calls here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6368]: https://mariadbcorp.atlassian.net/browse/DOCS-6368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ