### PR TITLE
DOCS-6233 Document RANGE COLUMNS INTERVAL partitioning

### DIFF
--- a/release-notes/mariadb-cloud-release-notes/mariadb-cloud-byoa-provisioning.md
+++ b/release-notes/mariadb-cloud-release-notes/mariadb-cloud-byoa-provisioning.md
@@ -6,9 +6,10 @@
     1. Release date (YYYY.MM.DD) — from Zhanna / Cloud UAT calendar.
     2. `enable-portal-provisioning-v2` enabled in prod (currently OFF).
   When both land: set the date + filename, add the SUMMARY.md nav entry, and
-  convert the cross-links back to {mariadb-cloud} aliases (they are currently
-  GitHub blob URLs so they are clickable during review; direct-main commits are
-  not auto-expanded).
+  convert the cross-links back to `mariadb-cloud` aliases, in braces (they are
+  currently GitHub blob URLs so they are clickable during review). Do not write
+  the braced token here: the expand-gitbook-aliases workflow seds the whole
+  tree, so it would rewrite this note itself on the next PR (see DOCS-6401).
 
   Tickets: DOCS-6320 (BYOA) + DOCS-6340 (provisioning UI) · MCDEV-2374, MCDEV-3304
 -->

--- a/server/SUMMARY.md
+++ b/server/SUMMARY.md
@@ -79,6 +79,7 @@
       * [LINEAR KEY Partitioning Type](server-usage/partitioning-tables/partitioning-types/linear-key-partitioning-type.md)
       * [LIST Partitioning Type](server-usage/partitioning-tables/partitioning-types/list-partitioning-type.md)
       * [RANGE COLUMNS and LIST COLUMNS Partitioning Types](server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md)
+      * [RANGE COLUMNS INTERVAL Partitioning Type](server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md)
       * [RANGE Partitioning Type](server-usage/partitioning-tables/partitioning-types/range-partitioning-type.md)
     * [Partitioning Limitations](server-usage/partitioning-tables/partitioning-limitations.md)
     * [Partitions Files](server-usage/partitioning-tables/partitions-files.md)

--- a/server/reference/sql-statements/data-definition/create/create-table.md
+++ b/server/reference/sql-statements/data-definition/create/create-table.md
@@ -851,7 +851,9 @@ partition_options:
         { [LINEAR] HASH(expr)
         | [LINEAR] KEY(column_list)
         | RANGE(expr)
+        | RANGE COLUMNS(column_list) [INTERVAL time_quantity time_unit [AUTO]]
         | LIST(expr)
+        | LIST COLUMNS(column_list)
         | SYSTEM_TIME [INTERVAL time_quantity time_unit] [LIMIT num] }
     [PARTITIONS num]
     [SUBPARTITION BY
@@ -902,11 +904,12 @@ CREATE TABLE t1 (a INT, b CHAR(5), c DATETIME)
 * `[LINEAR]` [`KEY`](../../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) is similar to `HASH`, but the index has an even distribution of data. Also, the expression can only be a column or a list of columns. `VALUES LESS THAN` and `VALUES IN` clauses can not be used with `KEY`.
 * [RANGE](../../../../server-usage/partitioning-tables/partitioning-types/range-partitioning-type.md) partitions the rows using on a range of values, using the `VALUES LESS THAN` operator. `VALUES IN` is not allowed with `RANGE`. The partition function can be any valid SQL expression which returns a single value.
 * [LIST](../../../../server-usage/partitioning-tables/partitioning-types/list-partitioning-type.md) assigns partitions based on a table's column with a restricted set of possible values. It is similar to `RANGE`, but `VALUES IN` must be used for at least 1 columns, and `VALUES LESS THAN` is disallowed.
+* [RANGE COLUMNS and LIST COLUMNS](../../../../server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md) are variants of `RANGE` and `LIST` that take a list of bare columns instead of a partitioning expression. `RANGE COLUMNS` also accepts an `INTERVAL` clause, which makes MariaDB add partitions automatically as data is written. See [RANGE COLUMNS INTERVAL Partitioning Type](../../../../server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md).
 * `SYSTEM_TIME` partitioning is used for [System-versioned tables](../../../sql-structure/temporal-tables/system-versioned-tables.md) to store historical data separately from current data.
 
 Only [HASH](../../../../server-usage/partitioning-tables/partitioning-types/hash-partitioning-type.md) and [KEY](../../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) can be used for subpartitions, and they can be `[LINEAR]`.
 
-It is possible to define up to 8092 partitions and subpartitions.
+It is possible to define up to 8192 partitions and subpartitions.
 
 The number of defined partitions can be optionally specified as `PARTITION count`. This can be done to avoid specifying all partitions individually. But you can also declare each individual partition and, additionally, specify a `PARTITIONS count` clause; in the case, the number of `PARTITION`s must equal count.
 

--- a/server/reference/sql-statements/data-definition/create/create-table.md
+++ b/server/reference/sql-statements/data-definition/create/create-table.md
@@ -856,7 +856,9 @@ partition_options:
         { [LINEAR] HASH(expr)
         | [LINEAR] KEY(column_list)
         | RANGE(expr)
+        | RANGE COLUMNS(column_list) [INTERVAL time_quantity time_unit [AUTO]]
         | LIST(expr)
+        | LIST COLUMNS(column_list)
         | SYSTEM_TIME [INTERVAL time_quantity <a data-footnote-ref href="#user-content-fn-8">time_unit</a>] [LIMIT num] }
     [PARTITIONS num]
     [SUBPARTITION BY
@@ -907,11 +909,12 @@ CREATE TABLE t1 (a INT, b CHAR(5), c DATETIME)
 * `[LINEAR]` [`KEY`](../../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) is similar to `HASH`, but the index has an even distribution of data. Also, the expression can only be a column or a list of columns. `VALUES LESS THAN` and `VALUES IN` clauses can not be used with `KEY`.
 * [RANGE](../../../../server-usage/partitioning-tables/partitioning-types/range-partitioning-type.md) partitions the rows using on a range of values, using the `VALUES LESS THAN` operator. `VALUES IN` is not allowed with `RANGE`. The partition function can be any valid SQL expression which returns a single value.
 * [LIST](../../../../server-usage/partitioning-tables/partitioning-types/list-partitioning-type.md) assigns partitions based on a table's column with a restricted set of possible values. It is similar to `RANGE`, but `VALUES IN` must be used for at least 1 columns, and `VALUES LESS THAN` is disallowed.
+* [RANGE COLUMNS and LIST COLUMNS](../../../../server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md) are variants of `RANGE` and `LIST` that take a list of bare columns instead of a partitioning expression. `RANGE COLUMNS` also accepts an `INTERVAL` clause, which makes MariaDB add partitions automatically as data is written. See [RANGE COLUMNS INTERVAL Partitioning Type](../../../../server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md).
 * `SYSTEM_TIME` partitioning is used for [System-versioned tables](../../../sql-structure/temporal-tables/system-versioned-tables.md) to store historical data separately from current data.
 
 Only [HASH](../../../../server-usage/partitioning-tables/partitioning-types/hash-partitioning-type.md) and [KEY](../../../../server-usage/partitioning-tables/partitioning-types/key-partitioning-type.md) can be used for subpartitions, and they can be `[LINEAR]`.
 
-It is possible to define up to 8092 partitions and subpartitions.
+It is possible to define up to 8192 partitions and subpartitions.
 
 The number of defined partitions can be optionally specified as `PARTITION count`. This can be done to avoid specifying all partitions individually. But you can also declare each individual partition and, additionally, specify a `PARTITIONS count` clause; in the case, the number of `PARTITION`s must equal count.
 

--- a/server/server-usage/partitioning-tables/partitioning-types/partitioning-types-overview.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/partitioning-types-overview.md
@@ -17,6 +17,7 @@ MariaDB supports the following partitioning types:
 * [RANGE](range-partitioning-type.md)
 * [LIST](list-partitioning-type.md)
 * [RANGE COLUMNS and LIST COLUMNS](range-columns-and-list-columns-partitioning-types.md)
+* [RANGE COLUMNS INTERVAL](range-columns-interval-partitioning.md)
 * [HASH](hash-partitioning-type.md)
 * [LINEAR HASH](linear-hash-partitioning-type.md)
 * [KEY](key-partitioning-type.md)

--- a/server/server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/range-columns-and-list-columns-partitioning-types.md
@@ -10,9 +10,12 @@ description: >-
 
 * The list can contain one or more columns.
 * Columns can be of any [integer](../../../reference/data-types/numeric-data-types/int.md), [string](../../../reference/data-types/string-data-types/), [DATE](../../../reference/data-types/date-and-time-data-types/date.md), and [DATETIME](../../../reference/data-types/date-and-time-data-types/datetime.md) types.
+* [TIMESTAMP](../../../reference/data-types/date-and-time-data-types/timestamp.md) columns are accepted only in combination with an `INTERVAL` clause. See [RANGE COLUMNS INTERVAL Partitioning Type](range-columns-interval-partitioning.md).
 * Only bare columns are permitted; no expressions.
 
 All the specified columns are compared to the specified values to determine which partition should contain a specific row. See below for details.
+
+A `RANGE COLUMNS` table can also extend its own partitions as data is written, by adding an `INTERVAL` clause. See [RANGE COLUMNS INTERVAL Partitioning Type](range-columns-interval-partitioning.md).
 
 ## Syntax
 

--- a/server/server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md
+++ b/server/server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md
@@ -1,0 +1,162 @@
+---
+description: >-
+  A RANGE COLUMNS variant that adds new partitions automatically, by a fixed
+  time interval, as data is written.
+---
+
+# RANGE COLUMNS INTERVAL Partitioning Type
+
+{% hint style="info" %}
+`INTERVAL` for [RANGE COLUMNS](range-columns-and-list-columns-partitioning-types.md) partitioning was added in MariaDB 13.1.
+{% endhint %}
+
+Adding an `INTERVAL` clause to a [RANGE COLUMNS](range-columns-and-list-columns-partitioning-types.md) partitioned table makes the server extend the table's partitions automatically. You define one starting partition; whenever a write reaches the table, MariaDB adds as many partitions of the given interval as it takes for the newest partition to cover the current date and time.
+
+This removes the routine maintenance that a time-ranged table normally needs, where a scheduled job or a person has to run [ALTER TABLE ... ADD PARTITION](../../../reference/sql-statements/data-definition/alter/alter-table/) before the data catches up with the last defined partition.
+
+In every other respect the table behaves like an ordinary `RANGE COLUMNS` partitioned table.
+
+## Syntax
+
+```bnf
+PARTITION BY RANGE COLUMNS (col_name)
+INTERVAL interval_expression time_unit [AUTO]
+(
+	PARTITION partition_name VALUES LESS THAN (value)
+	[, PARTITION partition_name VALUES LESS THAN (value) ... ]
+)
+```
+
+Oracle's interval functions are accepted as an alternative spelling of the interval:
+
+```bnf
+PARTITION BY RANGE COLUMNS (col_name)
+INTERVAL ( NUMTODSINTERVAL(number, 'DAY' | 'HOUR' | 'MINUTE' | 'SECOND') )
+(
+	PARTITION partition_name VALUES LESS THAN (value)
+	[, PARTITION partition_name VALUES LESS THAN (value) ... ]
+)
+
+PARTITION BY RANGE COLUMNS (col_name)
+INTERVAL ( NUMTOYMINTERVAL(number, 'YEAR' | 'MONTH') )
+(
+	PARTITION partition_name VALUES LESS THAN (value)
+	[, PARTITION partition_name VALUES LESS THAN (value) ... ]
+)
+```
+
+The `AUTO` keyword is optional and has no effect — automatic partition creation is always enabled when an `INTERVAL` clause is present. `SHOW CREATE TABLE` does not report it.
+
+## Requirements and Restrictions
+
+* Exactly one partitioning column, of type [DATE](../../../reference/data-types/date-and-time-data-types/date.md), [DATETIME](../../../reference/data-types/date-and-time-data-types/datetime.md) or [TIMESTAMP](../../../reference/data-types/date-and-time-data-types/timestamp.md). `TIMESTAMP` is permitted only in combination with `INTERVAL`; plain `RANGE COLUMNS` partitioning rejects it.
+* At least one partition must be defined. `PARTITION BY RANGE COLUMNS (col) INTERVAL 1 DAY` on its own fails with `For RANGE partitions each partition must be defined`.
+* No partition may use `MAXVALUE`, at table creation or later through `ALTER TABLE ... ADD PARTITION`. A `MAXVALUE` partition would swallow every future row and make automatic creation pointless.
+* The interval must be positive and must not carry a sub-second component. `INTERVAL 1.1 SECOND_MICROSECOND` is rejected, as are `INTERVAL 0 DAY` and `INTERVAL -1 DAY`.
+* For a `DATE` column, the interval must be at least one day.
+* `NUMTODSINTERVAL()` accepts only `DAY`, `HOUR`, `MINUTE` and `SECOND`; `NUMTOYMINTERVAL()` accepts only `YEAR` and `MONTH`. In both forms the number must be greater than zero.
+* The interval may be an expression, but not a subquery or a stored function call.
+* `LIST COLUMNS` partitioning does not accept `INTERVAL`.
+* Subpartitioning is allowed, restricted as usual to `[LINEAR] KEY` and `[LINEAR] HASH`.
+* The 8192-partition limit still applies. A short interval combined with an old starting partition can reach it in a single statement, which fails with `Too many partitions (including subpartitions) were defined`.
+
+## How Partitions Are Added
+
+The upper bound of the highest partition is the transition point. When a write arrives, the server repeatedly adds the interval to that bound until it passes the current date and time, and creates one partition per step. New partitions are named `pN`, where `N` is chosen from the first gap in the existing `pN` names that is large enough to hold all of them.
+
+Automatic creation happens for these statements:
+
+* [INSERT](../../../reference/sql-statements/data-manipulation/inserting-loading-data/insert.md) and `INSERT ... SELECT`
+* [REPLACE](../../../reference/sql-statements/data-manipulation/changing-deleting-data/replace.md) and `REPLACE ... SELECT`
+* [UPDATE](../../../reference/sql-statements/data-manipulation/changing-deleting-data/update.md), including multi-table `UPDATE`
+* [LOAD DATA INFILE](../../../reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile.md)
+
+It also happens when one of those statements runs inside a [trigger](../../triggers-events/triggers/) body, and on a replica when it applies the corresponding row events. Read-only statements and DDL never create partitions.
+
+{% hint style="warning" %}
+Partitions are created up to the current time, not up to the value being written. A row dated further in the future than the newest partition's bound still fails with `Table has no partition for value from column_list` — and the partitions covering the present are created anyway, because the statement is rolled back but the partition changes are not.
+{% endhint %}
+
+Rows earlier than the lowest partition are not accommodated either; partitions are only ever added at the top. Automatic creation happens only in DML, so an `ALTER TABLE` that introduces an `INTERVAL` clause whose starting partition does not already cover the existing rows fails.
+
+## Transactions and Replication
+
+Adding partitions does not cause the implicit commit that DDL normally would, so the surrounding transaction stays open. If that transaction is rolled back, the rows are undone but the new partitions remain.
+
+The implicit `ADD PARTITION` is not written to the binary log. A replica creates the same partitions itself while applying the row events, so primary and replica converge without a separate DDL event.
+
+## Examples
+
+Start from a single partition covering everything before 20 April 2026, and add a day's worth at a time:
+
+```sql
+CREATE TABLE t1 (c DATETIME)
+  ENGINE = InnoDB
+  PARTITION BY RANGE COLUMNS (c)
+  INTERVAL 1 DAY (
+    PARTITION p0 VALUES LESS THAN ('2026-04-20')
+  );
+```
+
+With the server clock at 2 May 2026, a single insert fills in the missing days:
+
+```sql
+INSERT INTO t1 VALUES ('2026-05-01');
+
+SELECT partition_name, partition_description
+  FROM information_schema.partitions WHERE table_name = 't1';
++----------------+-----------------------+
+| partition_name | partition_description |
++----------------+-----------------------+
+| p0             | '2026-04-20'          |
+| p1             | '2026-04-21 00:00:00' |
+| p2             | '2026-04-22 00:00:00' |
+...
+| p12            | '2026-05-02 00:00:00' |
+| p13            | '2026-05-03 00:00:00' |
++----------------+-----------------------+
+```
+
+The same table using Oracle's interval spelling, and a `TIMESTAMP` column:
+
+```sql
+CREATE TABLE t2 (c TIMESTAMP)
+  ENGINE = InnoDB
+  PARTITION BY RANGE COLUMNS (c)
+  INTERVAL (NUMTOYMINTERVAL(1, 'MONTH')) (
+    PARTITION p0 VALUES LESS THAN ('2026-01-01')
+  );
+```
+
+Subpartitioned by `KEY`:
+
+```sql
+CREATE TABLE t3 (c DATE, d INT)
+  ENGINE = InnoDB
+  PARTITION BY RANGE COLUMNS (c)
+  INTERVAL 3 DAY
+  SUBPARTITION BY KEY (d) SUBPARTITIONS 2 (
+    PARTITION p0 VALUES LESS THAN ('2026-04-25')
+  );
+```
+
+`INTERVAL` can be added to or removed from an existing table by repartitioning it:
+
+```sql
+ALTER TABLE t1
+  PARTITION BY RANGE COLUMNS (c)
+  INTERVAL 1 WEEK (
+    PARTITION p0 VALUES LESS THAN ('2026-04-20')
+  );
+```
+
+## See Also
+
+* [RANGE COLUMNS and LIST COLUMNS Partitioning Types](range-columns-and-list-columns-partitioning-types.md)
+* [RANGE Partitioning Type](range-partitioning-type.md)
+* [Partitioning Overview](../partitioning-overview.md)
+* [Partitioning Limitations](../partitioning-limitations.md)
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
+
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
Documents the `INTERVAL` clause of `PARTITION BY RANGE COLUMNS`, new in MariaDB 13.1 ([MDEV-15621](https://jira.mariadb.org/browse/MDEV-15621)). With an `INTERVAL` clause the server adds partitions automatically as data is written, so a time-ranged table no longer needs a scheduled `ALTER TABLE ... ADD PARTITION`.

Jira: [DOCS-6233](https://mariadbcorp.atlassian.net/browse/DOCS-6233)

## What's here

**New page** — `server/server-usage/partitioning-tables/partitioning-types/range-columns-interval-partitioning.md`

* Syntax: the MariaDB form plus both Oracle spellings (`NUMTODSINTERVAL`, `NUMTOYMINTERVAL`), and the fact that the optional `AUTO` keyword has no effect and is not echoed by `SHOW CREATE TABLE`.
* Requirements and restrictions: one temporal partitioning column; `TIMESTAMP` only with `INTERVAL`; at least one partition; no `MAXVALUE`; positive, non-sub-second interval; at least one day for a `DATE` column; the accepted `NUMTO*INTERVAL` units; no subqueries; not available for `LIST COLUMNS`; subpartitioning limited to `[LINEAR] KEY`/`HASH`; the 8192-partition cap.
* How partitions are added: the transition point, `pN` gap-filling naming, the statements that trigger creation, triggers and replicated row events, and a warning about the counterintuitive part — partitions track the **clock**, not the value being written, so a future-dated row still fails while the partitions are created anyway.
* Transactions and replication: no implicit commit (`ROLLBACK` undoes the rows but keeps the partitions), and the implicit `ADD PARTITION` is not binlogged — the replica reconstructs it from the row events.
* Examples, including real `information_schema.partitions` output.

**Counterparts**

* `partitioning-types-overview.md` + `server/SUMMARY.md` — list the new page.
* `range-columns-and-list-columns-partitioning-types.md` — `TIMESTAMP` columns are accepted only in combination with an `INTERVAL` clause, plus a pointer to the new page.
* `create-table.md` — the `partition_options` grammar listed neither `RANGE COLUMNS` nor `LIST COLUMNS`, so adding the `INTERVAL` form meant adding both `COLUMNS` variants; a matching bullet was added to the partition-methods list.

**Drive-by fix, unrelated to the ticket:** `create-table.md` said "up to 8092 partitions". `sql/sql_const.h` defines `MAX_PARTITIONS 8192`, and `partitioning-limitations.md` already said 8192. Happy to split this out if reviewers would rather keep the PR single-purpose.

## Source verification

Every factual claim on the new page was checked against MariaDB server at commit `c0b303f8741` (feature commit `e6fc36cfe3d`, Yuchen Pei, 2026-06-11) — 26 claims, all verified, none left unverified. The full claim-by-claim fact-check report is posted on the Jira ticket.

Two notes worth reviewer attention:

* The ticket body quotes Oracle's interval-partitioning documentation as the feature *request*. Several of those specifics did **not** ship: no `NUMBER` partitioning key (temporal columns only) and no interval-range/-hash/-list composite partitioning. The page documents what the code does, not the Oracle text.
* The commit message's list of triggering statements omits multi-table `UPDATE`, which the code does handle (`SQLCOM_UPDATE_MULTI`). The page follows the code.

## Checks

`codespell` and `lychee` (CI-mirroring flags via `.claude/hooks/doc-lint.sh`) pass on all five files; frontmatter, GitBook block balance, link style, and `SUMMARY.md` consistency all check out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6233]: https://mariadbcorp.atlassian.net/browse/DOCS-6233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

## Rebased 2026-08-18 — the DOCS-6401 mitigation commit was dropped

This PR originally carried a second commit touching `release-notes/mariadb-cloud-release-notes/mariadb-cloud-byoa-provisioning.md`, to defuse a literal `{mariadb-cloud}` token that the `expand-gitbook-aliases` workflow kept expanding into a self-contradiction. **That commit is gone and the file is no longer in this diff.**

Tauseef Khan rewrote that page on 2026-08-17 (`eb925636b`, DOCS-6320) and his version states the same instruction in prose without braces, so `main` now holds **zero** braced alias tokens in that file. The mitigation is redundant, and cloud release notes are his to own — re-imposing my wording over his rewrite would have been wrong. Dropping it also removed the merge conflict this PR had accumulated.

The branch is now a single commit rebased onto `main` (`e9a9cbf9d`), 145 commits ahead of where it was opened. `SUMMARY.md` and `create-table.md` both auto-merged with no conflicts, and the 8092 → 8192 drive-by is still needed — `main` still says 8092.

**[DOCS-6401](https://mariadbcorp.atlassian.net/browse/DOCS-6401) is still open (TODO).** Only the token that triggered it is gone; both workflow defects — the tree-wide `sed` and the merge-ref push — are unfixed, so the next stale alias token anywhere in the tree will do this to whoever opens the next PR.

[MDEV-15621]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-15621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
