### PR TITLE
DOCS-6378 Fix character_set_collations version on SET NAMES

### DIFF
--- a/server/reference/data-types/string-data-types/character-sets/set-names.md
+++ b/server/reference/data-types/string-data-types/character-sets/set-names.md
@@ -52,7 +52,7 @@ SELECT VARIABLE_NAME, SESSION_VALUE
 {% endtab %}
 
 {% tab title="< 11.8" %}
-The `utf8` [character set](./) (and related collations) is an alias for `utf8mb3` , rather than the other way around. [MariaDB 11.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/11.4/what-is-mariadb-114) added the [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) variable, so the `SELECT` query is more specific in this example:
+The `utf8` [character set](./) (and related collations) is an alias for `utf8mb3`, rather than the other way around. MariaDB 11.2 added the [character\_set\_collations](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#character_set_collations) variable, so the `SELECT` query is more specific in this example:
 
 ```sql
 SELECT VARIABLE_NAME, SESSION_VALUE 


### PR DESCRIPTION
Fixes [DOCS-6378](https://mariadbcorp.atlassian.net/browse/DOCS-6378).

The **SET NAMES** page (the `< 11.8` example tab) said MariaDB 11.4 added `character_set_collations`. It was added in **11.2**.

### Verification

| Source | Says |
|---|---|
| Community Server commit `75f25e4ca77` — *MDEV-30164 System variable for default collations* (`sql/sys_vars.cc`) | earliest containing tag is `mariadb-11.2.1` |
| Server System Variables → `#character_set_collations` | `Introduced: MariaDB 11.2` |
| System Variables Added in MariaDB 11.2 | `character_set_collations — MariaDB 11.2.1` |

11.4 is the first *Enterprise Server* release to carry the variable — which is what "What's New in MariaDB Enterprise Server 11.4" correctly says — so this looks like an ES version carried into a Community Server page. The removed citation linked the *CS* 11.4 release notes, reinforcing the wrong version.

### The removed link — reviewer's call

The version link is dropped rather than retargeted, on editorial grounds: the sibling "Current" tab links no version either, the useful link (to the variable's reference entry) is kept, and the only correct target would be `community-server/old-releases/11.2/what-is-mariadb-112` — an unmaintained-release page.

To correct my own earlier reasoning here: retargeting **is** cleanly available via the `{release-notes}` alias token, which the expansion Action supports and lychee skips. I had said it would require hand-authoring an expanded `app.gitbook.com` URL; that was wrong. So this is a judgment call, not a constraint — if you'd rather keep the citation, say so and I'll add:

```
[MariaDB 11.2]({release-notes}/community-server/old-releases/11.2/what-is-mariadb-112)
```

A stray space before a comma on the same line goes too.

### Out of scope

Two Connector/J pages describe `connectionCollation` as "useful only for the server before MariaDB 11.4". That boundary is defensible as practical guidance rather than an introduction claim, so it's left alone.

### Checks

All green: `codespell-check`, `link-check`, `expand-links`, `generate`, both GitBook builds. Also verified locally with the CI-exact codespell invocation and lychee.

Found while spot-checking site-search relevance for `character_set_collations` after DOCS-6373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6378]: https://mariadbcorp.atlassian.net/browse/DOCS-6378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ