### PR TITLE
MXS-6766: Add security vulnerability list for MaxScale

### DIFF
--- a/maxscale/maxscale-security/fixed-security-vulnerabilities.md
+++ b/maxscale/maxscale-security/fixed-security-vulnerabilities.md
@@ -1,0 +1,19 @@
+---
+description: >-
+  This page contains a full list of fixed security vulnerabilities in all versions
+  and series of MariaDB MaxScale.
+---
+
+# Security Vulnerabilities Fixed in MariaDB MaxScale
+
+The list is updated continuously. CVEs may be added retroactively to already-released versions, as vulnerabilities can be reported to and assigned by CVE Numbering Authorities (CNAs) after the corresponding fix has been released. As a result, a release may receive additional CVE entries over time even after it has been published.
+
+## List of Fixed Security Vulnerabilities
+
+| CVE ID (with cve.org link)                                        | MXS Issue                                            | MariaDB MaxScale Releases       |
+| ----------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------- |
+| [CVE-2023-40354](https://nvd.nist.gov/vuln/detail/CVE-2023-40354) | [MXS-4681](https://jira.mariadb.org/browse/MXS-4681) | 2.5.28, 6.4.9, 22.08.8, 23.02.3 |
+
+{% include "../../.gitbook/includes/license-copyright-mariadb.md" %}
+
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
The list currently only contains CVE-2023-40354 which was added in the ticket.