### PR TITLE
DOCS-6376: hide Connector/J 2.7.15, 3.3.6, 3.4.4, 3.5.10 release notes for now

### DIFF
--- a/release-notes/connectors/java/2.7/2.7.15.md
+++ b/release-notes/connectors/java/2.7/2.7.15.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Release notes for MariaDB Connector/J 2.7.15, a Stable (GA) release published
+  29 July 2026.
+hidden: true
+---
+
 # Connector/J 2.7.15 Release Notes
 
 {% include "../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/3.3/3.3.6.md
+++ b/release-notes/connectors/java/3.3/3.3.6.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Release notes for MariaDB Connector/J 3.3.6, a Stable (GA) release published
+  29 July 2026.
+hidden: true
+---
+
 # Connector/J 3.3.6 Release Notes
 
 {% include "../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/3.4/3.4.4.md
+++ b/release-notes/connectors/java/3.4/3.4.4.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Release notes for MariaDB Connector/J 3.4.4, a Stable (GA) release published
+  29 July 2026.
+hidden: true
+---
+
 # Connector/J 3.4.4 Release Notes
 
 {% include "../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/3.5/3.5.10.md
+++ b/release-notes/connectors/java/3.5/3.5.10.md
@@ -1,3 +1,10 @@
+---
+description: >-
+  Release notes for MariaDB Connector/J 3.5.10, a Stable (GA) release published
+  29 July 2026.
+hidden: true
+---
+
 # Connector/J 3.5.10 Release Notes
 
 <a href="https://mariadb.com/downloads/connectors/connectors-data-access/java8-connector" class="button primary">Download</a> <a href="3.5.10.md" class="button secondary">Release Notes</a> <a href="../changelogs/3.5/3.5.10.md" class="button secondary">Changelog</a> <a href="https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j" class="button secondary">Connector/J Overview</a>

--- a/release-notes/connectors/java/changelogs/2.7/2.7.15.md
+++ b/release-notes/connectors/java/changelogs/2.7/2.7.15.md
@@ -1,3 +1,8 @@
+---
+description: Full changelog for MariaDB Connector/J 2.7.15, listing every commit in the release.
+hidden: true
+---
+
 # Connector/J 2.7.15 Changelog
 
 {% include "../../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/changelogs/3.3/3.3.6.md
+++ b/release-notes/connectors/java/changelogs/3.3/3.3.6.md
@@ -1,3 +1,8 @@
+---
+description: Full changelog for MariaDB Connector/J 3.3.6, listing every commit in the release.
+hidden: true
+---
+
 # Connector/J 3.3.6 Changelog
 
 {% include "../../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/changelogs/3.4/3.4.4.md
+++ b/release-notes/connectors/java/changelogs/3.4/3.4.4.md
@@ -1,3 +1,8 @@
+---
+description: Full changelog for MariaDB Connector/J 3.4.4, listing every commit in the release.
+hidden: true
+---
+
 # Connector/J 3.4.4 Changelog
 
 {% include "../../../../.gitbook/includes/latest-java.md" %}

--- a/release-notes/connectors/java/changelogs/3.5/3.5.10.md
+++ b/release-notes/connectors/java/changelogs/3.5/3.5.10.md
@@ -1,3 +1,8 @@
+---
+description: Full changelog for MariaDB Connector/J 3.5.10, listing every commit in the release.
+hidden: true
+---
+
 # Connector/J 3.5.10 Changelog
 
 <a href="https://mariadb.com/downloads/connectors/connectors-data-access/java8-connector" class="button primary">Download</a> <a href="../../3.5/3.5.10.md" class="button secondary">Release Notes</a> <a href="3.5.10.md" class="button secondary">Changelog</a> <a href="https://app.gitbook.com/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j" class="button secondary">Connector/J Overview</a>


### PR DESCRIPTION
Follow-up to #810 (which added the base release notes). This hides the four new Connector/J release pages and their changelogs until the releases are made public.

## What changed
Adds `description:` + `hidden: true` frontmatter to the 8 new version pages:

- `release-notes/connectors/java/{2.7/2.7.15, 3.3/3.3.6, 3.4/3.4.4, 3.5/3.5.10}.md`
- `release-notes/connectors/java/changelogs/{2.7/2.7.15, 3.3/3.3.6, 3.4/3.4.4, 3.5/3.5.10}.md`

`hidden: true` keeps the pages in the `SUMMARY.md` nav tree (entries added in #810) but drops them from the published table of contents. Un-hiding later = remove the one `hidden: true` line per page.

Left visible, per ticket scope: the `all-releases.md` rows, the about-page `maxAllowedColumns`/`maxAllowedPacket` option docs, and the 3.5.9 CONJ-1299 tweak.

## Verification
Release-note content (authored in #810) was fact-checked against the `mariadb-connector-j` tags — release dates, per-version CONJ lists, and the new option defaults all confirmed against source. Full report posted to the ticket via `/jira-resolve`.

Ticket: https://mariadbcorp.atlassian.net/browse/DOCS-6376

🤖 Generated with [Claude Code](https://claude.com/claude-code)