### PR TITLE
DOCS-6373 Document character_set_collations default and FK collation rules

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md
@@ -54,6 +54,7 @@ Foreign keys have the following requirements:
 
 * Referenced columns in the parent table must be a an index or a prefix of an index.
 * Foreign key columns and referenced columns must be of the same type, or similar types. For integer types, the size and sign must also be the same.
+* For string types, the foreign key column and the referenced column must use the same character set **and** the same collation. Two columns that differ only in collation, such as `utf8mb4_general_ci` and `utf8mb4_uca1400_ai_ci`, cannot be compared, so a foreign key between them is rejected. See [Changing the Character Set or Collation of a Foreign Key Column](foreign-keys.md#changing-the-character-set-or-collation-of-a-foreign-key-column).
 * Both foreign key columns and referenced columns can be [PERSISTENT](../../../reference/sql-statements/data-definition/create/generated-columns.md) columns. However, the `ON UPDATE CASCADE`, `ON UPDATE SET NULL`, `ON DELETE SET NULL` clauses are not allowed in this case.
 * The parent and the child table must use the same storage engine, and must not be `TEMPORARY` or partitioned tables. However, they can be the same table.
 
@@ -102,8 +103,57 @@ The allowed actions for `ON DELETE` and `ON UPDATE` are:
 
 Foreign key constraints can be disabled by setting the [foreign\_key\_checks](../system-variables/server-system-variables.md#foreign_key_checks) server system variable to `0`. This speeds up the insertion of large quantities of data.
 
+Setting `foreign_key_checks` to `0` suspends the checks on data, but it does not permit schema changes that would leave the constraint itself invalid. Regardless of the setting, a column used in a foreign key cannot be dropped, renamed, or changed in a way that alters how its values compare, including a change of type, character set, or collation. See [Changing the Character Set or Collation of a Foreign Key Column](foreign-keys.md#changing-the-character-set-or-collation-of-a-foreign-key-column).
+
 {% hint style="info" %}
 For detailed information about constraints, see [this page](../../../reference/sql-statements/data-definition/constraint.md).
+{% endhint %}
+
+## Changing the Character Set or Collation of a Foreign Key Column
+
+Because a foreign key requires both string columns to share a character set and collation, converting one table without the other breaks the constraint. MariaDB refuses the conversion rather than allowing it:
+
+* Converting the child table fails with [error 1832](../../../reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md), `Cannot change column '...': used in a foreign key constraint '...'`.
+* Converting the parent table fails with [error 1833](../../../reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md), `Cannot change column '...': used in a foreign key constraint '...' of table '...'`.
+
+{% hint style="warning" %}
+Setting `foreign_key_checks` to `0` does not lift this restriction, and neither does requesting `ALGORITHM=COPY` or `ALGORITHM=INPLACE`. The conversion is rejected in every combination of the two. This is deliberate: allowing it would leave a foreign key whose columns can no longer be compared, producing a schema that cannot be restored from a dump.
+{% endhint %}
+
+Instead, drop the constraint, convert both tables, and re-create the constraint. Dropping it in the **same** `ALTER TABLE` statement as the column change is supported, so the child table needs only one statement:
+
+```sql
+SET FOREIGN_KEY_CHECKS=0;
+
+ALTER TABLE child
+  DROP FOREIGN KEY fk_name,
+  MODIFY col VARCHAR(24) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+ALTER TABLE parent
+  MODIFY col VARCHAR(24) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+ALTER TABLE child
+  ADD CONSTRAINT fk_name FOREIGN KEY (col) REFERENCES parent (col);
+
+SET FOREIGN_KEY_CHECKS=1;
+```
+
+The order matters. The parent table cannot be converted while a child foreign key still references it, and a child's constraint cannot be dropped from within the parent's `ALTER TABLE`. Across a whole schema, drop every affected constraint first, convert all the tables, then re-create the constraints.
+
+Re-creating a constraint while `foreign_key_checks` is `0` does not validate the existing rows against it. To have them validated, restore `foreign_key_checks` to `1` before the `ADD CONSTRAINT` statement.
+
+To list the constraints that need dropping and re-creating, query the [KEY\_COLUMN\_USAGE](../../../reference/system-tables/information-schema/information-schema-tables/information-schema-key_column_usage-table.md) table:
+
+```sql
+SELECT TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME,
+       REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+  FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+ WHERE TABLE_SCHEMA = DATABASE()
+   AND REFERENCED_TABLE_NAME IS NOT NULL;
+```
+
+{% hint style="info" %}
+Converting a table to a different collation changes how its values compare and sort, which also changes what counts as a duplicate in a unique index. Where a conversion is only needed to make two tables match, converting the older tables **forward** to the newer collation is usually preferable to moving the newer ones back. See [Setting Character Sets and Collations](../../../reference/data-types/string-data-types/character-sets/setting-character-sets-and-collations.md).
 {% endhint %}
 
 ## Metadata

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -691,7 +691,7 @@ The suffix can be upper or lower-case.
 
 #### `foreign_key_checks`
 
-* Description: If set to 1 (the default) [foreign key constraints](../optimization-and-indexes/foreign-keys.md) (including ON UPDATE and ON DELETE behavior) [InnoDB](../../../server-usage/storage-engines/innodb/) tables are checked, while if set to 0, they are not checked. `0` is not recommended for normal use, though it can be useful in situations where you know the data is consistent, but want to reload data in a different order from that specified by parent/child relationships. Setting this variable to 1 does not retrospectively check for inconsistencies introduced while set to 0.
+* Description: If set to 1 (the default) [foreign key constraints](../optimization-and-indexes/foreign-keys.md) (including ON UPDATE and ON DELETE behavior) [InnoDB](../../../server-usage/storage-engines/innodb/) tables are checked, while if set to 0, they are not checked. `0` is not recommended for normal use, though it can be useful in situations where you know the data is consistent, but want to reload data in a different order from that specified by parent/child relationships. Setting this variable to 1 does not retrospectively check for inconsistencies introduced while set to 0. Setting it to 0 suspends the checks on data only; it does not permit schema changes that would leave a constraint invalid, so a column used in a foreign key still cannot be dropped, renamed, or changed in type, character set, or collation. See [Changing the Character Set or Collation of a Foreign Key Column](../optimization-and-indexes/foreign-keys.md#changing-the-character-set-or-collation-of-a-foreign-key-column).
 * Command line: None
 * Scope: Global, Session
 * Dynamic: Yes

--- a/server/reference/data-types/string-data-types/character-sets/setting-character-sets-and-collations.md
+++ b/server/reference/data-types/string-data-types/character-sets/setting-character-sets-and-collations.md
@@ -114,6 +114,8 @@ SHOW CREATE DATABASE danish_names;
 
 Although there are [character\_set\_database](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_database) and [collation\_database](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#collation_database) system variables which can be set dynamically, these are used for determining the character set and collation for the default database, and should only be set by the server.
 
+A database's collation is inherited only by statements that don't name a character set of their own. A `CREATE TABLE` that names one, such as `CREATE TABLE ... DEFAULT CHARACTER SET utf8mb4`, takes its collation from the [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) map instead. See [Table Level](setting-character-sets-and-collations.md#table-level) and [Changing Default Collation](setting-character-sets-and-collations.md#changing-default-collation).
+
 ## Table Level
 
 The [CREATE TABLE](../../../sql-statements/data-definition/create/create-table.md) and [ALTER TABLE](../../../sql-statements/data-definition/alter/alter-table/) statements support optional character set and collation clauses, a MariaDB and MySQL extension to standard SQL.
@@ -124,7 +126,18 @@ CREATE TABLE english_names (id INT, name VARCHAR(40))
   COLLATE 'utf8_icelandic_ci';
 ```
 
-If neither character set nor collation is provided, the database default will be used. If only the character set is provided, the default collation for that character set will be used . If only the collation is provided, the associated character set will be used. See [Supported Character Sets and Collations](supported-character-sets-and-collations.md).
+If neither character set nor collation is provided, the database default will be used. If only the character set is provided, the default collation for that character set will be used. If only the collation is provided, the associated character set will be used. See [Supported Character Sets and Collations](supported-character-sets-and-collations.md).
+
+{% hint style="warning" %}
+Naming a character set without a `COLLATE` clause does **not** inherit the database's collation. The collation comes from the [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) map instead, which has a non-empty default value since MariaDB 11.5. So these two statements can produce different collations in the same database:
+
+```sql
+CREATE TABLE t1 (id VARCHAR(24));                                -- inherits the database collation
+CREATE TABLE t2 (id VARCHAR(24)) DEFAULT CHARACTER SET utf8mb4;  -- uses character_set_collations
+```
+
+In a database whose default collation is `utf8mb4_general_ci`, `t1` is `utf8mb4_general_ci` while `t2` is `utf8mb4_uca1400_ai_ci`. To get the same result from both, either add an explicit `COLLATE` clause or change the map — see [Changing Default Collation](setting-character-sets-and-collations.md#changing-default-collation).
+{% endhint %}
 
 ```sql
 ALTER TABLE table_name
@@ -435,11 +448,28 @@ SELECT @param_coll;
 
 {% tabs %}
 {% tab title="Current" %}
-It is possible to change the default collation associated with a particular character set. The [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) system variable accepts a comma-delimited list of character sets and new default collations, for example:
+The default collation associated with a particular character set is determined by the [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) system variable, which accepts a comma-delimited list of character sets and their default collations, for example:
 
 ```sql
 SET @@character_set_collations = 'utf8mb4=uca1400_ai_ci, latin2=latin2_hungarian_ci';
 ```
+
+The variable is **not** empty by default. Since MariaDB 11.5, its default value maps every Unicode character set to a UCA 14.0.0 collation, so the map applies even on a server where nobody has ever set the variable. To see the value in effect:
+
+```sql
+SELECT @@character_set_collations;
++-----------------------------------------------------------------------------------------------------------------------------------------+
+| @@character_set_collations                                                                                                              |
++-----------------------------------------------------------------------------------------------------------------------------------------+
+| utf8mb3=utf8mb3_uca1400_ai_ci,ucs2=ucs2_uca1400_ai_ci,utf8mb4=utf8mb4_uca1400_ai_ci,utf16=utf16_uca1400_ai_ci,utf32=utf32_uca1400_ai_ci |
++-----------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+A collation can be given either by its full name, such as `utf8mb4_uca1400_ai_ci`, or by the shorter family name that applies to any character set, such as `uca1400_ai_ci`. The server stores the full name, so the value it reports back is always the expanded form.
+{% endtab %}
+
+{% tab title="< 11.5" %}
+The variable exists but is empty by default, so each character set uses its compiled-in default collation, such as `utf8mb4_general_ci` for `utf8mb4`.
 {% endtab %}
 
 {% tab title="< 11.2.1" %}
@@ -447,7 +477,7 @@ It is **not** possible to change the default collation associated with a particu
 {% endtab %}
 {% endtabs %}
 
-The new variable takes effect in all cases where a character set is explicitly or implicitly specified without an explicit `COLLATE` clause, including but not limited to:
+The variable takes effect in all cases where a character set is explicitly or implicitly specified without an explicit `COLLATE` clause, including but not limited to:
 
 * Column collation
 * Table collation
@@ -461,10 +491,38 @@ The new variable takes effect in all cases where a character set is explicitly o
 * `_utf8mb3 0x61` - a character string literal with an introducer with hex hybrid notation
 * `@@collation_connection` after a `SET NAMES` statement without `COLLATE`
 
+### Overriding the Map for One Character Set
+
+Assigning to the variable **replaces the entire map**; it does not merge with the value already in effect. Setting only `utf8mb4` therefore returns the other Unicode character sets to their compiled-in defaults:
+
+```sql
+SET GLOBAL character_set_collations = 'utf8mb4=utf8mb4_general_ci';
+```
+
+To change `utf8mb4` while keeping the UCA 14.0.0 defaults for the rest, list them all:
+
+```sql
+SET GLOBAL character_set_collations =
+  'utf8mb3=uca1400_ai_ci,ucs2=uca1400_ai_ci,utf16=uca1400_ai_ci,utf32=uca1400_ai_ci,utf8mb4=utf8mb4_general_ci';
+```
+
+To make either change permanent, set it in a [configuration file](../../../../server-management/install-and-upgrade-mariadb/configuring-mariadb/configuring-mariadb-with-option-files.md):
+
+```ini
+[mariadbd]
+character-set-collations = utf8mb4=utf8mb4_general_ci
+```
+
+{% hint style="info" %}
+`SET GLOBAL` affects new connections only. Existing connections keep the session value they inherited when they connected, so reconnect the application before relying on the new map.
+{% endhint %}
+
 ## Default Character Set and Collation Changes
 
 {% hint style="info" %}
-The default character set and collation changed in MariaDB 11.8.
+The default character set and collation changed in MariaDB 11.6. Separately, the default collation applied to an explicitly named Unicode character set changed in MariaDB 11.5 — see [Changing Default Collation](setting-character-sets-and-collations.md#changing-default-collation).
+
+MariaDB 11.8 is the first long-term support release containing either change, so both take effect at once when upgrading from an earlier long-term support release such as MariaDB 10.6 or 11.4.
 {% endhint %}
 
 The default character set has changed from `latin1` to `utf8mb4`, and the default collation has changed from `latin1_swedish_ci` to `utf8mb4_uca1400_ai_ci`. This update improves global compatibility and supports modern data requirements, such as emojis.

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md
@@ -6,6 +6,14 @@
 
 ## Possible Causes and Solutions
 
+An `ALTER TABLE` statement tried to change a column that the table uses as a [foreign key](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md), in a way that would change how its values compare with the referenced column. Changing the column's type, length, character set, or collation all qualify. A common case is converting a table to a different collation, where the referenced table still uses the old one.
+
+Setting `foreign_key_checks` to `0` does not lift this restriction, and neither does choosing a different `ALGORITHM`.
+
+To make the change, drop the constraint in the same `ALTER TABLE` statement as the column change, apply the matching change to the referenced table, then re-create the constraint. For the full procedure, see [Changing the Character Set or Collation of a Foreign Key Column](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md#changing-the-character-set-or-collation-of-a-foreign-key-column).
+
+If the referenced table is the one being altered, the server reports [error 1833](e1833.md) instead.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 {% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}

--- a/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md
+++ b/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md
@@ -6,6 +6,14 @@
 
 ## Possible Causes and Solutions
 
+An `ALTER TABLE` statement tried to change a column that another table references through a [foreign key](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md), in a way that would change how its values compare with the referencing column. Changing the column's type, length, character set, or collation all qualify. A common case is converting a table to a different collation, where the referencing table still uses the old one. The third name in the message is the table holding the constraint.
+
+Setting `foreign_key_checks` to `0` does not lift this restriction, and neither does choosing a different `ALGORITHM`.
+
+A referencing table's constraint cannot be dropped from within the referenced table's `ALTER TABLE` statement, so drop it on the referencing table first, then apply the change to both tables and re-create the constraint. For the full procedure, see [Changing the Character Set or Collation of a Foreign Key Column](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md#changing-the-character-set-or-collation-of-a-foreign-key-column).
+
+If the table being altered is the one holding the constraint, the server reports [error 1832](e1832.md) instead.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 {% include "../../../.gitbook/includes/license-cc-by-sa-gnu-fdl.md" %}


### PR DESCRIPTION
[DOCS-6373](https://mariadbcorp.atlassian.net/browse/DOCS-6373)

Two related documentation gaps, both found while answering a MariaDB Community Slack question. A user with a database predating MariaDB 11 (tables in `utf8mb4_general_ci`) ran `ALTER DATABASE ... COLLATE = 'utf8mb4_general_ci'`, which fixed a bare `CREATE TABLE` but not their application's `CREATE TABLE ... DEFAULT CHARACTER SET utf8mb4` — that came out `utf8mb4_uca1400_ai_ci` and broke a foreign key. After correcting it, converting the mixed-collation tables failed on foreign keys, and `foreign_key_checks=0` didn't help.

## `setting-character-sets-and-collations.md`

The *Changing Default Collation* section already listed every context `character_set_collations` applies to, but opened with "It is possible to change the default collation…" and never said the variable **has a non-empty default since 11.5** — so a reader who never set it concludes the section isn't about them.

- Reframe the section around the variable determining the default, and state the 11.5 default explicitly, with a `< 11.5` tab for the empty-by-default behavior.
- Show the value as the server actually reports it (expanded collation names), and note both the full and short family forms are accepted as input.
- New *Overriding the Map for One Character Set* subsection: assignment **replaces the whole map**, so setting only `utf8mb4` silently reverts the other Unicode character sets; includes the full-list form and the option-file equivalent.
- Add the missing link and warning at the two places readers actually look — *Database Level* and *Table Level* — because naming a character set bypasses the inherited database collation.
- Correct the hint that said the default character set changed in **11.8**. It changed in **11.6** (MDEV-19123, first in `mariadb-11.6.1`), which the page's own top tabs already said. 11.8 is only the first LTS containing it.

## `foreign-keys.md`

- *Requirements and Limitations* listed type/size/sign matching but not that string columns must share **character set and collation**.
- New *Changing the Character Set or Collation of a Foreign Key Column* section: errors 1832/1833, the fact that `foreign_key_checks=0` does **not** lift the restriction (deliberate — MDEV-31086, "MODIFY COLUMN can break FK constraints, and lead to unrestorable dumps"), the supported drop-in-the-same-`ALTER` / convert / re-create procedure, why the order matters, and a `KEY_COLUMN_USAGE` query to enumerate the constraints.

## Also

- `foreign_key_checks` variable description: note that `0` suspends data checks only, not the schema restrictions.
- Errors [1832](server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832.md) and [1833](server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1833.md) had empty *Possible Causes and Solutions* sections — filled in, cross-linked to each other and to the procedure.

## Verification

Every claim checked against `mariadb-server` @ `cded2b25e65` (13.0.1), corroborated by in-tree mtr expectations — chiefly `mysql-test/suite/innodb/t/fk_col_alter.test`, which asserts the FK rejection under `FOREIGN_KEY_CHECKS=1` *and* `=0`, for both `ALGORITHM=COPY` and `ALGORITHM=INPLACE`, and whose "Correct way to change character set in foreign key constraint" block is the procedure documented here. Full fact-check report (15 claims, 1 correction) is on the ticket. `docs-check` passes: codespell + lychee clean, blocks balanced, no new pages so `SUMMARY.md` is untouched.

Not verified on a live server — claims about the rejection behavior and the working procedure rest on source plus the mtr expectations. The tested sequence in the new section is the one to spot-check if a reviewer wants to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6373]: https://mariadbcorp.atlassian.net/browse/DOCS-6373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ