### PR TITLE
DOCS-6218: document the DENY statement (MDEV-14443)

### DIFF
--- a/server/.gitbook/assets/deny-railroad.svg
+++ b/server/.gitbook/assets/deny-railroad.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="865" height="223">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="56" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">DENY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_type"
+      xlink:title="priv_type">
+      <rect x="127" y="47" width="80" height="32"/>
+      <rect x="125" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="135" y="65">priv_type</text>
+   </a>
+   <rect x="247" y="79" width="26" height="32" rx="10"/>
+   <rect x="245"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="255" y="97">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_list"
+      xlink:title="column_list">
+      <rect x="293" y="79" width="92" height="32"/>
+      <rect x="291" y="77" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="301" y="97">column_list</text>
+   </a>
+   <rect x="405" y="79" width="26" height="32" rx="10"/>
+   <rect x="403"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="413" y="97">)</text>
+   <rect x="127" y="3" width="24" height="32" rx="10"/>
+   <rect x="125"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="135" y="21">,</text>
+   <rect x="491" y="47" width="40" height="32" rx="10"/>
+   <rect x="489"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="499" y="65">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#object_type"
+      xlink:title="object_type">
+      <rect x="571" y="79" width="94" height="32"/>
+      <rect x="569" y="77" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="579" y="97">object_type</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_level"
+      xlink:title="priv_level">
+      <rect x="705" y="47" width="80" height="32"/>
+      <rect x="703" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="713" y="65">priv_level</text>
+   </a>
+   <rect x="805" y="47" width="38" height="32" rx="10"/>
+   <rect x="803"
+         y="45"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="813" y="65">TO</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#account_or_role"
+      xlink:title="account_or_role">
+      <rect x="695" y="189" width="122" height="32"/>
+      <rect x="693" y="187" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="703" y="207">account_or_role</text>
+   </a>
+   <rect x="695" y="145" width="24" height="32" rx="10"/>
+   <rect x="693"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="703" y="163">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m56 0 h10 m20 0 h10 m80 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m-344 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m344 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-344 0 h10 m24 0 h10 m0 0 h300 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-212 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m23 44 h-3"/>
+   <polygon points="855 203 863 199 863 207"/>
+   <polygon points="855 203 847 199 847 207"/>
+</svg>

--- a/server/.gitbook/assets/revoke-deny-railroad.svg
+++ b/server/.gitbook/assets/revoke-deny-railroad.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="981" height="223">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="74" height="32" rx="10"/>
+   <rect x="29"
+         y="45"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="65">REVOKE</text>
+   <rect x="125" y="47" width="56" height="32" rx="10"/>
+   <rect x="123"
+         y="45"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="133" y="65">DENY</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_type"
+      xlink:title="priv_type">
+      <rect x="221" y="47" width="80" height="32"/>
+      <rect x="219" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="229" y="65">priv_type</text>
+   </a>
+   <rect x="341" y="79" width="26" height="32" rx="10"/>
+   <rect x="339"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="97">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#column_list"
+      xlink:title="column_list">
+      <rect x="387" y="79" width="92" height="32"/>
+      <rect x="385" y="77" width="92" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="395" y="97">column_list</text>
+   </a>
+   <rect x="499" y="79" width="26" height="32" rx="10"/>
+   <rect x="497"
+         y="77"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="507" y="97">)</text>
+   <rect x="221" y="3" width="24" height="32" rx="10"/>
+   <rect x="219"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="21">,</text>
+   <rect x="585" y="47" width="40" height="32" rx="10"/>
+   <rect x="583"
+         y="45"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="593" y="65">ON</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#object_type"
+      xlink:title="object_type">
+      <rect x="665" y="79" width="94" height="32"/>
+      <rect x="663" y="77" width="94" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="673" y="97">object_type</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#priv_level"
+      xlink:title="priv_level">
+      <rect x="799" y="47" width="80" height="32"/>
+      <rect x="797" y="45" width="80" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="807" y="65">priv_level</text>
+   </a>
+   <rect x="899" y="47" width="60" height="32" rx="10"/>
+   <rect x="897"
+         y="45"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="907" y="65">FROM</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#account_or_role"
+      xlink:title="account_or_role">
+      <rect x="811" y="189" width="122" height="32"/>
+      <rect x="809" y="187" width="122" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="819" y="207">account_or_role</text>
+   </a>
+   <rect x="811" y="145" width="24" height="32" rx="10"/>
+   <rect x="809"
+         y="143"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="819" y="163">,</text>
+   <path class="line"
+         d="m17 61 h2 m0 0 h10 m74 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m80 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m-344 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m344 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-344 0 h10 m24 0 h10 m0 0 h300 m20 44 h10 m40 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-212 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m122 0 h10 m-162 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m23 44 h-3"/>
+   <polygon points="971 203 979 199 979 207"/>
+   <polygon points="971 203 963 199 963 207"/>
+</svg>

--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -1299,6 +1299,7 @@
       * [ALTER USER](reference/sql-statements/account-management-sql-statements/alter-user.md)
       * [CREATE ROLE](reference/sql-statements/account-management-sql-statements/create-role.md)
       * [CREATE USER](reference/sql-statements/account-management-sql-statements/create-user.md)
+      * [DENY](reference/sql-statements/account-management-sql-statements/deny.md)
       * [DROP ROLE](reference/sql-statements/account-management-sql-statements/drop-role.md)
       * [DROP USER](reference/sql-statements/account-management-sql-statements/drop-user.md)
       * [GRANT](reference/sql-statements/account-management-sql-statements/grant.md)

--- a/server/reference/sql-statements/account-management-sql-statements/README.md
+++ b/server/reference/sql-statements/account-management-sql-statements/README.md
@@ -45,6 +45,18 @@ Complete guide to creating MariaDB user accounts. Complete CREATE USER syntax fo
 
 {% columns %}
 {% column %}
+{% content-ref url="deny.md" %}
+[deny.md](deny.md)
+{% endcontent-ref %}
+{% endcolumn %}
+
+{% column %}
+Block a privilege outright. Learn how a deny overrides every grant at every level, and how to lift one again with REVOKE DENY.
+{% endcolumn %}
+{% endcolumns %}
+
+{% columns %}
+{% column %}
 {% content-ref url="drop-role.md" %}
 [drop-role.md](drop-role.md)
 {% endcontent-ref %}

--- a/server/reference/sql-statements/account-management-sql-statements/deny.md
+++ b/server/reference/sql-statements/account-management-sql-statements/deny.md
@@ -1,0 +1,344 @@
+---
+description: >-
+  Block a privilege outright with DENY. A deny always beats a grant, at any
+  level, and can only be removed with REVOKE DENY.
+---
+
+# DENY
+
+{% hint style="info" %}
+`DENY` and `REVOKE DENY` were added in [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443).
+{% endhint %}
+
+## Syntax
+
+```bnf
+/* 1. Denying Privileges */
+DENY
+    priv_type [(column_list)]
+      [, priv_type [(column_list)]] ...
+    ON [object_type] priv_level
+    TO account_or_role [, account_or_role] ...
+
+/* 2. Removing a Deny */
+REVOKE DENY
+    priv_type [(column_list)]
+      [, priv_type [(column_list)]] ...
+    ON [object_type] priv_level
+    FROM account_or_role [, account_or_role] ...
+```
+
+![Railroad diagram of DENY — equivalent to the BNF above](../../../.gitbook/assets/deny-railroad.svg)
+
+![Railroad diagram of REVOKE DENY — equivalent to the BNF above](../../../.gitbook/assets/revoke-deny-railroad.svg)
+
+`account_or_role`, `priv_type`, `object_type`, and `priv_level` accept the same values as they do
+for [GRANT](grant.md). Sub-rule diagrams are not repeated here — see [GRANT](grant.md#syntax) for
+those productions.
+
+## Description
+
+`DENY` records a privilege that an account must never have. Where [GRANT](grant.md) adds a
+privilege and [REVOKE](revoke.md) takes a granted privilege away, `DENY` stores a separate,
+negative entry that is consulted on every privilege check. As long as the deny exists, the
+privilege is refused, no matter how many `GRANT` statements say otherwise:
+
+```sql
+GRANT SELECT ON *.* TO alice;
+DENY SELECT ON secrets.payroll TO alice;
+```
+
+`alice` can now read every table on the server except `secrets.payroll`.
+
+The typical use is the "everything except" case that `GRANT` and `REVOKE` alone handle awkwardly:
+grant broadly, then carve out the objects or columns that must stay out of reach.
+
+Use `REVOKE DENY` to remove a deny. Nothing else restores the privilege — there is no privilege
+that lets an account bypass a deny, and a later `GRANT` does not cancel one.
+
+To issue `DENY` or `REVOKE DENY`, you need the `GRANT OPTION` privilege plus the privileges you
+are denying, exactly as you would to `GRANT` them.
+
+`DENY` applies to privileges only. It cannot be used to deny a role or proxy access, so there is
+no `DENY role` or `DENY PROXY` form.
+
+## Deny Levels
+
+A deny is recorded at the level named by `priv_level`, matching the [privilege
+levels](grant.md#privilege-levels) used by `GRANT`:
+
+| Level | Syntax | Example |
+| --- | --- | --- |
+| Global | `*.*` | `DENY SELECT ON *.* TO alice;` |
+| Database | `db_name.*` | `DENY INSERT ON hr.* TO alice;` |
+| Table | `db_name.tbl_name` | `DENY DELETE ON hr.staff TO alice;` |
+| Column | `priv_type (column)` on a table | `DENY SELECT (salary) ON hr.staff TO alice;` |
+| Routine | `PROCEDURE`, `FUNCTION`, `PACKAGE`, or `PACKAGE BODY` | `DENY EXECUTE ON FUNCTION hr.bonus TO alice;` |
+
+Global denies cover administrative privileges as well as data privileges. Denying `RELOAD`,
+`SHUTDOWN`, `PROCESS`, `FILE`, or `CONNECTION ADMIN` on `*.*` blocks the matching operations even
+for an account that holds `ALL PRIVILEGES`:
+
+```sql
+GRANT ALL PRIVILEGES ON *.* TO opsuser@localhost;
+DENY SHUTDOWN ON *.* TO opsuser@localhost;
+```
+
+```sql
+SHUTDOWN;
+ERROR 42000: Access denied; you need (at least one of) the SHUTDOWN privilege(s) for this operation
+```
+
+As with `GRANT`, a routine deny must state the routine type. Leaving it out makes MariaDB read the
+name as a table:
+
+```sql
+DENY EXECUTE ON hr.bonus TO alice;
+ERROR 42000: Illegal GRANT/REVOKE command; please consult the manual to see which privileges can be used
+```
+
+## Precedence
+
+Two rules cover every case:
+
+* **A deny beats a grant.** If a privilege is denied anywhere in the hierarchy that applies to an
+  object, the privilege is refused.
+* **Order does not matter.** `GRANT` then `DENY` and `DENY` then `GRANT` give the same result.
+
+A deny also propagates downwards: a global deny masks database, table, and column grants; a
+database deny masks table and column grants; a table deny masks column grants.
+
+```sql
+DENY SELECT ON hr.* TO alice;
+GRANT SELECT ON hr.staff TO alice;
+```
+
+```sql
+SELECT * FROM hr.staff;
+ERROR 42000: SELECT command denied to user 'alice'@'localhost' for table `hr`.`staff`
+```
+
+A deny only affects the privileges it names. Other privileges on the same object are unaffected:
+
+```sql
+GRANT SELECT, INSERT ON hr.staff TO alice;
+DENY SELECT ON hr.staff TO alice;
+```
+
+`alice` can still insert into `hr.staff`; only reading it is refused.
+
+Denies also reach statements that read a table implicitly. An `UPDATE ... WHERE` needs `SELECT` on
+the columns in the `WHERE` clause, so a `SELECT` deny stops it, while the same `UPDATE` without a
+`WHERE` clause succeeds.
+
+A deny follows the account into definer context as well. A view defined with `SQL SECURITY DEFINER`
+fails if the definer is denied the privileges the view needs, even when the invoker holds them.
+
+## Roles and PUBLIC
+
+Denies can be granted to a [role](../../../security/user-account-management/roles/), and they
+travel through the role graph the same way privileges do. A deny on any role an account holds wins
+over a grant on any other role, at any depth:
+
+```sql
+CREATE ROLE reader, blocked, combined;
+GRANT SELECT ON hr.staff TO reader;
+DENY SELECT ON hr.staff TO blocked;
+GRANT reader TO combined;
+GRANT blocked TO combined;
+GRANT combined TO alice@localhost;
+```
+
+With `combined` active, `alice` cannot read `hr.staff`.
+
+Denying to [PUBLIC](grant.md#to-public) blocks a privilege for every account on the server:
+
+```sql
+DENY SELECT ON hr.staff TO PUBLIC;
+```
+
+## Removing a Deny
+
+`REVOKE DENY` removes the named privileges from an existing deny entry at that exact level. It
+fails if there is no matching deny, even when a positive grant exists:
+
+```sql
+GRANT INSERT ON hr.* TO alice;
+REVOKE DENY INSERT ON hr.* FROM alice;
+ERROR 42000: There is no such grant defined for user 'alice' on host '%'
+```
+
+`REVOKE DENY` matches by level, so a table-level revoke does not touch column-level denies on the
+same table. Remove those by naming the columns:
+
+```sql
+DENY DELETE ON hr.staff TO alice;
+DENY SELECT (salary) ON hr.staff TO alice;
+REVOKE DENY ALL PRIVILEGES ON hr.staff FROM alice;   -- clears the DELETE deny only
+REVOKE DENY SELECT (salary) ON hr.staff FROM alice;  -- clears the column deny
+```
+
+[REVOKE ALL PRIVILEGES, GRANT OPTION](revoke.md) clears an account's denies along with its grants:
+
+```sql
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM alice;
+```
+
+Dropping the object a deny points at also removes the deny. Dropping a stored procedure, for
+example, deletes the deny entries recorded against it.
+
+## Viewing Denies
+
+[SHOW GRANTS](../administrative-sql-statements/show/show-grants.md) reports denies as separate
+`DENY` lines beside the `GRANT` lines:
+
+```sql
+SHOW GRANTS FOR alice@localhost;
++---------------------------------------------------------------+
+| Grants for alice@localhost                                    |
++---------------------------------------------------------------+
+| GRANT USAGE ON *.* TO `alice`@`localhost`                     |
+| DENY SELECT ON *.* TO `alice`@`localhost`                     |
+| DENY INSERT ON `hr`.* TO `alice`@`localhost`                  |
+| GRANT SELECT ON `hr`.`staff` TO `alice`@`localhost`           |
+| DENY UPDATE (`salary`) ON `hr`.`staff` TO `alice`@`localhost` |
++---------------------------------------------------------------+
+```
+
+`DENY` lines are only visible to a connection that has the `SELECT` privilege on the `mysql`
+database. Accounts without it see their own `GRANT` lines but none of their denies, so a deny is
+not self-advertising. The same applies to `SHOW GRANTS FOR CURRENT_ROLE`, `SHOW GRANTS FOR role`,
+and `SHOW GRANTS FOR PUBLIC`.
+
+{% hint style="info" %}
+The visibility check is itself subject to denies. An account with `SELECT` on `mysql.*` but a deny
+on `mysql.global_priv` sees no denies, and cannot run `SHOW GRANTS` for another account.
+{% endhint %}
+
+## Effect on Metadata
+
+Because metadata visibility follows privileges, a deny also hides what the account may not read:
+
+* A global `SELECT` deny hides databases from [SHOW DATABASES](../administrative-sql-statements/show/show-databases.md).
+* A table-level `SELECT` deny hides the table from [SHOW TABLES](../administrative-sql-statements/show/show-tables.md), `SHOW TABLE STATUS`, `INFORMATION_SCHEMA.TABLES`, and `INFORMATION_SCHEMA.COLUMNS`, and makes `SHOW CREATE TABLE`, `SHOW COLUMNS`, and `SHOW INDEX` fail.
+* A column-level `SELECT` deny hides the denied columns from `SHOW COLUMNS` and `INFORMATION_SCHEMA.COLUMNS`, and drops index rows that use them from `INFORMATION_SCHEMA.STATISTICS` and `INFORMATION_SCHEMA.KEY_COLUMN_USAGE`. The remaining columns stay visible, and `SHOW CREATE TABLE` still prints the full table definition.
+* A routine-level `EXECUTE` deny hides that routine from `INFORMATION_SCHEMA.ROUTINES` while leaving the other routines in the database visible.
+
+If every privilege an account holds in a database is denied, [USE](../administrative-sql-statements/use-database.md) is refused as well:
+
+```sql
+USE hr;
+ERROR 42000: Access denied for user 'alice'@'localhost' to database 'hr'
+```
+
+## Storage and Persistence
+
+Denies are stored in the `Priv` JSON document of the
+[mysql.global\_priv](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md)
+table, under a `denies` key, and not in `mysql.db`, `mysql.tables_priv`, or `mysql.columns_priv`.
+Each array element carries the level in `type`, the object names, and the denied privilege bits:
+
+```sql
+SELECT User, Host, JSON_PRETTY(JSON_EXTRACT(Priv, '$.denies')) AS denies
+  FROM mysql.global_priv WHERE User = 'alice';
++-------+------+---------------------------+
+| User  | Host | denies                    |
++-------+------+---------------------------+
+| alice | %    | [                         |
+|       |      |     {                     |
+|       |      |         "type": "column", |
+|       |      |         "db": "hr",       |
+|       |      |         "table": "staff", |
+|       |      |         "column": "salary",|
+|       |      |         "bits": 1         |
+|       |      |     }                     |
+|       |      | ]                         |
++-------+------+---------------------------+
+```
+
+`type` is one of `global`, `db`, `table`, `column`, `function`, `procedure`, `package`, or
+`package body`. `bits` uses the same privilege bit values as the `access` field, listed in
+[Mapping the access Field Values to Grants](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md#mapping-the-access-field-values-to-grants).
+
+Denies survive [FLUSH PRIVILEGES](../administrative-sql-statements/flush-commands/flush.md) and a
+server restart, and replicate to replicas like any other account management statement.
+
+Column names and routine names in denies are matched case insensitively. Database and table names
+follow [lower\_case\_table\_names](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lower_case_table_names):
+with the default `0` on Linux, `DENY SELECT ON DbCase.T` and `DENY SELECT ON dbcase.t` are two
+distinct denies.
+
+{% hint style="warning" %}
+Editing the `denies` array directly with `UPDATE` is not supported. A malformed entry is skipped at
+startup and on `FLUSH PRIVILEGES`, with a `Malformed DENY entry in mysql.global_priv` warning in
+the [error log](../../../server-management/server-monitoring-logs/error-log.md) — leaving the
+privilege silently allowed. Always use `DENY` and `REVOKE DENY`.
+{% endhint %}
+
+## Comparison with REVOKE
+
+`REVOKE` and `DENY` are not interchangeable:
+
+| | `REVOKE` | `DENY` |
+| --- | --- | --- |
+| What it does | Removes a granted privilege | Records a permanent block |
+| Can a later `GRANT` restore access? | Yes | No |
+| Effect of a broader grant | A grant at a higher level still applies | Refused regardless of level |
+| How to undo | `GRANT` | `REVOKE DENY` |
+
+If an account holds `SELECT ON *.*` and you revoke `SELECT` on one table, the global grant still
+covers that table. A deny is what actually excludes it.
+
+## Examples
+
+Grant broad access, then exclude one table:
+
+```sql
+CREATE USER analyst@'%' IDENTIFIED BY 'secret';
+GRANT SELECT ON sales.* TO analyst@'%';
+DENY SELECT ON sales.customer_pii TO analyst@'%';
+```
+
+Hide two columns while leaving the rest of the table readable:
+
+```sql
+GRANT SELECT ON hr.staff TO analyst@'%';
+DENY SELECT (salary, ssn) ON hr.staff TO analyst@'%';
+```
+
+```sql
+SELECT id, name FROM hr.staff;   -- succeeds
+SELECT * FROM hr.staff;
+ERROR 42000: SELECT command denied to user 'analyst'@'%' for column 'salary' in table 'staff'
+```
+
+Stop an account from writing to a column it can otherwise insert into:
+
+```sql
+GRANT SELECT, INSERT ON hr.audit_log TO app@localhost;
+DENY INSERT (modified_by) ON hr.audit_log TO app@localhost;
+```
+
+Block a function while leaving a procedure callable:
+
+```sql
+GRANT EXECUTE ON PROCEDURE hr.refresh TO app@localhost;
+GRANT EXECUTE ON FUNCTION hr.bonus TO app@localhost;
+DENY EXECUTE ON FUNCTION hr.bonus TO app@localhost;
+```
+
+Lift the deny again:
+
+```sql
+REVOKE DENY EXECUTE ON FUNCTION hr.bonus FROM app@localhost;
+```
+
+## See Also
+
+* [GRANT](grant.md)
+* [REVOKE](revoke.md)
+* [SHOW GRANTS](../administrative-sql-statements/show/show-grants.md)
+* [Roles](../../../security/user-account-management/roles/)
+* [mysql.global\_priv Table](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md)
+
+{% @marketo/form formId="4316" %}

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -112,6 +112,10 @@ Use the [REVOKE](revoke.md) statement to revoke privileges granted with the `GRA
 
 Use the [SHOW GRANTS](../administrative-sql-statements/show/show-grants.md) statement to determine what privileges an account has.
 
+{% hint style="info" %}
+From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), a privilege blocked with [DENY](deny.md) cannot be granted back. A deny takes precedence over every `GRANT` at every privilege level, whatever order the statements are issued in, and is only lifted by `REVOKE DENY`.
+{% endhint %}
+
 ### Account Names
 
 For `GRANT` statements, account names are specified as the `username` argument in the same way as they are for [CREATE USER](create-user.md) statements. See [account names](create-user.md#account-names) from the `CREATE USER` page for details on how account names are specified.
@@ -1027,6 +1031,7 @@ GRANT ALL PRIVILEGES ON  *.* TO 'alexander'@'localhost' WITH GRANT OPTION;
 * [CREATE USER](create-user.md)
 * [ALTER USER](alter-user.md)
 * [DROP USER](drop-user.md)
+* [DENY](deny.md) blocks a privilege so that no `GRANT` can restore it.
 * [SET PASSWORD](set-password.md)
 * [SHOW CREATE USER](../administrative-sql-statements/show/show-create-user.md)
 * [mysql.global\_priv table](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md)

--- a/server/reference/sql-statements/account-management-sql-statements/revoke.md
+++ b/server/reference/sql-statements/account-management-sql-statements/revoke.md
@@ -22,15 +22,22 @@ REVOKE
 REVOKE ALL [PRIVILEGES], GRANT OPTION
     FROM account_or_role [, account_or_role] ...
 
-/* 3. Revoking Proxy Access */
+/* 3. Revoking a Deny (from MariaDB 13.1) */
+REVOKE DENY
+    priv_type [(column_list)]
+      [, priv_type [(column_list)]] ...
+    ON [object_type] priv_level
+    FROM account_or_role [, account_or_role] ...
+
+/* 4. Revoking Proxy Access */
 REVOKE PROXY ON user_or_role
     FROM account_or_role [, account_or_role] ...
 
-/* 4. Revoking Roles */
+/* 5. Revoking Roles */
 REVOKE role [, role] ...
     FROM account_or_role [, account_or_role] ...
 
-/* 5. Revoking Admin Option for Roles */
+/* 6. Revoking Admin Option for Roles */
 REVOKE ADMIN OPTION FOR role [, role] ...
     FROM account_or_role [, account_or_role] ...
 
@@ -93,6 +100,8 @@ To use this `REVOKE` syntax, you must have the global [CREATE USER](create-user.
 Revoking all privileges doesn't remove _all_ privileges, not even with the second syntax. The user still keeps the `USAGE` privilege, making it possible to connect to the server (but nothing else). To remove that privilege, too, remove the user entirely with a `DROP USER` statement.
 {% endhint %}
 
+Revoking a privilege is not the same as blocking it. A privilege that a broader grant still covers remains in effect after the narrower grant is revoked, and any later `GRANT` restores it. To block a privilege outright, use [DENY](deny.md) instead.
+
 ### Examples
 
 Revoking a particular privilege (`SUPER`):
@@ -116,6 +125,16 @@ REVOKE ALL, GRANT OPTION FROM 'myuser'@'localhost';
 {% hint style="info" %}
 The `PRIVILEGES` keyword is optional for `ALL PRIVILEGES`.
 {% endhint %}
+
+## Denies
+
+From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), `REVOKE DENY` removes a negative privilege created with [DENY](deny.md). It is the only way to restore a denied privilege.
+
+```sql
+REVOKE DENY SELECT ON hr.staff FROM 'alice'@'localhost';
+```
+
+The privileges, object type, and privilege level must match the deny that is being removed, and the statement fails if no such deny exists — even when a positive grant does. `REVOKE ALL PRIVILEGES, GRANT OPTION` clears an account's denies together with its grants. See [DENY](deny.md#removing-a-deny) for details.
 
 ## Roles
 

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-grants.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-grants.md
@@ -77,11 +77,32 @@ SHOW GRANTS FOR public;
 {% endtab %}
 {% endtabs %}
 
+### Denies
+
+From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), privileges blocked with [DENY](../../account-management-sql-statements/deny.md) are listed as separate `DENY` lines beside the `GRANT` lines:
+
+```sql
+SHOW GRANTS FOR 'alice'@'localhost';
++---------------------------------------------------------------+
+| Grants for alice@localhost                                    |
++---------------------------------------------------------------+
+| GRANT USAGE ON *.* TO `alice`@`localhost`                     |
+| DENY SELECT ON *.* TO `alice`@`localhost`                     |
+| GRANT SELECT ON `hr`.`staff` TO `alice`@`localhost`           |
+| DENY UPDATE (`salary`) ON `hr`.`staff` TO `alice`@`localhost` |
++---------------------------------------------------------------+
+```
+
+`DENY` lines are only visible to a connection that holds the `SELECT` privilege on the `mysql` database. An account without it sees its own `GRANT` lines but none of its denies, so denies are not self-advertising. This applies to `SHOW GRANTS`, `SHOW GRANTS FOR CURRENT_ROLE`, `SHOW GRANTS FOR role`, and `SHOW GRANTS FOR PUBLIC` alike.
+
+The visibility check is itself subject to denies: an account with `SELECT` on `mysql.*` but a deny on `mysql.global_priv` sees no denies, and cannot run `SHOW GRANTS` for another account.
+
 ## See Also
 
 * [Authentication from MariaDB 10.4](../../../../security/user-account-management/authentication-from-mariadb-10-4.md)
 * [SHOW CREATE USER](show-create-user.md) shows how the user was created.
 * [SHOW PRIVILEGES](show-privileges.md) shows the privileges supported by MariaDB.
+* [DENY](../../account-management-sql-statements/deny.md) blocks a privilege so that no `GRANT` can restore it.
 * [Roles](../../../../security/user-account-management/roles/)
 
 <sub>_This page is licensed: GPLv2, originally from_</sub> [<sub>_fill\_help\_tables.sql_</sub>](https://github.com/MariaDB/server/blob/main/scripts/fill_help_tables.sql)

--- a/server/reference/system-tables/the-mysql-database-tables/mysql-global_priv-table.md
+++ b/server/reference/system-tables/the-mysql-database-tables/mysql-global_priv-table.md
@@ -20,6 +20,8 @@ The `mysql.global_priv` table contains the following fields:
 
 From [MariaDB 10.5.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.5/10.5.2), in order to help the server understand which version a privilege record was written by, the `priv` field contains a new JSON field, `version_id` ([MDEV-21704](https://jira.mariadb.org/browse/MDEV-21704)).
 
+From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), the `Priv` field also holds a `denies` array, recording the negative privileges created with [DENY](../../sql-statements/account-management-sql-statements/deny.md). Denies are stored here for every privilege level, not in `mysql.db`, `mysql.tables_priv`, or `mysql.columns_priv`. See [The denies Field](mysql-global_priv-table.md#the-denies-field).
+
 ## Examples
 
 ```sql
@@ -141,6 +143,50 @@ The `access` field contains the grants of the user which can be mapped to indivi
 | BINLOG\_REPLAY        | (1ULL << 37) |
 | SLAVE\_MONITOR        | (1ULL << 38) |
 | SHOW\_CREATE\_ROUTINE | (1ULL << 39) |
+
+## The `denies` Field
+
+From [MariaDB 13.1](https://jira.mariadb.org/browse/MDEV-14443), the `denies` array records the privileges that [DENY](../../sql-statements/account-management-sql-statements/deny.md) blocks for an account or role. Each element describes one privilege level:
+
+```sql
+DENY SELECT ON hr.* TO user1@localhost;
+DENY SELECT (salary) ON hr.staff TO user1@localhost;
+SELECT JSON_PRETTY(JSON_EXTRACT(Priv, '$.denies')) FROM mysql.global_priv
+  WHERE User='user1'\G
+
+*************************** 1. row ***************************
+JSON_PRETTY(JSON_EXTRACT(Priv, '$.denies')): [
+    {
+        "type": "db",
+        "db": "hr",
+        "bits": 1
+    },
+    {
+        "type": "column",
+        "db": "hr",
+        "table": "staff",
+        "column": "salary",
+        "bits": 1
+    }
+]
+```
+
+The fields of an element are:
+
+| Field | Description |
+| ----- | ----------- |
+| `type` | The privilege level: `global`, `db`, `table`, `column`, `function`, `procedure`, `package`, or `package body`. |
+| `db` | Database name. Absent for `global`. |
+| `table` | Table name, for `table` and `column` entries. |
+| `column` | Column name, for `column` entries. |
+| `function`, `procedure`, `package`, `package body` | Routine name, named after the entry's `type`. |
+| `bits` | The denied privileges, using the same bit values as the `access` field. |
+
+An account with no denies has either no `denies` key or an empty array.
+
+{% hint style="warning" %}
+Do not edit the `denies` array with `UPDATE`. A malformed entry is skipped when privileges are loaded, with a `Malformed DENY entry in mysql.global_priv` warning written to the [error log](../../../server-management/server-monitoring-logs/error-log.md), which leaves the privilege allowed. Use `DENY` and `REVOKE DENY` instead.
+{% endhint %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 


### PR DESCRIPTION
Documents `DENY` / `REVOKE DENY` — the negative grants added for **MariaDB 13.1** ([MDEV-14443](https://jira.mariadb.org/browse/MDEV-14443)).

Jira: [DOCS-6218](https://mariadbcorp.atlassian.net/browse/DOCS-6218)

## What's here

**New page** — `server/reference/sql-statements/account-management-sql-statements/deny.md`, covering both statements: syntax, the five deny levels, precedence, roles and `PUBLIC`, removing a deny, `SHOW GRANTS` visibility, effects on metadata, `mysql.global_priv` storage, a `REVOKE`-vs-`DENY` comparison, and examples. Plus two railroad diagrams.

**Cross-references**, so the feature is discoverable from the pages readers already land on:

| Page | Change |
|---|---|
| `revoke.md` | `REVOKE DENY` in the syntax block + a "Denies" section + a revoke-isn't-blocking note |
| `grant.md` | Hint that a deny cannot be granted back; See Also entry |
| `show-grants.md` | "Denies" section: the `DENY` lines and who may see them |
| `mysql-global_priv-table.md` | New "The `denies` Field" section with the JSON schema |
| `SUMMARY.md`, section `README.md` | Nav entry |

## Verification

Verified against MariaDB server @ `b8dbc264f03ad4ebb483f6380715d81b67cc2a42` (`origin/main`), where the feature is the single squashed commit `934108aab5c`. **38 claims VERIFIED, 0 UNVERIFIED.** Behavior is cited to the 20 `mysql-test/main/deny_*.result` files plus `rpl_deny.result`, so the error messages quoted on the page are verbatim server output; mechanism is cited to `sql/privilege.h`, `sql/sql_yacc.yy`, and `sql/sql_acl.cc`.

The full fact-check report (claim → doc `file:line` → source `file:line @ SHA` → verdict) is posted to the Jira ticket.

## Two things worth a reviewer's eye

1. **`934108aab5c` is a rewrite**, not the 2022 `vicentiu-deny-command` branch the ticket description was written against — and that branch is unmerged. So two items the ticket promises did **not** ship, and are deliberately *not* documented:
   - the **`IGNORE DENIES` privilege** — absent from `sql/` entirely at the pinned SHA (the ticket text strikes it out itself). The page therefore states plainly that nothing bypasses a deny.
   - **querying denies via `INFORMATION_SCHEMA.USER_PRIVILEGES`** — no implementation, no test coverage.

2. **Version string is a series, not a release.** `VERSION` at the SHA is `13.1.0` alpha and no `mariadb-13.1.*` tag exists yet, so all six references say "MariaDB 13.1". Worth tightening to `13.1.1` once tagged.

Five further behaviors I found but deliberately left out (with reasons — mostly inconclusive tests or likely cosmetic warts) are listed in the fact-check report rather than asserted here.

## Checks

`codespell` PASS, `lychee` PASS (both installed locally and actually run), frontmatter / GitBook blocks / link style / `SUMMARY.md` PASS.

The railroad diagrams were generated with bottlecaps RR 2.6 (`-noembedded -suppressebnf`, default theme) **after** confirming the toolchain regenerates the committed `grant-privileges-railroad.svg` byte-identically, so they match existing house style exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6218]: https://mariadbcorp.atlassian.net/browse/DOCS-6218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ