### PR TITLE
DOCS-6365 fix slug labels typed into prose in Connector/J 3.0 release notes

### DIFF
--- a/release-notes/connectors/java/3.0/3.0.1.md
+++ b/release-notes/connectors/java/3.0/3.0.1.md
@@ -24,8 +24,7 @@ MariaDB Connector/J 3.0.1 is a [_**Beta**_](../../../community-server/about/rele
 
 ## Notable Changes
 
-See [mariadb-connector-j-300-release-notes.md](3.0.0.md) for 3.0 release.\
-with the following fixes :
+See the [MariaDB Connector/J 3.0.0 Release Notes](3.0.0.md) for the 3.0 release, with the following fixes:
 
 ## Bugs Fixed
 

--- a/release-notes/connectors/java/3.0/3.0.2.md
+++ b/release-notes/connectors/java/3.0/3.0.2.md
@@ -24,8 +24,7 @@ MariaDB Connector/J 3.0.2 is a [_**Release Candidate (RC)**_](../../../community
 
 ## Notable Changes
 
-See [mariadb-connector-j-300-release-notes](3.0.0.md) and [mariadb-connector-j-301-release-notes](3.0.1.md) for 3.0 release.\
-with the following changes:
+See the [MariaDB Connector/J 3.0.0 Release Notes](3.0.0.md) and [MariaDB Connector/J 3.0.1 Release Notes](3.0.1.md) for the 3.0 release, with the following changes:
 
 ### Feature
 


### PR DESCRIPTION
Fixes [DOCS-6365](https://mariadbcorp.atlassian.net/browse/DOCS-6365).

The "Notable Changes" intro on the Connector/J **3.0.1** and **3.0.2** release notes used page slugs as link text, so the live site renders raw slugs (`mariadb-connector-j-300-release-notes`) instead of page titles. These are plain inline links rather than content-refs, so GitBook never substitutes the title — and the PDF pipeline correctly leaves them alone.

Also folded the stray trailing-backslash hard break into the sentence it belonged to; it was splitting one sentence into a fragment plus a dangling `with the following fixes :`.

**Before**

> See \[mariadb-connector-j-300-release-notes.md](3.0.0.md) for 3.0 release.\
> with the following fixes :

**After**

> See the \[MariaDB Connector/J 3.0.0 Release Notes](3.0.0.md) for the 3.0 release, with the following fixes:

Link text follows the phrasing already used elsewhere in the connector release notes (cf. Connector/ODBC 1.0.7, "See the [MariaDB Connector/ODBC 1.0.6 Release Notes](...)").

### Scope

I swept the whole tree for the same defect — a filename or page slug used as link text outside a `content-ref` block. These two lines (three links) are the only instances; other slug-looking labels are legitimate (`content-ref` bodies, system-variable anchors like `raft-sst-listen-port`, CMAPI endpoint names like `mode-set`).

### Checks

- `codespell --check-filenames --skip ./.git --ignore-words .codespellignore` — pass
- `lychee` on both changed files — 9 OK, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6365]: https://mariadbcorp.atlassian.net/browse/DOCS-6365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ