### PR TITLE
DOCS-3977 Document the rowid filter notation in EXPLAIN output

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
@@ -124,6 +124,7 @@ The output of **orders.r\_rows=NULL** and **orders.r\_filtered=NULL** shows that
 
 ## See Also
 
+* [EXPLAIN](explain.md)
 * [ANALYZE FORMAT=JSON](analyze-format-json.md)
 * [SHOW ANALYZE](../show/show-analyze.md)
 * [ANALYZE TABLE](../../table-statements/analyze-table.md)

--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
@@ -112,6 +112,33 @@ WHERE
 
 The output of **orders.r\_rows=NULL** and **orders.r\_filtered=NULL** shows that the table `orders` was never scanned. Indeed, we can also see customer.r\_filtered=0.00. This shows that a part of WHERE attached to table `customer` was never satisfied (or, satisfied in less than 0.01% of cases).
 
+### Rowid Filter Notation
+
+Added in MariaDB 10.4.3 ([MDEV-16188](https://jira.mariadb.org/browse/MDEV-16188)).
+
+When the [Rowid Filtering Optimization](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/rowid-filtering-optimization.md) applies to a table, `r_rows` takes the same `<r_rows> (<N>%)` form that [EXPLAIN](explain.md#rowid-filter-notation) uses for `rows` — but both halves are observations rather than estimates. `r_rows` counts the rows actually read from the table, which with a filter in place means the rows the filter accepted, and `(<N>%)` is the selectivity the filter actually achieved. The `type`, `key` and `key_len` columns use the same composite notation as in `EXPLAIN`.
+
+For the query used on the [EXPLAIN](explain.md#rowid-filter-notation) page, `ANALYZE` reports:
+
+```
+*************************** 2. row ***************************
+           id: 1
+  select_type: SIMPLE
+        table: lineitem
+         type: ref|filter
+possible_keys: PRIMARY,i_l_shipdate,i_l_orderkey,i_l_orderkey_quantity
+          key: i_l_orderkey|i_l_shipdate
+      key_len: 4|4
+          ref: dbt3_s001.orders.o_orderkey
+         rows: 4 (2%)
+       r_rows: 0.15 (2%)
+     filtered: 1.63
+   r_filtered: 100.00
+        Extra: Using where; Using rowid filter
+```
+
+The optimizer expected 4 rows per lookup and a 2% filter, so 4\*0.02 = 0.08 rows to be accepted on average. Execution actually read 0.15 rows per lookup — the filter let through roughly twice what was expected — although the observed selectivity still rounds to the same 2%.
+
 ## ANALYZE FORMAT=JSON
 
 [ANALYZE FORMAT=JSON](analyze-format-json.md) produces JSON output. It produces much more information than tabular `ANALYZE`.

--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
@@ -84,21 +84,21 @@ The `select_type` column can have the following values:
 
 This column contains information on how the table is accessed.
 
-| Value            | Description                                                                                                                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ALL              | A full table scan is done for the table (all rows are read). This is bad if the table is large and the table is joined against a previous table! This happens when the optimizer could not find any usable index to access rows. |
-| const            | There is only one possibly matching row in the table. The row is read before the optimization phase and all columns in the table are treated as constants.                                                                       |
-| eq\_ref          | A unique index is used to find the rows. This is the best possible plan to find the row.                                                                                                                                         |
-| filter           | A second index is being used with the [Rowid Filtering Optimization](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/rowid-filtering-optimization.md).                                                |
-| fulltext         | A fulltext index is used to access the rows.                                                                                                                                                                                     |
-| index\_merge     | A 'range' access is done for several index and the found rows are merged. The key column shows which keys are used.                                                                                                              |
-| index\_subquery  | This is similar as ref, but used for sub queries that are transformed to key lookups.                                                                                                                                            |
-| index            | A full scan over the used index. Better than `ALL` but still bad if index is large and the table is joined against a previous table.                                                                                             |
-| range            | The table will be accessed with a key over one or more value ranges.                                                                                                                                                             |
-| ref\_or\_null    | Like 'ref' but in addition another search for the 'null' value is done if the first value was not found. This happens usually with sub queries.                                                                                  |
-| ref              | A non unique index or prefix of an unique index is used to find the rows. Good if the prefix doesn't match many rows.                                                                                                            |
-| system           | The table has 0 or 1 rows.                                                                                                                                                                                                       |
-| unique\_subquery | This is similar as eq\_ref, but used for sub queries that are transformed to key lookups                                                                                                                                         |
+| Value                | Description                                                                                                                                                                                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ALL                  | A full table scan is done for the table (all rows are read). This is bad if the table is large and the table is joined against a previous table! This happens when the optimizer could not find any usable index to access rows.                                                                                    |
+| const                | There is only one possibly matching row in the table. The row is read before the optimization phase and all columns in the table are treated as constants.                                                                                                                                                          |
+| eq\_ref              | A unique index is used to find the rows. This is the best possible plan to find the row.                                                                                                                                                                                                                            |
+| access\_type\|filter | The join type is combined with the [Rowid Filtering Optimization](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/rowid-filtering-optimization.md): `ref\|filter`, `eq_ref\|filter`, `range\|filter`. `filter` never appears alone. See [Rowid Filter Notation](#rowid-filter-notation). |
+| fulltext             | A fulltext index is used to access the rows.                                                                                                                                                                                                                                                                        |
+| index\_merge         | A 'range' access is done for several index and the found rows are merged. The key column shows which keys are used.                                                                                                                                                                                                 |
+| index\_subquery      | This is similar as ref, but used for sub queries that are transformed to key lookups.                                                                                                                                                                                                                               |
+| index                | A full scan over the used index. Better than `ALL` but still bad if index is large and the table is joined against a previous table.                                                                                                                                                                                |
+| range                | The table will be accessed with a key over one or more value ranges.                                                                                                                                                                                                                                                |
+| ref\_or\_null        | Like 'ref' but in addition another search for the 'null' value is done if the first value was not found. This happens usually with sub queries.                                                                                                                                                                     |
+| ref                  | A non unique index or prefix of an unique index is used to find the rows. Good if the prefix doesn't match many rows.                                                                                                                                                                                               |
+| system               | The table has 0 or 1 rows.                                                                                                                                                                                                                                                                                          |
+| unique\_subquery     | This is similar as eq\_ref, but used for sub queries that are transformed to key lookups                                                                                                                                                                                                                            |
 
 ### Extra Column
 
@@ -144,12 +144,60 @@ The optimization phase can do the following changes to the `WHERE` clause:
 | Using index for group-by                             | The index is being used to resolve a `GROUP BY` or `DISTINCT` query. The rows are not read. This is very efficient if the table has a lot of identical index entries as duplicates are quickly jumped over.                                                                                                                                                                                                                                                          |
 | Using intersect(...)                                 | For index\_merge joins. Shows which index are part of the intersect.                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Using join buffer                                    | We store previous row combinations in a row buffer to be able to match each row against all of the rows combinations in the join buffer at one go.                                                                                                                                                                                                                                                                                                                   |
+| Using rowid filter                                   | A [rowid filter](#rowid-filter-notation) built from a second index is checked before rows are read from the table.                                                                                                                                                                                                                                                                                                                                    |
 | Using sort\_union(...)                               | For index\_merge joins. Shows which index are part of the union.                                                                                                                                                                                                                                                                                                                                                                                                     |
 | Using temporary                                      | A temporary table is created to hold the result. This typically happens if you are using `GROUP BY`, `DISTINCT` or `ORDER BY`.                                                                                                                                                                                                                                                                                                                                       |
 | Using where                                          | A `WHERE` expression (in additional to the possible key lookup) is used to check if the row should be accepted. If you don't have 'Using where' together with a join type of `ALL`, you are probably doing something wrong!                                                                                                                                                                                                                                          |
 | Using where; FirstMatch(_mytable_)                   | When one matching record combination has been found, shortcut the execution and jump back to the _mytable_ table. See [this page](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/optimization-strategies/firstmatch-strategy.md) for details on the `FirstMatch` Strategy.                                                                                                                                                               |
 | Using where with pushed condition                    | Like 'Using where' but the where condition is pushed down to the table engine for internal optimization at the row level.                                                                                                                                                                                                                                                                                                                                            |
 | Using buffer                                         | The `UPDATE` statement will first buffer the rows, and then run the updates, rather than do updates on the fly. See [Using Buffer UPDATE Algorithm](using-buffer-update-algorithm.md) for a detailed explanation.                                                                                                                                                                                                                                                    |
+
+### Rowid Filter Notation
+
+When the optimizer applies the [Rowid Filtering Optimization](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/rowid-filtering-optimization.md), it adds no row of its own to the `EXPLAIN` output. Instead, it annotates the row of the table the filter applies to:
+
+| Column   | Example value                | Meaning                                                                                                      |
+| -------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| type     | `ref\|filter`                | The join type used for the lookup, followed by the literal `filter`.                                         |
+| key      | `i_l_orderkey\|i_l_shipdate` | The index used for the lookup, followed by the index the filter was built from.                               |
+| key\_len | `4\|4`                       | The key length used from each of those two indexes. Tabular `EXPLAIN` only — `FORMAT=JSON` does not show it.  |
+| rows     | `4 (2%)`                     | The row estimate, followed by the selectivity the optimizer expects from the filter.                          |
+| Extra    | `Using rowid filter`         | Added to the values already listed for the row.                                                              |
+
+For example, with the `dbt3_s001` dataset, the row for `lineitem` reads:
+
+```sql
+EXPLAIN SELECT o_orderkey, l_linenumber, l_shipdate, o_totalprice
+  FROM orders JOIN lineitem ON o_orderkey=l_orderkey
+  WHERE l_shipdate BETWEEN '1997-01-01' AND '1997-01-31'
+    AND o_totalprice BETWEEN 200000 AND 230000\G
+```
+
+```
+*************************** 2. row ***************************
+           id: 1
+  select_type: SIMPLE
+        table: lineitem
+         type: ref|filter
+possible_keys: PRIMARY,i_l_shipdate,i_l_orderkey,i_l_orderkey_quantity
+          key: i_l_orderkey|i_l_shipdate
+      key_len: 4|4
+          ref: dbt3_s001.orders.o_orderkey
+         rows: 4 (2%)
+        Extra: Using where; Using rowid filter
+```
+
+The filter here was built from `i_l_shipdate`, and the optimizer expects it to pass 2% of the rows that the `i_l_orderkey` lookup returns.
+
+{% hint style="warning" %}
+The percentage is rounded to a whole number, so a highly selective filter can display `(0%)`. That does not mean the filter is inactive — it means the optimizer expects it to pass fewer than 0.5% of the rows.
+{% endhint %}
+
+The [ANALYZE statement](analyze-statement.md) annotates `r_rows` the same way, but its percentage is the selectivity actually observed during execution rather than the estimate.
+
+[EXPLAIN FORMAT=JSON](explain-format-json.md) does not use this notation. It reports the filter as a `rowid_filter` object instead, with the expected selectivity in a `selectivity_pct` member.
+
+Rowid filtering is controlled by the `rowid_filter` flag in [optimizer\_switch](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#optimizer_switch) and is enabled by default.
 
 ## EXPLAIN EXTENDED
 

--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
@@ -44,6 +44,25 @@ There is an online [EXPLAIN Analyzer](../../../../clients-and-utilities/analyzin
 
 `EXPLAIN` can acquire metadata locks in the same way that `SELECT` does, as it needs to know table metadata and, sometimes, data as well.
 
+## A Simple Example
+
+Before the individual columns are described, here is what `EXPLAIN` output looks like for a simple two-table join. Reading a whole plan first makes the column-by-column reference below easier to follow. Here `t0` holds 10 rows and `t1` has a unique index on column `a`:
+
+```sql
+EXPLAIN SELECT t0.a, t1.b FROM t0, t1 WHERE t0.a = t1.a;
+```
+
+```
++------+-------------+-------+--------+---------------+------+---------+-----------+------+-------------+
+| id   | select_type | table | type   | possible_keys | key  | key_len | ref       | rows | Extra       |
++------+-------------+-------+--------+---------------+------+---------+-----------+------+-------------+
+|    1 | SIMPLE      | t0    | ALL    | NULL          | NULL | NULL    | NULL      |   10 | Using where |
+|    1 | SIMPLE      | t1    | eq_ref | a             | a    | 5       | test.t0.a |    1 |             |
++------+-------------+-------+--------+---------------+------+---------+-----------+------+-------------+
+```
+
+The rows are listed in join order, top to bottom. MariaDB scans all of `t0` (`type: ALL`, 10 rows), and for each row it looks up the single matching row in `t1` through the unique `a` index (`type: eq_ref`, 1 row); the `ref` column shows that the lookup value comes from `test.t0.a`. The columns shown here are described in the next section.
+
 ## Columns in EXPLAIN ... SELECT
 
 | Column name    | Description                                                                                         |
@@ -154,15 +173,19 @@ The optimization phase can do the following changes to the `WHERE` clause:
 
 ### Rowid Filter Notation
 
+Added in MariaDB 10.4.3 ([MDEV-16188](https://jira.mariadb.org/browse/MDEV-16188)).
+
 When the optimizer applies the [Rowid Filtering Optimization](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/rowid-filtering-optimization.md), it adds no row of its own to the `EXPLAIN` output. Instead, it annotates the row of the table the filter applies to:
 
 | Column   | Example value                | Meaning                                                                                                      |
 | -------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | type     | `ref\|filter`                | The join type used for the lookup, followed by the literal `filter`.                                         |
-| key      | `i_l_orderkey\|i_l_shipdate` | The index used for the lookup, followed by the index the filter was built from.                               |
+| key      | `i_l_orderkey\|i_l_shipdate` | The key used for the lookup, followed by the key the filter was built from.                                   |
 | key\_len | `4\|4`                       | The key length used from each of those two indexes. Tabular `EXPLAIN` only — `FORMAT=JSON` does not show it.  |
 | rows     | `4 (2%)`                     | The row estimate, followed by the selectivity the optimizer expects from the filter.                          |
 | Extra    | `Using rowid filter`         | Added to the values already listed for the row.                                                              |
+
+The selectivity percentage in the `rows` column is shown only when a rowid filter is actually applied to that table; rows without a filter show the plain row estimate with no percentage.
 
 For example, with the `dbt3_s001` dataset, the row for `lineitem` reads:
 
@@ -190,7 +213,7 @@ possible_keys: PRIMARY,i_l_shipdate,i_l_orderkey,i_l_orderkey_quantity
 The filter here was built from `i_l_shipdate`, and the optimizer expects it to pass 2% of the rows that the `i_l_orderkey` lookup returns.
 
 {% hint style="warning" %}
-The percentage is rounded to a whole number, so a highly selective filter can display `(0%)`. That does not mean the filter is inactive — it means the optimizer expects it to pass fewer than 0.5% of the rows.
+The percentage is rounded to a whole number, so a highly selective filter can display `(0%)`. This means the optimizer expects the filter to accept fewer than 0.5% of the rows.
 {% endhint %}
 
 The [ANALYZE statement](analyze-statement.md) annotates `r_rows` the same way, but its percentage is the selectivity actually observed during execution rather than the estimate.
@@ -307,6 +330,7 @@ SELECT * FROM table_name
 
 ## See Also
 
+* [ANALYZE Statement](analyze-statement.md)
 * [SHOW EXPLAIN](../show/show-explain.md)
 * [Ignored Indexes](../../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/ignored-indexes.md)
 

--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/explain.md
@@ -182,10 +182,14 @@ When the optimizer applies the [Rowid Filtering Optimization](../../../../ha-and
 | type     | `ref\|filter`                | The join type used for the lookup, followed by the literal `filter`.                                         |
 | key      | `i_l_orderkey\|i_l_shipdate` | The key used for the lookup, followed by the key the filter was built from.                                   |
 | key\_len | `4\|4`                       | The key length used from each of those two indexes. Tabular `EXPLAIN` only — `FORMAT=JSON` does not show it.  |
-| rows     | `4 (2%)`                     | The row estimate, followed by the selectivity the optimizer expects from the filter.                          |
+| rows     | `4 (2%)`                     | The row estimate, followed by the selectivity the optimizer expects from the filter. In this case the server expects to find 4 rows in the table and 4\*0.02 = 0.08 rows to be accepted on average. |
 | Extra    | `Using rowid filter`         | Added to the values already listed for the row.                                                              |
 
 The selectivity percentage in the `rows` column is shown only when a rowid filter is actually applied to that table; rows without a filter show the plain row estimate with no percentage.
+
+{% hint style="info" %}
+**Selectivity** is the fraction of a table's rows that a condition is expected to match, expressed here as a percentage. A filter with 2% selectivity is expected to accept 2 rows in every 100 — the lower the percentage, the more selective the filter, and the more work it saves. For a rowid filter the optimizer computes it as the number of rows its index range scan is estimated to match, divided by the total number of rows in the table.
+{% endhint %}
 
 For example, with the `dbt3_s001` dataset, the row for `lineitem` reads:
 
@@ -210,13 +214,13 @@ possible_keys: PRIMARY,i_l_shipdate,i_l_orderkey,i_l_orderkey_quantity
         Extra: Using where; Using rowid filter
 ```
 
-The filter here was built from `i_l_shipdate`, and the optimizer expects it to pass 2% of the rows that the `i_l_orderkey` lookup returns.
+The filter here was built from `i_l_shipdate`; only rows it accepts are read from `lineitem`.
 
 {% hint style="warning" %}
 The percentage is rounded to a whole number, so a highly selective filter can display `(0%)`. This means the optimizer expects the filter to accept fewer than 0.5% of the rows.
 {% endhint %}
 
-The [ANALYZE statement](analyze-statement.md) annotates `r_rows` the same way, but its percentage is the selectivity actually observed during execution rather than the estimate.
+The [ANALYZE statement](analyze-statement.md#rowid-filter-notation) annotates `r_rows` the same way, but its percentage is the selectivity actually observed during execution rather than the estimate.
 
 [EXPLAIN FORMAT=JSON](explain-format-json.md) does not use this notation. It reports the filter as a `rowid_filter` object instead, with the expected selectivity in a `selectivity_pct` member.
 


### PR DESCRIPTION
EXPLAIN annotates the row of a table that uses the Rowid Filtering Optimization with composite values, but explain.md documented none of them and listed "filter" as a standalone type value, which no plan ever reports. Readers looking up the ref|filter, key|filter_index, 4|4 or "4 (2%)" notation they saw in real output found nothing (MDEV-29292).

- Reword the Type-column row: the value is access_type|filter, with ref|filter, eq_ref|filter and range|filter as the common forms. "filter" is only ever appended to another join type.
- Add "Using rowid filter" to the Extra-column table.
- Add a Rowid Filter Notation section covering type, key, key_len, rows and Extra, a worked example, the rounding caveat that makes a highly selective filter display (0%), and cross-references to ANALYZE, EXPLAIN FORMAT=JSON and optimizer_switch.

Also reflow the Type-column table to the new column widths; those rows change in padding only.

Every statement verified against MariaDB server @ 548c80ae, and the example output is taken from mysql-test/main/rowid_filter.result.