### PR TITLE
DOCS-6396 Correct r_rows values in ANALYZE examples

### DIFF
--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
@@ -43,7 +43,7 @@ possible_keys: key1
       key_len: 5
           ref: NULL
          rows: 181
-       r_rows: 181
+       r_rows: 181.00
      filtered: 100.00
    r_filtered: 10.50
         Extra: Using index condition; Using where
@@ -72,19 +72,19 @@ WHERE
 ```
 
 ```
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
-| id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows | filtered | r_filtered | Extra       |
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
-|  1 | SIMPLE      | customer | ALL  | PRIMARY,...   | NULL        | NULL    | NULL               | 149095 | 150000 |    18.08 |       9.13 | Using where |
-|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |     10 |   100.00 |      30.03 | Using where |
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
+| id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows    | filtered | r_filtered | Extra       |
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
+|  1 | SIMPLE      | customer | ALL  | PRIMARY       | NULL        | NULL    | NULL               | 149095 | 150000.00 |    18.08 |       9.13 | Using where |
+|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |     10.00 |   100.00 |      30.03 | Using where |
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 ```
 
 Here, one can see that
 
-* For table customer, customer.rows=149095, customer.r\_rows=150000. The estimate for number of rows we will read was fairly precise
+* For table customer, customer.rows=149095, customer.r\_rows=150000.00. The estimate for number of rows we will read was fairly precise
 * customer.filtered=18.08, customer.r\_filtered=9.13. The optimizer somewhat overestimated the number of records that will match selectivity of condition attached to `customer` table (in general, when you have a full scan and r\_filtered is less than 15%, it's time to consider adding an appropriate index).
-* For table orders, orders.rows=7, orders.r\_rows=10. This means that on average, there are 7 orders for a given c\_custkey, but in our case there were 10, which is close to the expectation (when this number is consistently far from the expectation, it may be time to run ANALYZE TABLE, or even edit the table statistics manually to get better query plans).
+* For table orders, orders.rows=7, orders.r\_rows=10.00. This means that on average, there are 7 orders for a given c\_custkey, but in our case there were 10, which is close to the expectation (when this number is consistently far from the expectation, it may be time to run ANALYZE TABLE, or even edit the table statistics manually to get better query plans).
 * orders.filtered=100, orders.r\_filtered=30.03. The optimizer didn't have any way to estimate which fraction of records will be left after it checks the condition that is attached to table orders (it's orders.o\_totalprice > 200\*1000). So, it used 100%. In reality, it is 30%. 30% is typically not selective enough to warrant adding new indexes. For joins with many tables, it might be worth to collect and use [column statistics](../../../../ha-and-performance/optimization-and-tuning/query-optimizations/statistics-for-optimizing-queries/engine-independent-table-statistics.md) for columns in question, this may help the optimizer to pick a better query plan.
 
 ### Meaning of NULL in r\_rows and r\_filtered
@@ -96,18 +96,18 @@ ANALYZE SELECT *
 FROM orders, customer 
 WHERE
   customer.c_custkey=orders.o_custkey AND
-  customer.c_acctbal < -0 AND 
+  customer.c_acctbal < 0 AND 
   customer.c_comment LIKE '%foo%' AND
   orders.o_totalprice > 200*1000;
 ```
 
 ```
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
-| id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows | filtered | r_filtered | Extra       |
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
-|  1 | SIMPLE      | customer | ALL  | PRIMARY,...   | NULL        | NULL    | NULL               | 149095 | 150000 |    18.08 |       0.00 | Using where |
-|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |   NULL |   100.00 |       NULL | Using where |
-+----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+--------+----------+------------+-------------+
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
+| id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows    | filtered | r_filtered | Extra       |
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
+|  1 | SIMPLE      | customer | ALL  | PRIMARY       | NULL        | NULL    | NULL               | 149095 | 150000.00 |    18.08 |       0.00 | Using where |
+|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |      NULL |   100.00 |       NULL | Using where |
++----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 ```
 
 The output of **orders.r\_rows=NULL** and **orders.r\_filtered=NULL** shows that the table `orders` was never scanned. Indeed, we can also see customer.r\_filtered=0.00. This shows that a part of WHERE attached to table `customer` was never satisfied (or, satisfied in less than 0.01% of cases).

--- a/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
+++ b/server/reference/sql-statements/administrative-sql-statements/analyze-and-explain-statements/analyze-statement.md
@@ -76,7 +76,7 @@ WHERE
 | id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows    | filtered | r_filtered | Extra       |
 +----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 |  1 | SIMPLE      | customer | ALL  | PRIMARY       | NULL        | NULL    | NULL               | 149095 | 150000.00 |    18.08 |       9.13 | Using where |
-|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |     10.00 |   100.00 |      30.03 | Using where |
+|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey | 7      | 10.00     |   100.00 |      30.03 | Using where |
 +----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 ```
 
@@ -106,7 +106,7 @@ WHERE
 | id | select_type | table    | type | possible_keys | key         | key_len | ref                | rows   | r_rows    | filtered | r_filtered | Extra       |
 +----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 |  1 | SIMPLE      | customer | ALL  | PRIMARY       | NULL        | NULL    | NULL               | 149095 | 150000.00 |    18.08 |       0.00 | Using where |
-|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey |      7 |      NULL |   100.00 |       NULL | Using where |
+|  1 | SIMPLE      | orders   | ref  | i_o_custkey   | i_o_custkey | 5       | customer.c_custkey | 7      | NULL      |   100.00 |       NULL | Using where |
 +----+-------------+----------+------+---------------+-------------+---------+--------------------+--------+-----------+----------+------------+-------------+
 ```
 


### PR DESCRIPTION
All three ANALYZE output examples on the page showed r_rows as a bare integer. The server builds that column as a two-decimal float -- Item_float(thd, avg_rows, 2) at sql/sql_explain.cc:1653 -- so it is never printed without decimals. Recorded output in mysql-test/main/ analyze_stmt.result:10 confirms: r_rows reads 10.00, not 10. Verified against server origin/main @ 87bcaaaa.

Fix r_rows in the vertical example (181.00) and in both tabular examples (150000.00, 10.00), widening the column from 6 to 9 characters. The NULL in the second example is correct as-is and stays: when a table is never scanned, sql_explain.cc:1646-1649 pushes item_null and bypasses the Item_float path entirely. Update the prose at L85 and L87, which quoted the same wrong values.

Also drop the editorial ellipsis from possible_keys. Real EXPLAIN never emits "..." -- push_string_list() at sql/sql_explain.cc:382-398 joins the key list with a bare comma and has no truncation -- so PRIMARY,... is not output the server can produce. The page gives no CREATE TABLE, so the true index list is unknowable; plain PRIMARY is used rather than inventing index names.

Fix a typo in the second example query: c_acctbal < -0 becomes < 0, matching the same query at L70 and the prose at L113.

One known deviation is left in place deliberately. The ref column is database-qualified in real output (dbt3_s001.orders.o_orderkey in mysql-test/main/rowid_filter.result:331), but the example's 150000-row customer table is dbt3 scale factor 1 while the test database dbt3_s001 is scale 0.01, so that qualifier would contradict the numbers shown. No database name is derivable from the page, so ref is left unqualified rather than invented.