### PR TITLE
DOCS-6364 fix escaped GitBook block markers on five pages

### DIFF
--- a/maxscale/reference/maxscale-monitors/mariadb-monitor.md
+++ b/maxscale/reference/maxscale-monitors/mariadb-monitor.md
@@ -45,8 +45,6 @@ GRANT CONNECTION ADMIN ON *.* TO 'mariadbmon'@'maxscalehost';
 
 [Topology scan](mariadb-monitor.md#scan-topology), [discover replicas](mariadb-monitor.md#discover-replicas) and [bootstrap](mariadb-monitor.md#bootstrap) require the following privilege:
 
-% tabs %\}
-
 ```sql
 GRANT REPLICATION MASTER ADMIN ON *.* TO 'mariadbmon'@'maxscalehost';
 ```

--- a/server/reference/sql-statements/data-definition/alter/alter-table/README.md
+++ b/server/reference/sql-statements/data-definition/alter/alter-table/README.md
@@ -835,7 +835,9 @@ Adding a primary key for an [application-time period table](../../../../sql-stru
 ALTER TABLE rooms ADD PRIMARY KEY(room_number, p WITHOUT OVERLAPS);
 ```
 
-\{% tabs %\} \{% tab title="Current" %\} An `ALTER` query can be replicated faster with this statement, which must be run before the `ALTER` statement:
+{% tabs %}
+{% tab title="Current" %}
+An `ALTER` query can be replicated faster with this statement, which must be run before the `ALTER` statement:
 
 ```sql
 SET @@SESSION.binlog_alter_two_phase = TRUE;
@@ -850,15 +852,16 @@ Binlog would contain two event groups, of which the first one gets delivered to 
 | master-bin.000001 | 700 | Query             |         1 |    
 ```
 
-\{% endtab %\}
+{% endtab %}
 
-\{% tab title="< 10.8.1" %\} This statement is not available:
+{% tab title="< 10.8.1" %}
+This statement is not available:
 
-```
-
-sql
+```sql
 SET @@SESSION.binlog_alter_two_phase = true;
 ```
+{% endtab %}
+{% endtabs %}
 
 ## See Also
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrading-from-mariadb-enterprise-server-10.6-to-11.8.md
@@ -100,7 +100,6 @@ The repository setup only configures the source; you must explicitly install the
 * APT: `sudo apt update && sudo apt install mariadb-server mariadb-backup`
 *   ZYpp: `sudo zypper install MariaDB-server MariaDB-backup`
 
-    \{% endstep %\}
 {% endstep %}
 
 {% step %}

--- a/tools/mariadb-ai-rag/deployment/troubleshooting-guide.md
+++ b/tools/mariadb-ai-rag/deployment/troubleshooting-guide.md
@@ -53,8 +53,6 @@ Recommended Steps:
 1. Check the status of all containers to ensure `mariadb` shows as Healthy.
 2. Restart the environment to clear the timeout.
 
-Bash
-
 ```bash
 docker compose -f docker-compose.dockerhub-dev.yml stop
 docker compose -f docker-compose.dockerhub-dev.yml start
@@ -90,15 +88,13 @@ Recommended Steps:
 
 ### 1. Check Overall Service Health
 
-Use Docker Compose to verify that all constituent containers are running correctly: \{% code title="Verify status" %\}
+Use Docker Compose to verify that all constituent containers are running correctly:
 
-Bash
-
-```
+{% code title="Verify status" %}
+```bash
 docker compose -f docker-compose.dockerhub-dev.yml ps
 ```
-
-\{% endcode %\}
+{% endcode %}
 
 ### 2. Verify Network Connectivity
 

--- a/tools/mariadb-ai-rag/reference/secret-management.md
+++ b/tools/mariadb-ai-rag/reference/secret-management.md
@@ -44,4 +44,4 @@ The MariaDB AI RAG system allows you to manage sensitive credentials (like API k
 | 1Password  | `config.env.1password.employee` | 1Password CLI         | Enterprise / Corporate |
 | HCP Vault  | `config.env.hcp.live`           | Managed Cloud Vault   | Production Cloud       |
 
-\{% @marketo/form formId="4316" %\}
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
Fixes [DOCS-6364](https://mariadbcorp.atlassian.net/browse/DOCS-6364).

Escaped markers (`\{% tabs %\}`) stop GitBook from rendering the block, so readers saw the literal syntax on the live site.

The ticket's `grep -rn '\{%' --include='*.md' .` returns 9 hits in 5 files. **Two of those are in `pdf/README.md`, which documents this very bug and escapes the markers deliberately — left alone.** I also scanned for the escaped *closing* variant (`%\}`), which surfaced a sixth file the ticket's grep misses.

Only two of the six were a plain unescape. The rest needed a judgment call:

| Page | Issue | Fix |
|---|---|---|
| `ai-rag/reference/secret-management` | escaped footer form marker | unescape — the same form appears unescaped in 8,217 other files |
| `ai-rag/deployment/troubleshooting-guide` | escaped `{% code %}`; opening marker stuck on the end of a prose line; stray `Bash` label inside the block | unescape, marker onto its own line, fold `Bash` into the fence language |
| ES 10.6→11.8 upgrade path | escaped `{% endstep %}` was a **duplicate** — the next line already closes the step | **removed**; unescaping would have double-closed the block |
| `maxscale/mariadb-monitor` | `% tabs %\}` had lost its opening brace and had no matching `endtabs`; neighboring tabs blocks are complete and balanced | **removed** as an orphan fragment |
| `alter-table` | escaped `tabs`/`tab`/`endtab`, **plus** a missing `{% endtab %}{% endtabs %}` and a mangled fence with `sql` on its own line | unescape + repair; the block would still have rendered broken after a bare unescape |

The `alter-table` and `maxscale` reconstructions follow the Current / `< <version>` tabs convention already used elsewhere in those files.

### Checks

- `codespell` (CI-exact invocation) — pass
- `lychee`, CI-equivalent flags, all 5 files — 249 OK, **0 errors**
- GitBook block balance verified per file after editing: `tabs`/`tab`/`code`/`step` openers all match their closers, fences all paired
- `alter-table` is in the help-tables extractor path; confirmed its `# ALTER TABLE` / `## Syntax` / `## Description` / `## Examples` / `## See Also` structure is untouched

Note: a stricter local run with `--include-fragments` reports 16 anchor-fragment errors across these files, but that flag isn't used in CI and the count is byte-identical on `main` — pre-existing, none introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6364]: https://mariadbcorp.atlassian.net/browse/DOCS-6364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ