### PR TITLE
DOCS-6264 Document generated columns in mariadb-dump output

### DIFF
--- a/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md
@@ -61,6 +61,47 @@ To see a list of the options your version of `mariadb-dump` supports, execute `m
 
 `mariadb-dump` includes logic to cater for the [mysql.transaction\_registry table](../../reference/system-tables/the-mysql-database-tables/mysql-transaction_registry-table.md).
 
+## Generated Columns
+
+From MariaDB 13.1, `mariadb-dump` no longer writes the computed values of [generated columns](../../reference/sql-statements/data-definition/create/generated-columns.md) into the `INSERT` statements it produces. The values are redundant, because the server recalculates them when the dump is reloaded.
+
+Given this table:
+
+```sql
+CREATE TABLE t1 (pk INTEGER, a INTEGER, b INTEGER, c VARCHAR(16),
+                 sum INTEGER GENERATED ALWAYS AS (a+b) VIRTUAL,
+                 sub VARCHAR(4) GENERATED ALWAYS AS (SUBSTRING(c, 1, 4)) VIRTUAL);
+```
+
+by default a generated column keeps its position in the row, and its value is written as `DEFAULT`:
+
+```sql
+INSERT INTO `t1` VALUES
+(1,11,12,'oneone',DEFAULT,DEFAULT),
+(2,21,22,'twotwo',DEFAULT,DEFAULT);
+```
+
+With `--complete-insert`, generated columns are left out of both the column list and the values:
+
+```sql
+INSERT INTO `t1` (`pk`, `a`, `b`, `c`) VALUES (1,11,12,'oneone'),
+(2,21,22,'twotwo');
+```
+
+An [INVISIBLE](../../reference/sql-statements/data-definition/create/invisible-columns.md) column anywhere in the table enables `--complete-insert`, so a table that has one produces the second form even when the option is not given.
+
+If every column in a table is generated, `--complete-insert` writes an empty column list, which preserves the row count:
+
+```sql
+INSERT INTO `t5` () VALUES (),
+(),
+();
+```
+
+{% hint style="info" %}
+This applies to the SQL output only. The `--xml` output is unchanged, and still contains generated columns with their computed values. `--tab` and `--dir` are also unaffected, because the server writes those data files with `SELECT ... INTO OUTFILE`. [System-versioned](../../reference/sql-structure/temporal-tables/system-versioned-tables.md) `row_start` and `row_end` columns are not treated as generated columns.
+{% endhint %}
+
 ## Old Versions of MySQL
 
 If you are using a recent version of `mariadb-dump` to generate a dump to be reloaded into a very old MySQL server, you should _not_ use the `--opt` or `--extended-insert` option. Use `--skip-opt` instead.
@@ -155,7 +196,7 @@ Change the dump to be compatible with a given mode. By default, tables are dumpe
 
 #### -c, --complete-insert
 
-Use complete [INSERT](../../reference/sql-statements/data-manipulation/inserting-loading-data/insert.md) statements that include column names.
+Use complete [INSERT](../../reference/sql-statements/data-manipulation/inserting-loading-data/insert.md) statements that include column names. From MariaDB 13.1, [generated columns](#generated-columns) are omitted from the column list.
 
 #### -C, --compress
 

--- a/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md
@@ -88,7 +88,23 @@ INSERT INTO `t1` (`pk`, `a`, `b`, `c`) VALUES (1,11,12,'oneone'),
 (2,21,22,'twotwo');
 ```
 
-An [INVISIBLE](../../reference/sql-statements/data-definition/create/invisible-columns.md) column anywhere in the table enables `--complete-insert`, so a table that has one produces the second form even when the option is not given.
+An [INVISIBLE](../../reference/sql-statements/data-definition/create/invisible-columns.md) column enables `--complete-insert` for that table, so the dump gets a column list even when the option is not given. Generated columns are then only left out from the first `INVISIBLE` column onward: a generated column declared _before_ it stays in the column list, with its value written as `DEFAULT`. Given this table:
+
+```sql
+CREATE TABLE t4 (pk INTEGER, a INTEGER,
+                 b INTEGER GENERATED ALWAYS AS (a+1),
+                 c INTEGER INVISIBLE,
+                 d INTEGER GENERATED ALWAYS AS (a+pk));
+```
+
+`b` precedes the `INVISIBLE` column and is kept, while `d` follows it and is omitted:
+
+```sql
+INSERT INTO `t4` (`pk`, `a`, `b`, `c`) VALUES (1,2,DEFAULT,10),
+(4,5,DEFAULT,20);
+```
+
+Passing `--complete-insert` explicitly leaves out every generated column, whatever its position.
 
 If every column in a table is generated, `--complete-insert` writes an empty column list, which preserves the row count:
 

--- a/server/reference/sql-statements/data-definition/create/generated-columns.md
+++ b/server/reference/sql-statements/data-definition/create/generated-columns.md
@@ -428,6 +428,7 @@ You can also use virtual columns to implement a "poor man's partial index". See 
 
 ## See Also
 
+* [Generated Columns](../../../../clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md#generated-columns) in `mariadb-dump`, for how generated columns appear in dump output.
 * [Putting Virtual Columns to good use](https://mariadb.com/blog/putting-virtual-columns-good-use) on the mariadb.com blog.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>


### PR DESCRIPTION
Closes [DOCS-6264](https://mariadbcorp.atlassian.net/browse/DOCS-6264) — documents [MDEV-32362](https://jira.mariadb.org/browse/MDEV-32362) and its follow-up [MDEV-40217](https://jira.mariadb.org/browse/MDEV-40217) (both `fixVersion: 13.1.1`).

## What changed in the server

From **MariaDB 13.1**, `mariadb-dump` no longer writes the computed values of generated columns into the `INSERT` statements it produces:

- **Default** — the column keeps its position and its value is written as `DEFAULT`.
- **`--complete-insert`** — the column is omitted from both the column list and the values. An `INVISIBLE` column anywhere in the table turns this mode on, so such a table gets this form without the option.
- **All columns generated** (MDEV-40217) — `--complete-insert` writes an empty column list, `INSERT INTO t () VALUES (),(),();`, which preserves the row count.

`--xml`, `--tab` and `--dir` are unaffected, and system-versioning `row_start` / `row_end` columns are not treated as generated columns.

## What this PR does

One page, `server/clients-and-utilities/backup-restore-and-import-clients/mariadb-dump.md`:

- new `## Generated Columns` section covering all three forms;
- one sentence added to the `-c, --complete-insert` option entry, linking to it.

## Verification

Verified against `MariaDB/server` `main` @ `5241bae7a55db0132e3484eb1ddd6ad4da77477f` — `client/mysqldump.cc` plus the mtr expectations in `mysql-test/main/mysqldump.result`. **Every dump snippet on the page is copied verbatim from that result file**, so no output is reconstructed by hand.

Two things worth a reviewer's eye:

1. The ticket's original description implies the old output *broke* restores. The commit message says otherwise ("*While this doesn't break restorability, it is unnecessary*") — the dump header replaces `sql_mode` with `NO_AUTO_VALUE_ON_ZERO`, clearing strict mode, so the redundant values were tolerated. The page therefore says only that the values are redundant.
2. MDEV-40217 was pushed twice; the first version emitted `DEFAULT` for every column. That was superseded on `main` by the empty-column-list form, which is what this page documents.

`codespell` and `lychee` both pass locally via `.claude/hooks/doc-lint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6264]: https://mariadbcorp.atlassian.net/browse/DOCS-6264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MDEV-32362]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-32362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MDEV-40217]: https://mdb2026-sandbox.atlassian.net/browse/MDEV-40217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ