### PR TITLE
Add minimum MariaDB version in post-quantum-cryptography-in-mariadb-t…

### DIFF
--- a/server/security/encryption/data-in-transit-encryption/post-quantum-cryptography-in-mariadb-tls.md
+++ b/server/security/encryption/data-in-transit-encryption/post-quantum-cryptography-in-mariadb-tls.md
@@ -18,7 +18,7 @@ MariaDB automatically negotiates ML-KEM for TLS 1.3 key exchange when linked aga
 
 | Component      | Version Requirement |
 | -------------- | ------------------- |
-| MariaDB Server | -                   |
+| MariaDB Server | 10.8.1 ([source](https://jira.mariadb.org/browse/MDEV-25785)), backported to 10.5.17 ([source](https://jira.mariadb.org/browse/MDEV-29000)) as well as to 10.6.9 and 10.7.5 ([source](https://jira.mariadb.org/browse/MDEV-28133)). (regarding the sources: MariaDB support for OpenSSL 3.0 guarantees support for 3.5.0 and later too due to [API and ABI compatibility](https://www.openssl-library.org/policies/?utm_source=chatgpt.com))            |
 | OpenSSL        | 3.5.0 or later      |
 
 ## How It Works


### PR DESCRIPTION
Other than implied by the current site, there IS a minimal version for MariaDB to be able to use OpenSSL 3.5. This should be given to inform the viewer that one may be forced to update its MariaDB server to use Post-Quantum Cryptography.