### PR TITLE
DOCS-6410 Retarget sequence links from the SEQUENCE storage engine to Sequences

### DIFF
--- a/release-notes/.gitbook/includes/backports-11.8.6-3-and-11.4.10-7.md
+++ b/release-notes/.gitbook/includes/backports-11.8.6-3-and-11.4.10-7.md
@@ -2,7 +2,7 @@
 title: backports-11.8.6-3-and-11.4.10-7
 ---
 
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [SEQUENCE tables](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine), backported from MariaDB Community Server 12.0 ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/), backported from MariaDB Community Server 12.0 ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
   * Previously, checking a sequence returned the note `The storage engine for the table doesn't support check`
   * The check first runs the underlying storage engine's own check, then validates the sequence: the table must hold exactly one row, the sequence options must be in range, and the sequence must not be exhausted
   * A sequence table with no rows reports the error `Fewer than one row in the table` and is flagged as corrupt; a table with more than one row reports the warning `More than one row in the table`

--- a/release-notes/.gitbook/includes/backports-11.8.6-3-and-11.4.10-7.md
+++ b/release-notes/.gitbook/includes/backports-11.8.6-3-and-11.4.10-7.md
@@ -2,7 +2,7 @@
 title: backports-11.8.6-3-and-11.4.10-7
 ---
 
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/), backported from MariaDB Community Server 12.0 ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/), backported from MariaDB Community Server 12.0 ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
   * Previously, checking a sequence returned the note `The storage engine for the table doesn't support check`
   * The check first runs the underlying storage engine's own check, then validates the sequence: the table must hold exactly one row, the sequence options must be in range, and the sequence must not be exhausted
   * A sequence table with no rows reports the error `Fewer than one row in the table` and is flagged as corrupt; a table with more than one row reports the warning `More than one row in the table`

--- a/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
+++ b/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
@@ -136,7 +136,7 @@ New [GIS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure
 ### Server <a href="#server" id="server"></a>
 
 * Add the FM format to [TO\_CHAR](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/string-functions/to_char), which suppresses following padding ([MDEV-36216](https://jira.mariadb.org/browse/MDEV-36216))
-* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences]({server}/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ### Trigger <a href="#trigger" id="trigger"></a>
 

--- a/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
+++ b/release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md
@@ -30,7 +30,7 @@ MariaDB 12.3 is a [long term release](../about/release-model.md), maintained unt
 * New authentication plugin [caching\_sha2\_password](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/clientserver-protocol/1-connecting/caching_sha2_password-authentication-plugin) for MySQL compatibility ([MDEV-9804](https://jira.mariadb.org/browse/MDEV-9804))
 * [( + ) for outer join syntax in Oracle mode](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/selecting-data/joins/join-syntax#oracle-mode) ([MDEV-13817](https://jira.mariadb.org/browse/MDEV-13817))
 * Associative arrays: [DECLARE TYPE .. TABLE OF .. INDEX BY](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/programmatic-compound-statements/declare-type) ([MDEV-34319](https://jira.mariadb.org/browse/MDEV-34319)) ([blog post](https://mariadb.org/bringing-oracles-associative-arrays-to-mariadb/))
-* [DROP USER](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/account-management-sql-statements/drop-user) will now by default issue a warning if the user has active sessions, or fail in [Oracle mode](https://github.com/mariadb-corporation/mariadb-docs/blob/main/release-notes/about/compatibility-and-differences/sql_modeoracle.md) ([MDEV-35617](https://jira.mariadb.org/browse/MDEV-35617))
+* [DROP USER](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/account-management-sql-statements/drop-user) will now by default issue a warning if the user has active sessions, or fail in [Oracle mode](../about/compatibility-and-differences/sql_modeoracle.md) ([MDEV-35617](https://jira.mariadb.org/browse/MDEV-35617))
 * Implement Oracle [TO\_NUMBER](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/numeric-functions/to_number) function ([MDEV-20022](https://jira.mariadb.org/browse/MDEV-20022))
 * Implement Oracle [TRUNC](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/date-time-functions/trunc) function ([MDEV-20023](https://jira.mariadb.org/browse/MDEV-20023))
 
@@ -136,7 +136,7 @@ New [GIS](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure
 ### Server <a href="#server" id="server"></a>
 
 * Add the FM format to [TO\_CHAR](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/string-functions/to_char), which suppresses following padding ([MDEV-36216](https://jira.mariadb.org/browse/MDEV-36216))
-* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [SEQUENCE tables](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences]({server}/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ### Trigger <a href="#trigger" id="trigger"></a>
 

--- a/release-notes/community-server/old-releases/12.0/what-is-mariadb-120.md
+++ b/release-notes/community-server/old-releases/12.0/what-is-mariadb-120.md
@@ -31,7 +31,7 @@ MariaDB 12.0 is a [rolling release](../../about/release-model.md). It is an evol
 ### Server <a href="#server" id="server"></a>
 
 * Add the FM format to [TO\_CHAR](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/string-functions/to_char), which suppresses following padding ([MDEV-36216](https://jira.mariadb.org/browse/MDEV-36216))
-* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [SEQUENCE tables](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences]({server}/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ### Optimizer <a href="#optimizer" id="optimizer"></a>
 

--- a/release-notes/community-server/old-releases/12.0/what-is-mariadb-120.md
+++ b/release-notes/community-server/old-releases/12.0/what-is-mariadb-120.md
@@ -31,7 +31,7 @@ MariaDB 12.0 is a [rolling release](../../about/release-model.md). It is an evol
 ### Server <a href="#server" id="server"></a>
 
 * Add the FM format to [TO\_CHAR](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/string-functions/to_char), which suppresses following padding ([MDEV-36216](https://jira.mariadb.org/browse/MDEV-36216))
-* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences]({server}/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [mariadb-check](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) and [CHECK TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) now support [sequences](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/) ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ### Optimizer <a href="#optimizer" id="optimizer"></a>
 

--- a/release-notes/enterprise-server/10.6/10.6.8-4.md
+++ b/release-notes/enterprise-server/10.6/10.6.8-4.md
@@ -110,7 +110,7 @@ MariaDB Enterprise Server 10.6.8-4 was released on 2022-06-13.
 
 ### Can result in unexpected behavior
 
-* When [OPTIMIZE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table) is executed on a [sequence](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine), the server raises an ER\_BINLOG\_UNSAFE\_STATEMENT warning, even if [binlog\_format](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables) is set to ROW or MIXED. ([MDEV-24617](https://jira.mariadb.org/browse/MDEV-24617))
+* When [OPTIMIZE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table) is executed on a [sequence]({server}/reference/sql-structure/sequences/), the server raises an ER\_BINLOG\_UNSAFE\_STATEMENT warning, even if [binlog\_format](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables) is set to ROW or MIXED. ([MDEV-24617](https://jira.mariadb.org/browse/MDEV-24617))
   * The warning can appear in the [MariaDB Error Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/error-log) as the following:
 
 ```

--- a/release-notes/enterprise-server/10.6/10.6.8-4.md
+++ b/release-notes/enterprise-server/10.6/10.6.8-4.md
@@ -110,7 +110,7 @@ MariaDB Enterprise Server 10.6.8-4 was released on 2022-06-13.
 
 ### Can result in unexpected behavior
 
-* When [OPTIMIZE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table) is executed on a [sequence]({server}/reference/sql-structure/sequences/), the server raises an ER\_BINLOG\_UNSAFE\_STATEMENT warning, even if [binlog\_format](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables) is set to ROW or MIXED. ([MDEV-24617](https://jira.mariadb.org/browse/MDEV-24617))
+* When [OPTIMIZE TABLE](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/optimizing-tables/optimize-table) is executed on a [sequence](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/), the server raises an ER\_BINLOG\_UNSAFE\_STATEMENT warning, even if [binlog\_format](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables) is set to ROW or MIXED. ([MDEV-24617](https://jira.mariadb.org/browse/MDEV-24617))
   * The warning can appear in the [MariaDB Error Log](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/error-log) as the following:
 
 ```

--- a/release-notes/enterprise-server/11.4/11.4.10-7.md
+++ b/release-notes/enterprise-server/11.4/11.4.10-7.md
@@ -38,7 +38,7 @@ MariaDB Enterprise Server 11.4.10-7 is a Stable (GA) maintenance release of [Mar
     * The option to use cached values during communication errors is now enabled by default.
     * The cache timeout is now defaulting to the maximum value.
 * Audit log plugin will now log events for MariaDB Enterprise Cluster (Galera) replication applier operations with a generic user name: `<wsrep_applier>`. Before this change the user name in audit logs has been empty ([MDEV-35511](https://jira.mariadb.org/browse/MDEV-35511))
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ## Issues Fixed
 

--- a/release-notes/enterprise-server/11.4/11.4.10-7.md
+++ b/release-notes/enterprise-server/11.4/11.4.10-7.md
@@ -38,7 +38,7 @@ MariaDB Enterprise Server 11.4.10-7 is a Stable (GA) maintenance release of [Mar
     * The option to use cached values during communication errors is now enabled by default.
     * The cache timeout is now defaulting to the maximum value.
 * Audit log plugin will now log events for MariaDB Enterprise Cluster (Galera) replication applier operations with a generic user name: `<wsrep_applier>`. Before this change the user name in audit logs has been empty ([MDEV-35511](https://jira.mariadb.org/browse/MDEV-35511))
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [SEQUENCE tables](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ## Issues Fixed
 

--- a/release-notes/enterprise-server/11.8/11.8.6-3.md
+++ b/release-notes/enterprise-server/11.8/11.8.6-3.md
@@ -44,7 +44,7 @@ MariaDB Enterprise Server 11.8.6-3 is a Stable (GA) maintenance release of Maria
     * The cache timeout is now defaulting to the maximum value.
 * parsec client plugin is now compiled and packaged on Windows ([MDEV-38360](https://jira.mariadb.org/browse/MDEV-38360))
 * Audit log plugin will now log events for MariaDB Enterprise Cluster (Galera) replication applier operations with a generic user name: `<wsrep_applier>`. Before this change the user name in audit logs has been empty ([MDEV-35511](https://jira.mariadb.org/browse/MDEV-35511))
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ## Issues Fixed
 

--- a/release-notes/enterprise-server/11.8/11.8.6-3.md
+++ b/release-notes/enterprise-server/11.8/11.8.6-3.md
@@ -44,7 +44,7 @@ MariaDB Enterprise Server 11.8.6-3 is a Stable (GA) maintenance release of Maria
     * The cache timeout is now defaulting to the maximum value.
 * parsec client plugin is now compiled and packaged on Windows ([MDEV-38360](https://jira.mariadb.org/browse/MDEV-38360))
 * Audit log plugin will now log events for MariaDB Enterprise Cluster (Galera) replication applier operations with a generic user name: `<wsrep_applier>`. Before this change the user name in audit logs has been empty ([MDEV-35511](https://jira.mariadb.org/browse/MDEV-35511))
-* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [SEQUENCE tables](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/storage-engines/sequence-storage-engine). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
+* [CHECK TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/table-statements/check-table) and [mariadb-check](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/table-tools/mariadb-check) now support [sequences]({server}/reference/sql-structure/sequences/). Previously, checking a sequence returned the note `The storage engine for the table doesn't support check` ([MDEV-22491](https://jira.mariadb.org/browse/MDEV-22491))
 
 ## Issues Fixed
 

--- a/server/clients-and-utilities/table-tools/mariadb-check.md
+++ b/server/clients-and-utilities/table-tools/mariadb-check.md
@@ -171,9 +171,9 @@ Using two `--verbose` options will also give you connection information.
 
 If you use three `--verbose` options you will also get, on stdout, all [ALTER](../../reference/sql-statements/data-definition/alter/alter-table/), [RENAME](../../reference/sql-statements/data-definition/rename-table.md), and [CHECK](../../server-usage/storage-engines/myrocks/myrocks-and-check-table.md) commands that mariadb-check executes.
 
-#### Sequence storage engine
+#### Sequences
 
-From MariaDB 12.0, `mariadb-check` supports [Sequence tables](../../server-usage/storage-engines/sequence-storage-engine.md).
+From MariaDB 12.0, `mariadb-check` supports [sequences](../../reference/sql-structure/sequences/).
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/reference/sql-statements/table-statements/check-table.md
+++ b/server/reference/sql-statements/table-statements/check-table.md
@@ -20,7 +20,9 @@ option = {FOR UPGRADE | QUICK | FAST | MEDIUM | EXTENDED | CHANGED}
 
 ## Description
 
-`CHECK TABLE` checks a table or tables for errors. `CHECK TABLE` works for [Archive](../../../server-usage/storage-engines/archive.md), [Aria](../../../server-usage/storage-engines/aria/), [CSV](../../../server-usage/storage-engines/csv/), [InnoDB](../../../server-usage/storage-engines/innodb/), [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/), and, from [MariaDB 12.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.0), [Sequence](../../../server-usage/storage-engines/sequence-storage-engine.md) tables. For Aria and MyISAM tables, the key statistics are updated as well. For CSV, see also [Checking and Repairing CSV Tables](../../../server-usage/storage-engines/csv/checking-and-repairing-csv-tables.md).
+`CHECK TABLE` checks a table or tables for errors. `CHECK TABLE` works for [Archive](../../../server-usage/storage-engines/archive.md), [Aria](../../../server-usage/storage-engines/aria/), [CSV](../../../server-usage/storage-engines/csv/), [InnoDB](../../../server-usage/storage-engines/innodb/), and [MyISAM](../../../server-usage/storage-engines/myisam-storage-engine/) tables. For Aria and MyISAM tables, the key statistics are updated as well. For CSV, see also [Checking and Repairing CSV Tables](../../../server-usage/storage-engines/csv/checking-and-repairing-csv-tables.md).
+
+From [MariaDB 12.0](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/12.0), `CHECK TABLE` also works on [sequences](../../sql-structure/sequences/). The sequence's underlying storage engine is checked first, then the sequence itself is validated.
 
 As an alternative, [myisamchk](../../../clients-and-utilities/myisam-clients-and-utilities/myisamchk.md) is a command-line tool for checking MyISAM tables when the tables are not being accessed. For Aria tables, there is a similar tool: [aria\_chk](../../../clients-and-utilities/aria-clients-and-utilities/aria_chk.md).
 


### PR DESCRIPTION
[DOCS-6410](https://mariadbcorp.atlassian.net/browse/DOCS-6410)

Everywhere the MDEV-22491 feature (`CHECK TABLE` and `mariadb-check` now support sequences) is documented, "SEQUENCE tables" linked to the **SEQUENCE storage engine** page. That is a different feature. Links now point at **Sequences** (`reference/sql-structure/sequences/`), and the wording says "sequences".

The two are unrelated things sharing a name:

| | Implemented in | What it is |
|---|---|---|
| SEQUENCE storage engine | `storage/sequence/sequence.cc` | A plugin that auto-discovers virtual, ephemeral, read-only `seq_1_to_10`-style tables. Cannot be created explicitly. |
| Sequence objects | `sql/ha_sequence.cc`, `sql/sql_sequence.cc` | Created with `CREATE SEQUENCE`. Persistent, stored via a wrapped real engine. `NEXTVAL`, `minvalue`, `cycle`. |

MDEV-22491 is entirely the second one. Verified against community **server @ `aab83aec`** (`origin/12.0`), with `origin/11.8` @ `dee8add8` as the "absent before 12.0" baseline:

- Commit `d52ddae57b58` "MDEV-22491 Support mariadb-check and CHECK TABLE with SEQUENCE" adds `ha_sequence::check()` at `sql/ha_sequence.cc`:423 and touches **zero** paths under `storage/sequence/`. Its test `mysql-test/suite/sql_sequence/check.test` does `create sequence s;` then `check table s;`.
- The old target is not merely imprecise, it is inverted: `class ha_seq` (`storage/sequence/sequence.cc`:57) overrides no `check()` at all, so the base default (`sql/handler.h`:5369-5370) returns `HA_ADMIN_NOT_IMPLEMENTED` and `sql/sql_admin.cc`:1215-1224 emits the note *"the storage engine for the table doesn't support check"* — the exact note these release notes say the feature removed.

## Changes

| File | Change |
|---|---|
| `server/reference/sql-statements/table-statements/check-table.md`:23,25 | Restructured rather than link-swapped: line 23 is a list of storage **engines**, so "Sequence" read as a sixth engine. The engine list now ends at MyISAM; sequence support moved to its own paragraph. |
| `server/clients-and-utilities/table-tools/mariadb-check.md`:174,176 | Heading `Sequence storage engine` → `Sequences`, plus the link. No page links the old `#sequence-storage-engine` anchor. |
| `release-notes/community-server/old-releases/12.0/what-is-mariadb-120.md`:34 | Link + wording. The original instance; the others were copied from it. |
| `release-notes/community-server/12.3/mariadb-12.3-changes-and-improvements.md`:139 | Link + wording. |
| `release-notes/enterprise-server/11.4/11.4.10-7.md`:41 | Link + wording (added by DOCS-6278). |
| `release-notes/enterprise-server/11.8/11.8.6-3.md`:47 | Link + wording (added by DOCS-6278). |
| `release-notes/.gitbook/includes/backports-11.8.6-3-and-11.4.10-7.md`:5 | Link + wording (added by DOCS-6278). |
| `release-notes/enterprise-server/10.6/10.6.8-4.md`:113 | **8th instance, not in the ticket.** MDEV-24617 ("`OPTIMIZE TABLE` on a sequence raises `ER_BINLOG_UNSAFE_STATEMENT`") is also about sequence objects — commit `e7cf871dda59` changes `sql/sql_class.cc` and `mysql-test/suite/sql_sequence/binlog.test`, whose body uses `next value for s1` / `alter sequence s1 maxvalue 1000`. |

## Drive-by fix required for CI

`mariadb-12.3-changes-and-improvements.md`:33 carried a pre-existing 404 — a raw GitHub blob URL to `release-notes/about/compatibility-and-differences/sql_modeoracle.md`, dropping the `community-server/` path segment. lychee scans whole changed files, so editing this page made it blocking. Replaced with the same-space relative link, matching `11.4/what-is-mariadb-114.md`:135. Introduced in `3f21a45ed`; unrelated to MDEV-22491.

## Deliberately unchanged

Every other `sequence-storage-engine` link in the repo was read for its subject and is correct — the MariaDB-vs-MySQL comparison pages (dated "MariaDB 10.0 and later", which is the engine via MDEV-3808; sequence objects arrived in 10.3), `online-schema-change.md`:121 ("read-only"), `except.md`:178, `table-discovery.md`, `list-of-plugins.md`, `choosing-the-right-storage-engine.md`, `connect-table-types-vir.md`, and the deliberate disambiguation pointers at `sequence-overview.md`:9,268 and `information-schema-sequences-table.md`:63.

The engine list at `check-table.md`:23 was left as found. Note that Connect, MERGE, Mroonga, MyRocks and partitioned tables also override `check()`, so the list is incomplete — outside this ticket.

## Follow-up

This corrects rows 1, 2 and 10 of the DOCS-6278 fact-check report, which marked the behavior VERIFIED against source while the **link target** went unverified. Lesson recorded on that report: a link target is a claim and needs its own verification; an existing published link is not evidence.

codespell and lychee clean on all 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6410]: https://mariadbcorp.atlassian.net/browse/DOCS-6410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ